### PR TITLE
Install default config files

### DIFF
--- a/force_torque_sensor_controller/CMakeLists.txt
+++ b/force_torque_sensor_controller/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
     )
 
-  install(FILES force_torque_sensor_plugin.xml
+  install(FILES force_torque_sensor_plugin.xml force_torque_sensor_controller.yaml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 

--- a/imu_sensor_controller/CMakeLists.txt
+++ b/imu_sensor_controller/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
     )
 
-  install(FILES imu_sensor_plugin.xml
+  install(FILES imu_sensor_plugin.xml imu_sensor_controller.yaml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 endif()

--- a/joint_state_controller/CMakeLists.txt
+++ b/joint_state_controller/CMakeLists.txt
@@ -36,7 +36,7 @@ else()
     RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
     )
 
-  install(FILES joint_state_plugin.xml
+  install(FILES joint_state_plugin.xml joint_state_controller.yaml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 endif()


### PR DESCRIPTION
I don't see a good reason not to have them in the debian packages, and they probably work perfectly as is in a majority of cases.
