### PR TITLE
Effort position controller fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# vi stuff
+.*.sw?
+
+# Python stuff
+*.pyc
+
+# Data files
+*.dat
+*.csv
+
+# Emacs temp files
+.#*
+
+# OSX Files
+.DS_Store
+

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -151,6 +151,13 @@ private:
    */
   void setCommandCB(const std_msgs::Float64ConstPtr& msg);
 
+  /**
+   * \brief Check that the command is within the hard limits of the joint. Checks for joint
+   *        type first. Sets command to limit if out of bounds.
+   * \param command - the input to test
+   */
+  void enforceJointLimits(double &command);
+
 };
 
 } // namespace

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -210,12 +210,10 @@ void JointPositionController::enforceJointLimits(double &command)
     if( command > joint_urdf_->limits->upper ) // above upper limnit
     {
       command = joint_urdf_->limits->upper;
-      ROS_WARN_STREAM_NAMED("temp","Command value is greater than upper limit");
     }
     else if( command < joint_urdf_->limits->lower ) // below lower limit
     {
       command = joint_urdf_->limits->lower;
-      ROS_WARN_STREAM_NAMED("temp","Command value is less than lower limit");
     }
   }
 }

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -122,9 +122,6 @@ void JointPositionController::setCommand(double cmd)
 
 void JointPositionController::starting(const ros::Time& time)
 {
-  ROS_DEBUG_STREAM_NAMED("joint_position_controller","Starting '" << joint_.getName()
-    << "' controller with initial position " << joint_.getPosition() );
-
   double command = joint_.getPosition();
 
   // Make sure joint is within limits if applicable

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -122,7 +122,15 @@ void JointPositionController::setCommand(double cmd)
 
 void JointPositionController::starting(const ros::Time& time)
 {
-  command_.initRT(joint_.getPosition());
+  ROS_DEBUG_STREAM_NAMED("joint_position_controller","Starting '" << joint_.getName()
+    << "' controller with initial position " << joint_.getPosition() );
+
+  double command = joint_.getPosition();
+
+  // Make sure joint is within limits if applicable
+  enforceJointLimits(command);
+
+  command_.initRT(command);
   pid_controller_->reset();
 }
 
@@ -132,10 +140,16 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
 
   double error, vel_error;
 
+  double current_position = joint_.getPosition();
+
+  // Make sure joint is within limits if applicable
+  enforceJointLimits(command);
+
   // Compute position error
   if (joint_urdf_->type == urdf::Joint::REVOLUTE)
   {
-    angles::shortest_angular_distance_with_limits(joint_.getPosition(),
+   angles::shortest_angular_distance_with_limits(
+      current_position,
       command,
       joint_urdf_->limits->lower,
       joint_urdf_->limits->upper,
@@ -143,11 +157,11 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   }
   else if (joint_urdf_->type == urdf::Joint::CONTINUOUS)
   {
-    error = angles::shortest_angular_distance(joint_.getPosition(), command);
+    error = angles::shortest_angular_distance(current_position, command);
   }
   else //prismatic
   {
-    error = command - joint_.getPosition();
+    error = command - current_position;
   }
 
   // Compute velocity error assuming desired velocity is 0
@@ -158,7 +172,6 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   double commanded_effort = pid_controller_->computeCommand(error, vel_error, period);
   joint_.setCommand(commanded_effort);
 
-
   // publish state
   if (loop_count_ % 10 == 0)
   {
@@ -166,7 +179,7 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
     {
       controller_state_publisher_->msg_.header.stamp = time;
       controller_state_publisher_->msg_.set_point = command;
-      controller_state_publisher_->msg_.process_value = joint_.getPosition();
+      controller_state_publisher_->msg_.process_value = current_position;
       controller_state_publisher_->msg_.process_value_dot = joint_.getVelocity();
       controller_state_publisher_->msg_.error = error;
       controller_state_publisher_->msg_.time_step = period.toSec();
@@ -187,6 +200,24 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
 void JointPositionController::setCommandCB(const std_msgs::Float64ConstPtr& msg)
 {
   setCommand(msg->data);
+}
+
+void JointPositionController::enforceJointLimits(double &command)
+{
+  // Check that this joint has applicable limits
+  if (joint_urdf_->type == urdf::Joint::REVOLUTE || joint_urdf_->type == urdf::Joint::PRISMATIC)
+  {
+    if( command > joint_urdf_->limits->upper ) // above upper limnit
+    {
+      command = joint_urdf_->limits->upper;
+      ROS_WARN_STREAM_NAMED("temp","Command value is greater than upper limit");
+    }
+    else if( command < joint_urdf_->limits->lower ) // below lower limit
+    {
+      command = joint_urdf_->limits->lower;
+      ROS_WARN_STREAM_NAMED("temp","Command value is less than lower limit");
+    }
+  }
 }
 
 } // namespace

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -39,7 +39,7 @@ namespace joint_state_controller
 
   bool JointStateController::init(hardware_interface::JointStateInterface* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh)
   {
-    // get all joint states from the hardware interface
+    // get all joint names from the hardware interface
     const std::vector<std::string>& joint_names = hw->getNames();
     for (unsigned i=0; i<joint_names.size(); i++)
       ROS_DEBUG("Got joint %s", joint_names[i].c_str());
@@ -78,17 +78,17 @@ namespace joint_state_controller
 
       // try to publish
       if (realtime_pub_->trylock()){
-  // we're actually publishing, so increment time
-  last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
+        // we're actually publishing, so increment time
+        last_publish_time_ = last_publish_time_ + ros::Duration(1.0/publish_rate_);
 
-  // populate joint state message
-  realtime_pub_->msg_.header.stamp = time;
-  for (unsigned i=0; i<joint_state_.size(); i++){
-    realtime_pub_->msg_.position[i] = joint_state_[i].getPosition();
-    realtime_pub_->msg_.velocity[i] = joint_state_[i].getVelocity();
-    realtime_pub_->msg_.effort[i] = joint_state_[i].getEffort();
-  }
-  realtime_pub_->unlockAndPublish();
+        // populate joint state message
+        realtime_pub_->msg_.header.stamp = time;
+        for (unsigned i=0; i<joint_state_.size(); i++){
+          realtime_pub_->msg_.position[i] = joint_state_[i].getPosition();
+          realtime_pub_->msg_.velocity[i] = joint_state_[i].getVelocity();
+          realtime_pub_->msg_.effort[i] = joint_state_[i].getEffort();
+        }
+        realtime_pub_->unlockAndPublish();
       }
     }
   }


### PR DESCRIPTION
- Added enforeJointLimits() function
- Enforced joint limits at `update()` and `starting()` functions
- Cleaned up joint_state_controller
- Added .gitignore

This fixes a bug where if you start the controller and your current joint position is slightly outside the joint limits, the starting commanded position is also outside the limit, and the `shortest_angular_distance_with_limits` function returns an incorrect value of 2*PI instead of a small decimal. This causes the error to be very high and causes a lot of noise in the PID controller.

This bug is also issued here: https://github.com/ros/angles/issues/2
