### PR TITLE
Effort Controller Fixes 

### DIFF
--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -16,23 +16,37 @@ if(USE_ROSBUILD)
 
 else()
   # Load catkin and all dependencies required for this package
-  find_package(catkin REQUIRED COMPONENTS controller_interface control_msgs forward_command_controller control_toolbox realtime_tools urdf)
+  find_package(catkin REQUIRED COMPONENTS
+    controller_interface
+    control_msgs
+    forward_command_controller
+    control_toolbox
+    realtime_tools
+    urdf
+  )
 
   include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
-  add_library(${PROJECT_NAME} 
-    src/joint_effort_controller.cpp include/effort_controllers/joint_effort_controller.h
-    src/joint_velocity_controller.cpp include/effort_controllers/joint_velocity_controller.h
-    src/joint_position_controller.cpp include/effort_controllers/joint_position_controller.h)
-
-  target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
   # Declare catkin package
   catkin_package(
-    CATKIN_DEPENDS controller_interface control_msgs control_toolbox realtime_tools urdf forward_command_controller 
+    CATKIN_DEPENDS 
+      controller_interface
+      control_msgs
+      control_toolbox
+      realtime_tools
+      urdf
+      forward_command_controller
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
     )
+
+  add_library(${PROJECT_NAME} 
+    src/joint_effort_controller.cpp 
+    src/joint_velocity_controller.cpp
+    src/joint_position_controller.cpp
+  )
+
+  target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   # Install
   install(DIRECTORY include/${PROJECT_NAME}/

--- a/effort_controllers/include/effort_controllers/joint_effort_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_effort_controller.h
@@ -34,8 +34,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS_JOINT_EFFORT_CONTROLLER_H
-#define EFFORT_CONTROLLERS_JOINT_EFFORT_CONTROLLER_H
+#ifndef EFFORT_CONTROLLERS__JOINT_EFFORT_CONTROLLER_H
+#define EFFORT_CONTROLLERS__JOINT_EFFORT_CONTROLLER_H
 
 #include <forward_command_controller/forward_command_controller.h>
 

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -33,8 +33,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS_JOINT_POSITION_CONTROLLER_H
-#define EFFORT_CONTROLLERS_JOINT_POSITION_CONTROLLER_H
+#ifndef EFFORT_CONTROLLERS__JOINT_POSITION_CONTROLLER_H
+#define EFFORT_CONTROLLERS__JOINT_POSITION_CONTROLLER_H
 
 /**
    @class effort_controllers::JointPositionController

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -62,7 +62,6 @@
 #include <ros/node_handle.h>
 #include <urdf/model.h>
 #include <control_toolbox/pid.h>
-#include <control_toolbox/pid_gains_setter.h>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread/condition.hpp>
 #include <realtime_tools/realtime_publisher.h>
@@ -96,7 +95,7 @@ public:
    * non-realtime thread with a pointer to the hardware interface, itself,
    * instead of a pointer to a RobotHW.
    *
-   * \param hw The specific hardware interface used by this controller.
+   * \param robot The specific hardware interface used by this controller.
    *
    * \param n A NodeHandle in the namespace from which the controller
    * should read its configuration, and where it should set up its ROS
@@ -136,7 +135,7 @@ public:
   void update(const ros::Time& time, const ros::Duration& period);
 
   /**
-   * \brief Set the PID parameters
+   * \brief Get the PID parameters
    */
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
 
@@ -168,7 +167,7 @@ public:
 
 private:
   int loop_count_;
-  boost::scoped_ptr<control_toolbox::Pid> pid_controller_;       /**< Internal PID controller. */
+  control_toolbox::Pid pid_controller_;       /**< Internal PID controller. */
 
   boost::scoped_ptr<
     realtime_tools::RealtimePublisher<

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -80,6 +80,15 @@ class JointPositionController: public controller_interface::Controller<hardware_
 {
 public:
 
+  /**
+   * \brief Store position and velocity command in struct to allow easier realtime buffer usage
+   */
+  struct Commands
+  {
+    double position_; // Last commanded position
+    double velocity_; // Last commanded velocity
+  };
+
   JointPositionController();
   ~JointPositionController();
 
@@ -154,8 +163,8 @@ public:
 
   hardware_interface::JointHandle joint_;
   boost::shared_ptr<const urdf::Joint> joint_urdf_;
-  realtime_tools::RealtimeBuffer<double> command_position_;             /**< Last commanded position. */
-  realtime_tools::RealtimeBuffer<double> command_velocity_;    /**< Last commanded velocity. */
+  realtime_tools::RealtimeBuffer<Commands> command_;
+  Commands command_struct_; // pre-allocated memory that is re-used to set the realtime buffer
 
 private:
   int loop_count_;

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -103,7 +103,16 @@ public:
    *
    * \param command
    */
-  void setCommand(double cmd);
+  void setCommand(double pos_target);
+
+  /*!
+   * \brief Give set position of the joint for next update: revolute (angle) and prismatic (position)
+   *        Also supports a target velocity
+   *
+   * \param pos_target - position setpoint
+   * \param vel_target - velocity setpoint
+   */
+  void setCommand(double pos_target, double vel_target);
 
   /** \brief This is called from within the realtime thread just before the
    * first call to \ref update
@@ -123,6 +132,11 @@ public:
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
 
   /**
+   * \brief Print debug info to console
+   */
+  void printDebug();
+
+  /**
    * \brief Get the PID parameters
    */
   void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min);
@@ -132,9 +146,16 @@ public:
    */
   std::string getJointName();
 
+  /**
+   * \brief Get the current position of the joint
+   * \return current position
+   */
+  double getPosition();
+
   hardware_interface::JointHandle joint_;
   boost::shared_ptr<const urdf::Joint> joint_urdf_;
-  realtime_tools::RealtimeBuffer<double> command_;             /**< Last commanded position. */
+  realtime_tools::RealtimeBuffer<double> command_position_;             /**< Last commanded position. */
+  realtime_tools::RealtimeBuffer<double> command_velocity_;    /**< Last commanded velocity. */
 
 private:
   int loop_count_;

--- a/effort_controllers/include/effort_controllers/joint_velocity_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_velocity_controller.h
@@ -59,15 +59,14 @@
 
 */
 
-#include <boost/thread/condition.hpp>
 #include <ros/node_handle.h>
+#include <boost/thread/condition.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <hardware_interface/joint_command_interface.h>
 #include <controller_interface/controller.h>
 #include <control_msgs/JointControllerState.h>
 #include <std_msgs/Float64.h>
 #include <control_toolbox/pid.h>
-#include <control_toolbox/pid_gains_setter.h>
 #include <realtime_tools/realtime_publisher.h>
 
 namespace effort_controllers
@@ -81,12 +80,26 @@ public:
   ~JointVelocityController();
 
   bool init(hardware_interface::EffortJointInterface *robot, const std::string &joint_name, const control_toolbox::Pid &pid);
+
+  /** \brief The init function is called to initialize the controller from a
+   * non-realtime thread with a pointer to the hardware interface, itself,
+   * instead of a pointer to a RobotHW.
+   *
+   * \param robot The specific hardware interface used by this controller.
+   *
+   * \param n A NodeHandle in the namespace from which the controller
+   * should read its configuration, and where it should set up its ROS
+   * interface.
+   *
+   * \returns True if initialization was successful and the controller
+   * is ready to be started.
+   */  
   bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 
   /*!
    * \brief Give set velocity of the joint for next update: revolute (angle) and prismatic (velocity)
    *
-   * \param double pos Velocity command to issue
+   * pp\param double pos Velocity command to issue
    */
   void setCommand(double cmd);
 
@@ -95,39 +108,59 @@ public:
    */
   void getCommand(double & cmd);
 
+  /** \brief This is called from within the realtime thread just before the
+   * first call to \ref update
+   *
+   * \param time The current time
+   */
+  void starting(const ros::Time& time);
+
   /*!
    * \brief Issues commands to the joint. Should be called at regular intervals
    */
-
-  void starting(const ros::Time& time) {
-    command_ = 0.0;
-    pid_controller_.reset();
-  }
   void update(const ros::Time& time, const ros::Duration& period);
 
+  /**
+   * \brief Get the PID parameters
+   */
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+
+  /**
+   * \brief Print debug info to console
+   */
+  void printDebug();
+
+  /**
+   * \brief Get the PID parameters
+   */
   void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min);
 
+  /**
+   * \brief Get the name of the joint this controller uses
+   */
   std::string getJointName();
+  
   hardware_interface::JointHandle joint_;
   double command_;                                /**< Last commanded velocity. */
 
 private:
-  control_toolbox::Pid pid_controller_;           /**< Internal PID controller. */
   int loop_count_;
+  control_toolbox::Pid pid_controller_;           /**< Internal PID controller. */
 
-  friend class JointVelocityControllerNode;
+  //friend class JointVelocityControllerNode; // what is this for??
 
   boost::scoped_ptr<
     realtime_tools::RealtimePublisher<
       control_msgs::JointControllerState> > controller_state_publisher_ ;
 
   ros::Subscriber sub_command_;
+
+  /**
+   * \brief Callback from /command subscriber for setpoint
+   */
   void setCommandCB(const std_msgs::Float64ConstPtr& msg);
 };
 
 } // namespace
-
-
 
 #endif

--- a/effort_controllers/include/effort_controllers/joint_velocity_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_velocity_controller.h
@@ -33,8 +33,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS_JOINT_VELOCITY_CONTROLLER_H
-#define EFFORT_CONTROLLERS_JOINT_VELOCITY_CONTROLLER_H
+#ifndef EFFORT_CONTROLLERS__JOINT_VELOCITY_CONTROLLER_H
+#define EFFORT_CONTROLLERS__JOINT_VELOCITY_CONTROLLER_H
 
 /**
    @class effort_controllers::JointVelocityController

--- a/effort_controllers/include/effort_controllers/joint_velocity_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_velocity_controller.h
@@ -99,7 +99,7 @@ public:
   /*!
    * \brief Give set velocity of the joint for next update: revolute (angle) and prismatic (velocity)
    *
-   * pp\param double pos Velocity command to issue
+   * \param double pos Velocity command to issue
    */
   void setCommand(double cmd);
 

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -35,7 +35,7 @@
 
 /*
  Author: Vijay Pradeep
- Contributors: Jonathan Bohren, Wim Meeussen, Dave Coleman
+ Contributors: Dave Coleman, Jonathan Bohren, Wim Meeussen
  Desc: Effort(force)-based position controller using basic PID loop
 */
 
@@ -65,8 +65,7 @@ bool JointPositionController::init(hardware_interface::EffortJointInterface *rob
   }
 
   // Load PID Controller using gains set on parameter server
-  pid_controller_.reset(new control_toolbox::Pid());
-  if (!pid_controller_->init(ros::NodeHandle(n, "pid")))
+  if (!pid_controller_.init(ros::NodeHandle(n, "pid")))
     return false;
 
   // Start realtime state publisher
@@ -98,17 +97,17 @@ bool JointPositionController::init(hardware_interface::EffortJointInterface *rob
 
 void JointPositionController::setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min)
 {
-  pid_controller_->setGains(p,i,d,i_max,i_min);
+  pid_controller_.setGains(p,i,d,i_max,i_min);
 }
 
 void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
 {
-  pid_controller_->getGains(p,i,d,i_max,i_min);
+  pid_controller_.getGains(p,i,d,i_max,i_min);
 }
 
 void JointPositionController::printDebug()
 {
-  pid_controller_->printValues();
+  pid_controller_.printValues();
 }
 
 std::string JointPositionController::getJointName()
@@ -154,7 +153,7 @@ void JointPositionController::starting(const ros::Time& time)
 
   command_.initRT(command_struct_);
 
-  pid_controller_->reset();
+  pid_controller_.reset();
 }
 
 void JointPositionController::update(const ros::Time& time, const ros::Duration& period)
@@ -194,7 +193,7 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
 
   // Set the PID error and compute the PID command with nonuniform
   // time step size. This also allows the user to pass in a precomputed derivative error.
-  double commanded_effort = pid_controller_->computeCommand(error, vel_error, period);
+  double commanded_effort = pid_controller_.computeCommand(error, vel_error, period);
   joint_.setCommand(commanded_effort);
 
   // publish state

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -35,7 +35,7 @@
 
 /*
  Author: Vijay Pradeep
- Contributors: Dave Coleman, Jonathan Bohren, Wim Meeussen
+ Contributors: Jonathan Bohren, Wim Meeussen, Dave Coleman
  Desc: Effort(force)-based position controller using basic PID loop
 */
 

--- a/effort_controllers/src/joint_velocity_controller.cpp
+++ b/effort_controllers/src/joint_velocity_controller.cpp
@@ -48,8 +48,8 @@ JointVelocityController::~JointVelocityController()
   sub_command_.shutdown();
 }
 
-  bool JointVelocityController::init(hardware_interface::EffortJointInterface *robot, 
-				     const std::string &joint_name, const control_toolbox::Pid &pid)
+bool JointVelocityController::init(hardware_interface::EffortJointInterface *robot, 
+  const std::string &joint_name, const control_toolbox::Pid &pid)
 {
   joint_ = robot->getHandle(joint_name);
   pid_controller_ = pid;
@@ -57,21 +57,25 @@ JointVelocityController::~JointVelocityController()
   return true;
 }
 
-  bool JointVelocityController::init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n)
+bool JointVelocityController::init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n)
 {
+  // Get joint name from parameter server
   std::string joint_name;
   if (!n.getParam("joint", joint_name)) {
     ROS_ERROR("No joint given (namespace: %s)", n.getNamespace().c_str());
     return false;
   }
 
+  // Load PID Controller using gains set on parameter server
   if (!pid_controller_.init(ros::NodeHandle(n, "pid")))
     return false;
 
+  // Start realtime state publisher
   controller_state_publisher_.reset(
     new realtime_tools::RealtimePublisher<control_msgs::JointControllerState>
     (n, "state", 1));
 
+  // Start command subscriber
   sub_command_ = n.subscribe<std_msgs::Float64>("command", 1, &JointVelocityController::setCommandCB, this);
 
   return true;
@@ -89,6 +93,11 @@ void JointVelocityController::getGains(double &p, double &i, double &d, double &
   pid_controller_.getGains(p,i,d,i_max,i_min);
 }
 
+void JointVelocityController::printDebug()
+{
+  pid_controller_.printValues();
+}
+
 std::string JointVelocityController::getJointName()
 {
   return joint_.getName();
@@ -101,21 +110,27 @@ void JointVelocityController::setCommand(double cmd)
 }
 
 // Return the current velocity command
-void JointVelocityController::getCommand(double  & cmd)
+void JointVelocityController::getCommand(double& cmd)
 {
   cmd = command_;
 }
 
+void JointVelocityController::starting(const ros::Time& time)
+{
+  command_ = 0.0;
+  pid_controller_.reset();
+}
+
 void JointVelocityController::update(const ros::Time& time, const ros::Duration& period)
 {
-  double error = command_ - joint_.getVelocity();
+  double error = 0; // \todo TEMP!! command_ - joint_.getVelocity();
 
   // Set the PID error and compute the PID command with nonuniform time
   // step size. The derivative error is computed from the change in the error
   // and the timestep dt.
-  double command = pid_controller_.computeCommand(error, period);
+  double commanded_effort = pid_controller_.computeCommand(error, period);
 
-  joint_.setCommand(command);
+  joint_.setCommand(commanded_effort);
 
   if(loop_count_ % 10 == 0)
   {
@@ -126,7 +141,7 @@ void JointVelocityController::update(const ros::Time& time, const ros::Duration&
       controller_state_publisher_->msg_.process_value = joint_.getVelocity();
       controller_state_publisher_->msg_.error = error;
       controller_state_publisher_->msg_.time_step = period.toSec();
-      controller_state_publisher_->msg_.command = command;
+      controller_state_publisher_->msg_.command = commanded_effort;
 
       double dummy;
       getGains(controller_state_publisher_->msg_.p,

--- a/effort_controllers/src/joint_velocity_controller.cpp
+++ b/effort_controllers/src/joint_velocity_controller.cpp
@@ -51,8 +51,10 @@ JointVelocityController::~JointVelocityController()
 bool JointVelocityController::init(hardware_interface::EffortJointInterface *robot, 
   const std::string &joint_name, const control_toolbox::Pid &pid)
 {
-  joint_ = robot->getHandle(joint_name);
   pid_controller_ = pid;
+
+  // Get joint handle from hardware interface
+  joint_ = robot->getHandle(joint_name);
 
   return true;
 }
@@ -65,6 +67,9 @@ bool JointVelocityController::init(hardware_interface::EffortJointInterface *rob
     ROS_ERROR("No joint given (namespace: %s)", n.getNamespace().c_str());
     return false;
   }
+
+  // Get joint handle from hardware interface
+  joint_ = robot->getHandle(joint_name);
 
   // Load PID Controller using gains set on parameter server
   if (!pid_controller_.init(ros::NodeHandle(n, "pid")))
@@ -123,7 +128,7 @@ void JointVelocityController::starting(const ros::Time& time)
 
 void JointVelocityController::update(const ros::Time& time, const ros::Duration& period)
 {
-  double error = 0; // \todo TEMP!! command_ - joint_.getVelocity();
+  double error = command_ - joint_.getVelocity();
 
   // Set the PID error and compute the PID command with nonuniform time
   // step size. The derivative error is computed from the change in the error


### PR DESCRIPTION
- Critical bug: velocity controller init() does not get hardware_interface handle for joint
  - joint_ = robot->getHandle(joint_name);
- Added an optional target velocity for the effort_controller/joint_position_controller if you want to specify both a position and velocity target for use with the velocity_error in the PID class
  - JointPositionController::setCommand(double pos_command, double vel_command)
- Removed unknown code "friend class JointVelocityControllerNode" - no reference found anywhere in ROS codebase (hydro-desktop)
- Removed the need to used a scoped_ptr for control_toolbox::Pid after an upstream fix
- Cleaned up code & commenting

@adolfo-rt  @jbohren
