### PR TITLE
Fixed PID destructor bug, cleaned up code

### DIFF
--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -24,11 +24,12 @@ else()
     src/joint_effort_controller.cpp include/effort_controllers/joint_effort_controller.h
     src/joint_velocity_controller.cpp include/effort_controllers/joint_velocity_controller.h
     src/joint_position_controller.cpp include/effort_controllers/joint_position_controller.h)
+
   target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   # Declare catkin package
   catkin_package(
-    CATKIN_DEPENDS controller_interface controllers_msgs control_toolbox realtime_tools urdf forward_command_controller
+    CATKIN_DEPENDS controller_interface controllers_msgs control_toolbox realtime_tools urdf forward_command_controller dynamic_reconfigure
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
     )

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -73,7 +73,6 @@
 #include <controllers_msgs/JointControllerState.h>
 #include <realtime_tools/realtime_buffer.h>
 
-
 namespace effort_controllers
 {
 
@@ -84,7 +83,19 @@ public:
   JointPositionController();
   ~JointPositionController();
 
-  bool init(hardware_interface::EffortJointInterface*robot, const std::string &joint_name,const control_toolbox::Pid &pid);
+  /** \brief The init function is called to initialize the controller from a
+   * non-realtime thread with a pointer to the hardware interface, itself,
+   * instead of a pointer to a RobotHW.
+   *
+   * \param hw The specific hardware interface used by this controller.
+   *
+   * \param n A NodeHandle in the namespace from which the controller
+   * should read its configuration, and where it should set up its ROS
+   * interface.
+   *
+   * \returns True if initialization was successful and the controller
+   * is ready to be started.
+   */  
   bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 
   /*!
@@ -94,6 +105,11 @@ public:
    */
   void setCommand(double cmd);
 
+  /** \brief This is called from within the realtime thread just before the
+   * first call to \ref update
+   *
+   * \param time The current time
+   */
   void starting(const ros::Time& time);
   
   /*!
@@ -101,24 +117,40 @@ public:
    */
   void update(const ros::Time& time, const ros::Duration& period);
 
+  /**
+   * \brief Set the PID parameters
+   */
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+
+  /**
+   * \brief Get the PID parameters
+   */
   void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min);
 
+  /**
+   * \brief Get the name of the joint this controller uses
+   */
   std::string getJointName();
+
   hardware_interface::JointHandle joint_;
   boost::shared_ptr<const urdf::Joint> joint_urdf_;
   realtime_tools::RealtimeBuffer<double> command_;             /**< Last commanded position. */
 
 private:
   int loop_count_;
-  control_toolbox::Pid pid_controller_;       /**< Internal PID controller. */
+  boost::scoped_ptr<control_toolbox::Pid> pid_controller_;       /**< Internal PID controller. */
 
   boost::scoped_ptr<
     realtime_tools::RealtimePublisher<
       controllers_msgs::JointControllerState> > controller_state_publisher_ ;
 
   ros::Subscriber sub_command_;
+
+  /**
+   * \brief Callback from /command subscriber for setpoint
+   */
   void setCommandCB(const std_msgs::Float64ConstPtr& msg);
+
 };
 
 } // namespace

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -19,12 +19,15 @@
   <build_depend>realtime_tools</build_depend> 
   <build_depend>urdf</build_depend> 
   <build_depend>forward_command_controller</build_depend>
-  <run_depend>forward_command_controller</run_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+
   <run_depend>controller_interface</run_depend> 
   <run_depend>controllers_msgs</run_depend> 
   <run_depend>control_toolbox</run_depend> 
   <run_depend>realtime_tools</run_depend> 
   <run_depend>urdf</run_depend> 
+  <run_depend>forward_command_controller</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
 
   <export>
     <controller_interface plugin="${prefix}/effort_controllers_plugins.xml"/>


### PR DESCRIPTION
Fixed issue where the control_toolbox::Pid class was destructed during initialization [here](https://github.com/davetcoleman/ros_controllers/compare/hydro-devel#L3L80):

```
control_toolbox::Pid pid;
```

Also lots of documentation and cleanup.

This PR is required for https://github.com/ros-controls/control_toolbox/pull/1 to work properly
