### PR TITLE
Xacro dependency does not work correctly in Groovy

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -63,7 +63,6 @@ else()
       trajectory_msgs
       rostest
       controller_manager
-      xacro
   )
 
   include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
@@ -94,7 +93,6 @@ else()
     trajectory_msgs
     rostest
     controller_manager
-    xacro
     INCLUDE_DIRS include
     LIBRARIES ${PROJECT_NAME}
   )

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -30,7 +30,6 @@
 
   <build_depend>rostest</build_depend>            <!--Tests-only!-->
   <build_depend>controller_manager</build_depend> <!--Tests-only!-->
-  <build_depend>xacro</build_depend>              <!--Tests-only!-->
 
 
   <run_depend>actionlib</run_depend>
@@ -48,7 +47,6 @@
 
   <run_depend>rostest</run_depend>            <!--Tests-only!-->
   <run_depend>controller_manager</run_depend> <!--Tests-only!-->
-  <run_depend>xacro</run_depend>              <!--Tests-only!-->
   <run_depend>rqt_plot</run_depend>           <!--Tests-only!-->
 
   <export>


### PR DESCRIPTION
I've had to make this fix in several places this past summer, but even after talking with the ROS infrastructure team I'm not sure what causes it.
