### PR TITLE
Fix issue #60

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -57,6 +57,7 @@
 #include <actionlib/server/action_server.h>
 
 // realtime_tools
+#include <realtime_tools/realtime_box.h>
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_publisher.h>
 
@@ -166,6 +167,7 @@ private:
   typedef JointTrajectorySegment<SegmentImpl> Segment;
   typedef std::vector<Segment> Trajectory;
   typedef boost::shared_ptr<Trajectory> TrajectoryPtr;
+  typedef realtime_tools::RealtimeBox<TrajectoryPtr> TrajectoryBox;
   typedef typename Segment::Scalar Scalar;
 
   typedef HardwareInterfaceAdapter<HardwareInterface, typename Segment::State> HwIfaceAdapter;
@@ -181,16 +183,14 @@ private:
   RealtimeGoalHandlePtr                        rt_active_goal_;     ///< Currently active action goal, if any.
 
   /**
-   * Pointer to trajectory currently being followed. Can be either a hold trajectory or a trajectory received from a
-   * ROS message.
+   * Thread-safe container with a smart pointer to trajectory currently being followed.
+   * Can be either a hold trajectory or a trajectory received from a ROS message.
    *
-   * We store separately hold and message trajectories because the \p starting(time) method must be realtime-safe.
-   * Because of this, the (single segment) hold trajectory is be preallocated at initialization time and its size is
-   * kept unchanged.
+   * We store the hold trajectory in a separate class member because the \p starting(time) method must be realtime-safe.
+   * The (single segment) hold trajectory is preallocated at initialization time and its size is kept unchanged.
    */
-  realtime_tools::RealtimeBuffer<Trajectory*>  curr_trajectory_ptr_;
-  TrajectoryPtr                                msg_trajectory_ptr_;  ///< Last trajectory received from a ROS message.
-  TrajectoryPtr                                hold_trajectory_ptr_; ///< Last hold trajectory values.
+  TrajectoryBox curr_trajectory_box_;
+  TrajectoryPtr hold_trajectory_ptr_; ///< Last hold trajectory values.
 
   typename Segment::State current_state_;    ///< Preallocated workspace variable.
   typename Segment::State desired_state_;    ///< Preallocated workspace variable.

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -184,13 +184,13 @@ inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
 checkPathTolerances(const typename Segment::State& state_error,
                     const Segment&                 segment)
 {
-  assert(segment.getGoalHandle() && segment.getGoalHandle() == rt_active_goal_);
-
+  const RealtimeGoalHandlePtr rt_segment_goal = segment.getGoalHandle();
   const SegmentTolerances<Scalar>& tolerances = segment.getTolerances();
   if (!checkStateTolerance(state_error, tolerances.state_tolerance))
   {
-    rt_active_goal_->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
-    rt_active_goal_->setAborted(rt_active_goal_->preallocated_result_);
+    rt_segment_goal->preallocated_result_->error_code =
+    control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
+    rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
     rt_active_goal_.reset();
   }
 }
@@ -200,19 +200,18 @@ inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
 checkGoalTolerances(const typename Segment::State& state_error,
                     const Segment&                 segment)
 {
-  assert(segment.getGoalHandle() && segment.getGoalHandle() == rt_active_goal_);
-
   // Controller uptime
   const ros::Time uptime = time_data_.readFromRT()->uptime;
 
   // Checks that we have ended inside the goal tolerances
+  const RealtimeGoalHandlePtr rt_segment_goal = segment.getGoalHandle();
   const SegmentTolerances<Scalar>& tolerances = segment.getTolerances();
   const bool inside_goal_tolerances = checkStateTolerance(state_error, tolerances.goal_state_tolerance);
 
   if (inside_goal_tolerances)
   {
-    rt_active_goal_->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::SUCCESSFUL;
-    rt_active_goal_->setSucceeded(rt_active_goal_->preallocated_result_);
+    rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::SUCCESSFUL;
+    rt_segment_goal->setSucceeded(rt_segment_goal->preallocated_result_);
     rt_active_goal_.reset();
   }
   else if (uptime.toSec() < segment.endTime() + tolerances.goal_time_tolerance)
@@ -228,8 +227,8 @@ checkGoalTolerances(const typename Segment::State& state_error,
       checkStateTolerance(state_error, tolerances.goal_state_tolerance, true);
     }
 
-    rt_active_goal_->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED;
-    rt_active_goal_->setAborted(rt_active_goal_->preallocated_result_);
+    rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED;
+    rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
     rt_active_goal_.reset();
   }
 }


### PR DESCRIPTION
This PR should fix the segmentation fault reported in #60, and also addresses a separate scenario in which the current trajectory could not be defined for the current control cycle, but for the next one onwards.
