### PR TITLE
Fixed PLUGINLIB_DECLARE_CLASS depreacated errors

### DIFF
--- a/effort_controllers/src/joint_effort_controller.cpp
+++ b/effort_controllers/src/joint_effort_controller.cpp
@@ -37,7 +37,4 @@
 #include <effort_controllers/joint_effort_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-PLUGINLIB_DECLARE_CLASS(effort_controllers,
-                        JointEffortController,
-                        effort_controllers::JointEffortController,
-                        controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(effort_controllers::JointEffortController,controller_interface::ControllerBase)

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -180,4 +180,4 @@ void JointPositionController::setCommandCB(const std_msgs::Float64ConstPtr& msg)
 
 } // namespace
 
-PLUGINLIB_DECLARE_CLASS(effort_controllers, JointPositionController, effort_controllers::JointPositionController, controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS( effort_controllers::JointPositionController, controller_interface::ControllerBase)

--- a/effort_controllers/src/joint_velocity_controller.cpp
+++ b/effort_controllers/src/joint_velocity_controller.cpp
@@ -142,4 +142,4 @@ void JointVelocityController::setCommandCB(const std_msgs::Float64ConstPtr& msg)
 
 } // namespace
 
-PLUGINLIB_DECLARE_CLASS(effort_controllers, JointVelocityController, effort_controllers::JointVelocityController, controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS( effort_controllers::JointVelocityController, controller_interface::ControllerBase)

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -99,4 +99,4 @@ namespace joint_state_controller
 }
 
 
-PLUGINLIB_DECLARE_CLASS(joint_state_controller, JointStateController, joint_state_controller::JointStateController, controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS( joint_state_controller::JointStateController, controller_interface::ControllerBase)

--- a/position_controllers/src/joint_position_controller.cpp
+++ b/position_controllers/src/joint_position_controller.cpp
@@ -37,7 +37,4 @@
 #include <position_controllers/joint_position_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-PLUGINLIB_DECLARE_CLASS(position_controllers,
-                        JointPositionController,
-                        position_controllers::JointPositionController,
-                        controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(position_controllers::JointPositionController,controller_interface::ControllerBase)

--- a/velocity_controllers/src/joint_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_velocity_controller.cpp
@@ -37,7 +37,4 @@
 #include <velocity_controllers/joint_velocity_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-PLUGINLIB_DECLARE_CLASS(velocity_controllers,
-                        JointVelocityController,
-                        velocity_controllers::JointVelocityController,
-                        controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(velocity_controllers::JointVelocityController,controller_interface::ControllerBase)


### PR DESCRIPTION
No brainer fix for:

```
WARNING: PLUGINLIB_DECLARE_CLASS is deprecated, please use PLUGINLIB_EXPORT_CLASS instead. You can run the script 'plugin_macro_update' provided with pluginlib in your package source folder to automatically and recursively update legacy macros.  Base = base_class_type, Derived = derived_class_type
```
