### PR TITLE
Fixed control_toolbox deprecated errors with updatePid()

### DIFF
--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -141,10 +141,12 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   }
   else //prismatic
   {
-    error = joint_.getPosition() - command;
+    error = command - joint_.getPosition();
   }
 
-  double commanded_effort = pid_controller_.updatePid(error, joint_.getVelocity(), period); // assuming desired velocity is 0
+  // Set the PID error and compute the PID command with nonuniform
+  // time step size. This also allows the user to pass in a precomputed derivative error. 
+  double commanded_effort = pid_controller_.computeCommand(error, joint_.getVelocity(), period); // assuming desired velocity is 0
   joint_.setCommand(commanded_effort);
 
 

--- a/effort_controllers/src/joint_velocity_controller.cpp
+++ b/effort_controllers/src/joint_velocity_controller.cpp
@@ -108,8 +108,13 @@ void JointVelocityController::getCommand(double  & cmd)
 
 void JointVelocityController::update(const ros::Time& time, const ros::Duration& period)
 {
-  double error = joint_.getVelocity() - command_;
-  double command = pid_controller_.updatePid(error, period);
+  double error = command_ - joint_.getVelocity();
+
+  // Set the PID error and compute the PID command with nonuniform time
+  // step size. The derivative error is computed from the change in the error
+  // and the timestep dt.
+  double command = pid_controller_.computeCommand(error, period);
+
   joint_.setCommand(command);
 
   if(loop_count_ % 10 == 0)


### PR DESCRIPTION
Please give feedback if this is the right way to fix this deprecated error. I had to reverse the way a PID's error is calculated per the deprecated function message:

According to `control_toolbox/include/control_toolbox/pid.h`:

> This function assumes p_error = (state - target)
> which is an unconventional definition of the error. Please use \ref
> computeCommand instead, which assumes error = (target - state) 

During build control_toolbox causes these deprecated warnings:

```
/home/dave/ros/ws_misc/src/ros_controllers/effort_controllers/src/joint_velocity_controller.cpp: In member function ‘virtual void effort_controllers::JointVelocityController::update(const ros::Time&, const ros::Duration&)’:
/home/dave/ros/ws_misc/src/ros_controllers/effort_controllers/src/joint_velocity_controller.cpp:112:59: warning: ‘double control_toolbox::Pid::updatePid(double, ros::Duration)’ is deprecated (declared at /home/dave/ros/ws_misc/src/ros_control/control_toolbox/include/control_toolbox/pid.h:231) [-Wdeprecated-declarations]

/home/dave/ros/ws_misc/src/ros_controllers/effort_controllers/src/joint_position_controller.cpp: In member function ‘virtual void effort_controllers::JointPositionController::update(const ros::Time&, const ros::Duration&)’:
/home/dave/ros/ws_misc/src/ros_controllers/effort_controllers/src/joint_position_controller.cpp:147:90: warning: ‘double control_toolbox::Pid::updatePid(double, double, ros::Duration)’ is deprecated (declared at /home/dave/ros/ws_misc/src/ros_control/control_toolbox/include/control_toolbox/pid.h:247) [-Wdeprecated-declarations]
```

How much will this break current robot's PID gains and control behavior? I think this fix needs to be done, and it should be done before the Hydro release.
@adolfo-rt @jbohren
