### PR TITLE
Update joint_position_controller.cpp

### DIFF
--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -80,9 +80,20 @@ bool JointPositionController::init(hardware_interface::EffortJointInterface *rob
 
   // Get URDF info about joint
   urdf::Model urdf;
-  if (!urdf.initParam("robot_description"))
+  std::string key;
+  if (n.searchParam("robot_description", key))
   {
-    ROS_ERROR("Failed to parse urdf file");
+    std::string val;
+    n.getParam(key, val);
+    urdf.initString(val);
+    
+  }
+  //SEARCHING FOR THE PARAMETER FROM "/gazebo" downwards does not seem useful 
+  //THIS BLOCK MIGHT BE DELETED (replaced with else return false; or somthing like this)
+  else if (!urdf.initParam("robot_description"))
+  {
+    
+    ROS_ERROR("Failed to parse urdf file");    
     return false;
   }
   joint_urdf_ = urdf.getJoint(joint_name);


### PR DESCRIPTION
The robot_description parameter is search in the gazebo namespace and not in the namespace of the controller.
This creates Problems when working with multiple different robots.

This fix added a search for the parameter in the robots own namespace before trying gazebo's namespace
