### PR TITLE
Link controllers to catkin libraries

### DIFF
--- a/joint_state_controller/CMakeLists.txt
+++ b/joint_state_controller/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
 
   include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
   add_library(${PROJECT_NAME} src/joint_state_controller.cpp)
+  target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   # Declare catkin package
   catkin_package(

--- a/position_controllers/CMakeLists.txt
+++ b/position_controllers/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
   include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
   add_library(${PROJECT_NAME}
     src/joint_position_controller.cpp include/position_controllers/joint_position_controller.h)
+  target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   # Declare catkin project
   catkin_package(

--- a/velocity_controllers/CMakeLists.txt
+++ b/velocity_controllers/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
   include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
   add_library(${PROJECT_NAME}
     src/joint_velocity_controller.cpp include/velocity_controllers/joint_velocity_controller.h)
+  target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   # Declare catkin package
   catkin_package(


### PR DESCRIPTION
GCC is quite lenient with missing symbols on shared libraries and doesn't event output any warning about it.
When building with other compilers, like clang, missing symbols result in build errors.
