### PR TITLE
adding simple gripper action controller for single dof grippers

### DIFF
--- a/gripper_action_controller/CMakeLists.txt
+++ b/gripper_action_controller/CMakeLists.txt
@@ -1,0 +1,178 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(gripper_action_controller)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin 
+  REQUIRED COMPONENTS
+      actionlib
+      angles
+      cmake_modules
+      roscpp
+      urdf
+      control_toolbox
+      controller_interface
+      hardware_interface
+      realtime_tools
+      control_msgs
+      trajectory_msgs
+      rostest
+      controller_manager
+      xacro
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependencies might have been
+##     pulled in transitively but can be declared for certainty nonetheless:
+##     * add a build_depend tag for "message_generation"
+##     * add a run_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   control_msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+INCLUDE_DIRS include
+LIBRARIES gripper_action_controller
+CATKIN_DEPENDS actionlib cmake_modules control_msgs controller_interface hardware_interface realtime_tools
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+include_directories(
+  include ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a cpp library
+add_library(gripper_action_controller
+   src/gripper_action_controller.cpp
+   include/gripper_action_controller/gripper_action_controller.h
+)
+
+target_link_libraries(gripper_action_controller
+ ${catkin_LIBRARIES}
+)
+
+## Declare a cpp executable
+# add_executable(gripper_action_controller_node src/gripper_action_controller_node.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(gripper_action_controller_node gripper_action_controller_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(gripper_action_controller_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+install(TARGETS gripper_action_controller
+   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+install(FILES ros_control_plugins.xml
+   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_gripper_action_controller.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
@@ -142,7 +142,7 @@ private:
   void setHoldPosition(const ros::Time& time);
 
   ros::Time last_movement_time_;                                    ///< Store stall time
-  double commanded_effort_;                                         ///< Computed command
+  double computed_command_;                                         ///< Computed command
 
   double stall_timeout_, stall_velocity_threshold_;                 ///< Stall related parameters
   double default_max_effort_;                                       ///< Max allowed effort

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
@@ -1,0 +1,161 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2014, SRI International
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of SRI International nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Sachin Chitta, Adolfo Rodriguez Tsouroukdissian
+
+#ifndef GRIPPER_ACTION_CONTROLLER_GRIPPER_ACTION_CONTROLLER_H
+#define GRIPPER_ACTION_CONTROLLER_GRIPPER_ACTION_CONTROLLER_H
+
+// C++ standard
+#include <cassert>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+
+// Boost
+#include <boost/shared_ptr.hpp>
+#include <boost/scoped_ptr.hpp>
+
+// ROS
+#include <ros/node_handle.h>
+
+// URDF
+#include <urdf/model.h>
+
+// ROS messages
+#include <control_msgs/GripperCommandAction.h>
+
+// actionlib
+#include <actionlib/server/action_server.h>
+
+// ros_controls
+#include <realtime_tools/realtime_server_goal_handle.h>
+#include <controller_interface/controller.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/internal/demangle_symbol.h>
+#include <realtime_tools/realtime_buffer.h>
+
+// Project
+#include <gripper_action_controller/hardware_interface_adapter.h>
+
+namespace gripper_action_controller
+{
+
+/**
+ * \brief Controller for executing a gripper command action for simple single-dof grippers.
+ *
+ * \tparam HardwareInterface Controller hardware interface. Currently \p hardware_interface::PositionJointInterface and
+ * \p hardware_interface::EffortJointInterface are supported out-of-the-box.
+ */
+template <class HardwareInterface>
+class GripperActionController : public controller_interface::Controller<HardwareInterface>
+{
+public:
+
+  /**
+   * \brief Store position and max effort in struct to allow easier realtime buffer usage
+   */
+  struct Commands
+  {
+    double position_; // Last commanded position
+    double max_effort_; // Max allowed effort
+  };
+  
+  GripperActionController();
+  
+  /** \name Non Real-Time Safe Functions
+   *\{*/
+  bool init(HardwareInterface* hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);
+  /*\}*/
+  
+  /** \name Real-Time Safe Functions
+   *\{*/
+  /** \brief Holds the current position. */
+  void starting(const ros::Time& time);
+
+  /** \brief Cancels the active action goal, if any. */
+  void stopping(const ros::Time& time);
+  
+  void update(const ros::Time& time, const ros::Duration& period);
+  /*\}*/
+
+  realtime_tools::RealtimeBuffer<Commands> command_;
+  Commands command_struct_, command_struct_rt_; // pre-allocated memory that is re-used to set the realtime buffer
+
+private:
+
+  typedef actionlib::ActionServer<control_msgs::GripperCommandAction>                         ActionServer;
+  typedef boost::shared_ptr<ActionServer>                                                     ActionServerPtr;
+  typedef ActionServer::GoalHandle                                                            GoalHandle;
+  typedef realtime_tools::RealtimeServerGoalHandle<control_msgs::GripperCommandAction>        RealtimeGoalHandle;
+  typedef boost::shared_ptr<RealtimeGoalHandle>                                               RealtimeGoalHandlePtr;
+
+  typedef HardwareInterfaceAdapter<HardwareInterface> HwIfaceAdapter;
+
+  bool                                          update_hold_position_; 
+  
+  bool                                         verbose_;            ///< Hard coded verbose flag to help in debugging
+  std::string                                  name_;               ///< Controller name.
+  hardware_interface::JointHandle joint_;                          ///< Handles to controlled joints.
+  std::string                     joint_name_;                      ///< Controlled joint names.
+
+  HwIfaceAdapter                               hw_iface_adapter_;   ///< Adapts desired goal state to HW interface.
+
+  RealtimeGoalHandlePtr                        rt_active_goal_;     ///< Currently active action goal, if any.
+  control_msgs::GripperCommandResultPtr        pre_alloc_result_;
+
+  ros::Duration action_monitor_period_;
+
+  // ROS API
+  ros::NodeHandle    controller_nh_;
+  ActionServerPtr    action_server_;
+
+  ros::Timer         goal_handle_timer_;
+
+  void goalCB(GoalHandle gh);
+  void cancelCB(GoalHandle gh);
+  void preemptActiveGoal();
+  void setHoldPosition(const ros::Time& time);
+
+  ros::Time last_movement_time_;                                    ///< Store stall time
+  double commanded_effort_;                                         ///< Computed command
+
+  double stall_timeout_, stall_velocity_threshold_;                 ///< Stall related parameters
+  double default_max_effort_;                                       ///< Max allowed effort
+  double goal_tolerance_;
+  /**
+   * \brief Check for success and publish appropriate result and feedback.
+   **/
+  void checkForSuccess(const ros::Time& time, double error_position, double current_position, double current_velocity);
+
+};
+
+} // namespace
+
+#include <gripper_action_controller/gripper_action_controller_impl.h>
+
+#endif // header guard

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
@@ -235,7 +235,7 @@ update(const ros::Time& time, const ros::Duration& period)
   checkForSuccess(time, error_position, current_position, current_velocity);
 
   // Hardware interface adapter: Generate and send commands
-  commanded_effort_ = hw_iface_adapter_.updateCommand(time, period,
+  computed_command_ = hw_iface_adapter_.updateCommand(time, period,
 						      command_struct_rt_.position_, 0.0, 
 						      error_position, error_velocity, command_struct_rt_.max_effort_);
 }
@@ -323,7 +323,7 @@ checkForSuccess(const ros::Time& time, double error_position, double current_pos
 
   if(fabs(error_position) < goal_tolerance_)
   {
-    pre_alloc_result_->effort = commanded_effort_;
+    pre_alloc_result_->effort = computed_command_;
     pre_alloc_result_->position = current_position;
     pre_alloc_result_->reached_goal = true;
     pre_alloc_result_->stalled = false;
@@ -337,7 +337,7 @@ checkForSuccess(const ros::Time& time, double error_position, double current_pos
     }
     else if( (time - last_movement_time_).toSec() > stall_timeout_)
     {
-      pre_alloc_result_->effort = commanded_effort_;
+      pre_alloc_result_->effort = computed_command_;
       pre_alloc_result_->position = current_position;
       pre_alloc_result_->reached_goal = false;
       pre_alloc_result_->stalled = true;

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
@@ -1,0 +1,351 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2014, SRI International
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of SRI International nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Sachin Chitta, Adolfo Rodriguez Tsouroukdissian, Stu Glaser
+
+#ifndef GRIPPER_ACTION_CONTROLLER_GRIPPER_ACTION_CONTROLLER_IMPL_H
+#define GRIPPER_ACTION_CONTROLLER_GRIPPER_ACTION_CONTROLLER_IMPL_H
+
+namespace gripper_action_controller
+{
+namespace internal
+{
+std::string getLeafNamespace(const ros::NodeHandle& nh)
+{
+  const std::string complete_ns = nh.getNamespace();
+  std::size_t id   = complete_ns.find_last_of("/");
+  return complete_ns.substr(id + 1);
+}  
+
+boost::shared_ptr<urdf::Model> getUrdf(const ros::NodeHandle& nh, const std::string& param_name)
+{
+  boost::shared_ptr<urdf::Model> urdf(new urdf::Model);
+
+  std::string urdf_str;
+  // Check for robot_description in proper namespace
+  if (nh.getParam(param_name, urdf_str))
+  {
+    if (!urdf->initString(urdf_str))
+    {
+      ROS_ERROR_STREAM("Failed to parse URDF contained in '" << param_name << "' parameter (namespace: " <<
+        nh.getNamespace() << ").");
+      return boost::shared_ptr<urdf::Model>();
+    }
+  }
+  // Check for robot_description in root
+  else if (!urdf->initParam("robot_description"))
+  {
+    ROS_ERROR_STREAM("Failed to parse URDF contained in '" << param_name << "' parameter");
+    return boost::shared_ptr<urdf::Model>();
+  }
+  return urdf;
+}
+
+typedef boost::shared_ptr<const urdf::Joint> UrdfJointConstPtr;
+std::vector<UrdfJointConstPtr> getUrdfJoints(const urdf::Model& urdf, const std::vector<std::string>& joint_names)
+{
+  std::vector<UrdfJointConstPtr> out;
+  for (unsigned int i = 0; i < joint_names.size(); ++i)
+  {
+    UrdfJointConstPtr urdf_joint = urdf.getJoint(joint_names[i]);
+    if (urdf_joint)
+    {
+      out.push_back(urdf_joint);
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Could not find joint '" << joint_names[i] << "' in URDF model.");
+      return std::vector<UrdfJointConstPtr>();
+    }
+  }
+  return out;
+}
+
+} // namespace
+
+template <class HardwareInterface>
+inline void GripperActionController<HardwareInterface>::
+starting(const ros::Time& time)
+{  
+  command_struct_rt_.position_ = joint_.getPosition();
+  command_struct_rt_.max_effort_ = default_max_effort_;
+  command_.initRT(command_struct_rt_);
+
+  // Hardware interface adapter
+  hw_iface_adapter_.starting(ros::Time(0.0));
+  last_movement_time_ = time;
+}
+ 
+template <class HardwareInterface>
+inline void GripperActionController<HardwareInterface>::
+stopping(const ros::Time& time)
+{
+  preemptActiveGoal();
+}
+
+template <class HardwareInterface>
+inline void GripperActionController<HardwareInterface>::
+preemptActiveGoal()
+{
+  RealtimeGoalHandlePtr current_active_goal(rt_active_goal_);
+   
+  // Cancels the currently active goal
+  if (current_active_goal)
+  {
+    // Marks the current goal as canceled
+    rt_active_goal_.reset();
+    if(current_active_goal->gh_.getGoalStatus().status == actionlib_msgs::GoalStatus::ACTIVE)
+      current_active_goal->gh_.setCanceled();
+  }
+}
+
+template <class HardwareInterface>
+GripperActionController<HardwareInterface>::
+GripperActionController()
+: verbose_(false) // Set to true during debugging
+{}
+
+template <class HardwareInterface>
+bool GripperActionController<HardwareInterface>::init(HardwareInterface* hw,
+						      ros::NodeHandle&   root_nh,
+						      ros::NodeHandle&   controller_nh)
+{
+  using namespace internal;
+  
+  // Cache controller node handle
+  controller_nh_ = controller_nh;
+  
+  // Controller name
+  name_ = getLeafNamespace(controller_nh_);
+  
+  // Action status checking update rate
+  double action_monitor_rate = 20.0;
+  controller_nh_.getParam("action_monitor_rate", action_monitor_rate);
+  action_monitor_period_ = ros::Duration(1.0 / action_monitor_rate);
+  ROS_DEBUG_STREAM_NAMED(name_, "Action status changes will be monitored at " << action_monitor_rate << "Hz.");
+  
+  // Controlled joint
+  controller_nh_.getParam("joint", joint_name_);
+  if (joint_name_.empty()) 
+  {
+    ROS_ERROR_STREAM_NAMED(name_, "Could not find joint name on param server");
+    return false;
+  }
+  
+  // URDF joints
+  boost::shared_ptr<urdf::Model> urdf = getUrdf(root_nh, "robot_description");
+  if (!urdf) 
+  {
+    return false;
+  }
+  
+  std::vector<std::string> joint_names;
+  joint_names.push_back(joint_name_);
+  std::vector<UrdfJointConstPtr> urdf_joints = getUrdfJoints(*urdf, joint_names);
+  if (urdf_joints.empty()) 
+  {
+    return false;
+  }
+  
+  // Initialize members
+  // Joint handle
+  try 
+  {
+    joint_ = hw->getHandle(joint_name_);
+  }
+  catch (...)
+  {
+    ROS_ERROR_STREAM_NAMED(name_, "Could not find joint '" << joint_name_ << "' in '" <<
+			   this->getHardwareInterfaceType() << "'.");
+    return false;
+  }
+
+  ROS_DEBUG_STREAM_NAMED(name_, "Initialized controller '" << name_ << "' with:" <<
+			 "\n- Hardware interface type: '" << this->getHardwareInterfaceType() << "'" <<
+			 "\n");
+  
+  // Default tolerances
+  controller_nh_.param<double>("goal_tolerance", goal_tolerance_, 0.01);
+  goal_tolerance_ = fabs(goal_tolerance_);
+  // Max allowable effort 
+  controller_nh_.param<double>("max_effort", default_max_effort_, 0.0);
+  default_max_effort_ = fabs(default_max_effort_);
+  // Stall - stall velocity threshold, stall timeout
+  controller_nh_.param<double>("stall_velocity_threshold", stall_velocity_threshold_, 0.001);
+  controller_nh_.param<double>("stall_timeout", stall_timeout_, 1.0);
+  
+  // Hardware interface adapter
+  hw_iface_adapter_.init(joint_, controller_nh_);
+
+  // Command - non RT version
+  command_struct_.position_ = joint_.getPosition();
+  command_struct_.max_effort_ = default_max_effort_;
+
+  // Result
+  pre_alloc_result_.reset(new control_msgs::GripperCommandResult());
+  pre_alloc_result_->position = command_struct_.position_;
+  pre_alloc_result_->reached_goal = false;
+  pre_alloc_result_->stalled = false;
+
+  // ROS API: Action interface
+  action_server_.reset(new ActionServer(controller_nh_, "gripper_cmd",
+					boost::bind(&GripperActionController::goalCB,   this, _1),
+					boost::bind(&GripperActionController::cancelCB, this, _1),
+					false));
+  action_server_->start();    
+  return true;
+}
+
+template <class HardwareInterface>
+void GripperActionController<HardwareInterface>::
+update(const ros::Time& time, const ros::Duration& period)
+{
+  command_struct_rt_ = *(command_.readFromRT());
+
+  double current_position = joint_.getPosition();
+  double current_velocity = joint_.getVelocity();
+
+  double error_position = command_struct_rt_.position_ - current_position;
+  double error_velocity = - current_velocity;
+    
+  checkForSuccess(time, error_position, current_position, current_velocity);
+
+  // Hardware interface adapter: Generate and send commands
+  commanded_effort_ = hw_iface_adapter_.updateCommand(time, period,
+						      command_struct_rt_.position_, 0.0, 
+						      error_position, error_velocity, command_struct_rt_.max_effort_);
+}
+
+template <class HardwareInterface>
+void GripperActionController<HardwareInterface>::
+goalCB(GoalHandle gh)
+{
+  ROS_DEBUG_STREAM_NAMED(name_,"Recieved new action goal");
+  
+  // Precondition: Running controller
+  if (!this->isRunning())
+  {
+    ROS_ERROR_NAMED(name_, "Can't accept new action goals. Controller is not running.");
+    control_msgs::GripperCommandResult result;
+    gh.setRejected(result);
+    return;
+  }
+
+  // Try to update goal
+  RealtimeGoalHandlePtr rt_goal(new RealtimeGoalHandle(gh));
+
+  // Accept new goal
+  preemptActiveGoal();
+  gh.setAccepted();
+
+  // This is the non-realtime command_struct
+  // We use command_ for sharing
+  command_struct_.position_ = gh.getGoal()->command.position;
+  command_struct_.max_effort_ = gh.getGoal()->command.max_effort;
+  command_.writeFromNonRT(command_struct_);
+
+  pre_alloc_result_->reached_goal = false;
+  pre_alloc_result_->stalled = false;
+
+  last_movement_time_ = ros::Time::now();
+    
+  // Setup goal status checking timer
+  goal_handle_timer_ = controller_nh_.createTimer(action_monitor_period_,
+						  &RealtimeGoalHandle::runNonRealtime,
+						  rt_goal);
+  goal_handle_timer_.start();
+  rt_active_goal_ = rt_goal;
+}
+
+template <class HardwareInterface>
+void GripperActionController<HardwareInterface>::
+cancelCB(GoalHandle gh)
+{
+  RealtimeGoalHandlePtr current_active_goal(rt_active_goal_);
+  
+  // Check that cancel request refers to currently active goal (if any)
+  if (current_active_goal && current_active_goal->gh_ == gh)
+  {
+    // Reset current goal
+    rt_active_goal_.reset();
+    
+    // Enter hold current position mode
+    setHoldPosition(ros::Time(0.0));
+    ROS_DEBUG_NAMED(name_, "Canceling active action goal because cancel callback recieved from actionlib.");
+    
+    // Mark the current goal as canceled
+    current_active_goal->gh_.setCanceled();
+  }
+}
+
+template <class HardwareInterface>
+void GripperActionController<HardwareInterface>::
+setHoldPosition(const ros::Time& time)
+{
+  command_struct_.position_ = joint_.getPosition();
+  command_struct_.max_effort_ = default_max_effort_;
+  command_.writeFromNonRT(command_struct_);
+}
+
+template <class HardwareInterface>
+void GripperActionController<HardwareInterface>::
+checkForSuccess(const ros::Time& time, double error_position, double current_position, double current_velocity)
+{
+  if(!rt_active_goal_)
+    return;
+
+  if(rt_active_goal_->gh_.getGoalStatus().status != actionlib_msgs::GoalStatus::ACTIVE)
+    return;
+
+  if(fabs(error_position) < goal_tolerance_)
+  {
+    pre_alloc_result_->effort = commanded_effort_;
+    pre_alloc_result_->position = current_position;
+    pre_alloc_result_->reached_goal = true;
+    pre_alloc_result_->stalled = false;
+    rt_active_goal_->setSucceeded(pre_alloc_result_);
+  }
+  else
+  {
+    if(fabs(current_velocity) > stall_velocity_threshold_)
+    {
+      last_movement_time_ = time;
+    }
+    else if( (time - last_movement_time_).toSec() > stall_timeout_)
+    {
+      pre_alloc_result_->effort = commanded_effort_;
+      pre_alloc_result_->position = current_position;
+      pre_alloc_result_->reached_goal = false;
+      pre_alloc_result_->stalled = true;
+      rt_active_goal_->setAborted(pre_alloc_result_);
+    }
+  }
+}
+
+} // namespace
+
+#endif // header guard

--- a/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
+++ b/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
@@ -1,0 +1,190 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2014, SRI International
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of SRI International nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Sachin Chitta, Adolfo Rodriguez Tsouroukdissian
+
+#ifndef GRIPPER_ACTION_CONTROLLER_HARDWARE_INTERFACE_ADAPTER_H
+#define GRIPPER_ACTION_CONTROLLER_HARDWARE_INTERFACE_ADAPTER_H
+
+#include <cassert>
+#include <string>
+#include <vector>
+
+#include <boost/shared_ptr.hpp>
+
+#include <ros/node_handle.h>
+#include <ros/time.h>
+
+#include <control_toolbox/pid.h>
+#include <hardware_interface/joint_command_interface.h>
+
+/**
+ * \brief Helper class to simplify integrating the GripperActionController with different hardware interfaces.
+ *
+ * The GripperActionController outputs position while
+ * it is supposed to work with either position or effort commands.
+ *
+ */
+template <class HardwareInterface>
+class HardwareInterfaceAdapter
+{
+public:
+  bool init(hardware_interface::JointHandle& joint_handle, ros::NodeHandle& controller_nh)
+  {
+    return false;
+  }
+
+  void starting(const ros::Time& time) {}
+  void stopping(const ros::Time& time) {}
+
+  double updateCommand(const ros::Time&     time,
+		       const ros::Duration& period,
+		       double desired_position,
+		       double desired_velocity,
+		       double error_position,
+		       double error_velocity,
+		       double max_allowed_effort) { return 0.0;}
+
+};
+
+/**
+ * \brief Adapter for a position-controlled hardware interface. Forwards desired positions as commands.
+ */
+template<>
+class HardwareInterfaceAdapter<hardware_interface::PositionJointInterface>
+{
+public:
+  HardwareInterfaceAdapter() : joint_handle_ptr_(0) {}
+
+  bool init(hardware_interface::JointHandle& joint_handle, ros::NodeHandle& controller_nh)
+  {
+    // Store pointer to joint handles
+    joint_handle_ptr_ = &joint_handle;
+
+    return true;
+  }
+
+  void starting(const ros::Time& time) {}
+  void stopping(const ros::Time& time) {}
+
+  double updateCommand(const ros::Time&     /*time*/,
+		       const ros::Duration& period,
+		       double desired_position,
+		       double desired_velocity,
+		       double error_position,
+		       double error_velocity,
+		       double max_allowed_effort)
+  {
+    // Forward desired position to command
+    (*joint_handle_ptr_).setCommand(desired_position);
+    return max_allowed_effort;
+  }
+
+private:
+  hardware_interface::JointHandle* joint_handle_ptr_;
+};
+
+/**
+ * \brief Adapter for an effort-controlled hardware interface. Maps position and velocity errors to effort commands
+ * through a position PID loop.
+ *
+ * The following is an example configuration of a controller that uses this adapter. Notice the \p gains entry:
+ * \code
+ * gripper_controller:
+ *   type: "gripper_action_controller/GripperActionController"
+ *   joints: gripper_joint
+ *   goal_tolerance: 0.01
+ *   stalled_velocity_threshold: 0.01
+ *   stall_timeout: 0.2
+ *   gains:
+ *     gripper_joint: {p: 200, d: 1, i: 5, i_clamp: 1}
+ * \endcode
+ */
+template<>
+class HardwareInterfaceAdapter<hardware_interface::EffortJointInterface>
+{
+public:
+  HardwareInterfaceAdapter() : joint_handle_ptr_(0) {}
+
+  bool init(hardware_interface::JointHandle& joint_handle, ros::NodeHandle& controller_nh)
+  {
+    // Store pointer to joint handles
+    joint_handle_ptr_ = &joint_handle;
+
+    // Initialize PIDs
+    ros::NodeHandle joint_nh(controller_nh, std::string("gains/") + joint_handle.getName());
+
+    // Init PID gains from ROS parameter server
+    pid_.reset(new control_toolbox::Pid());
+    if (!pid_->init(joint_nh))
+    {
+      ROS_WARN_STREAM("Failed to initialize PID gains from ROS parameter server.");
+      return false;
+    }
+  
+    return true;
+  }
+
+  void starting(const ros::Time& time)
+  {
+    if (!joint_handle_ptr_) 
+    {
+      return;
+    }
+    // Reset PIDs, zero effort commands
+    pid_->reset();
+    (*joint_handle_ptr_).setCommand(0.0);
+  }
+
+  void stopping(const ros::Time& time) {}
+
+  double updateCommand(const ros::Time&     /*time*/,
+		       const ros::Duration& period,
+		       double desired_position,
+		       double desired_velocity,
+		       double error_position,
+		       double error_velocity,
+		       double max_allowed_effort)
+  {
+    // Preconditions
+    if (!joint_handle_ptr_) {return 0.0;}
+
+    // Update PIDs
+      double command = pid_->computeCommand(error_position, error_velocity, period);
+      command = std::min<double>(fabs(max_allowed_effort), std::max<double>(-fabs(max_allowed_effort), command));
+      (*joint_handle_ptr_).setCommand(command);
+      return command;
+  }
+
+private:
+  typedef boost::shared_ptr<control_toolbox::Pid> PidPtr;
+  PidPtr pid_;
+  hardware_interface::JointHandle* joint_handle_ptr_;
+};
+
+#endif // header guard

--- a/gripper_action_controller/package.xml
+++ b/gripper_action_controller/package.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<package>
+  <name>gripper_action_controller</name>
+  <version>0.0.0</version>
+  <description>The gripper_action_controller package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="robot.moveit@gmail.com">Sachin Chitta</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>BSD</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/gripper_action_controller</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>cmake_modules</build_depend>
+  <build_depend>control_msgs</build_depend>
+  <build_depend>controller_interface</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>realtime_tools</build_depend>
+  <run_depend>actionlib</run_depend>
+  <run_depend>cmake_modules</run_depend>
+  <run_depend>control_msgs</run_depend>
+  <run_depend>controller_interface</run_depend>
+  <run_depend>hardware_interface</run_depend>
+  <run_depend>realtime_tools</run_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <controller_interface plugin="${prefix}/ros_control_plugins.xml"/>
+  </export>
+</package>

--- a/gripper_action_controller/package.xml
+++ b/gripper_action_controller/package.xml
@@ -26,7 +26,7 @@
   <!-- Authors do not have to be maintianers, but could be -->
   <!-- Example: -->
   <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
+  <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <!-- The *_depend tags are used to specify dependencies -->
   <!-- Dependencies can be catkin packages or system dependencies -->

--- a/gripper_action_controller/ros_control_plugins.xml
+++ b/gripper_action_controller/ros_control_plugins.xml
@@ -1,0 +1,17 @@
+<library path="lib/libgripper_action_controller">
+
+  <class name="position_controllers/GripperActionController"
+         type="position_controllers::GripperActionController"
+         base_class_type="controller_interface::ControllerBase">
+    <description>
+    </description>
+  </class>
+
+  <class name="effort_controllers/GripperActionController"
+         type="effort_controllers::GripperActionController"
+         base_class_type="controller_interface::ControllerBase">
+    <description>
+    </description>
+  </class>
+
+</library>

--- a/gripper_action_controller/src/gripper_action_controller.cpp
+++ b/gripper_action_controller/src/gripper_action_controller.cpp
@@ -47,7 +47,7 @@ namespace effort_controllers
 {
   /**
    * \brief Gripper action controller that sends
-   * commands to a \b position interface.
+   * commands to a \b effort interface.
    */
   typedef gripper_action_controller::GripperActionController<hardware_interface::EffortJointInterface>
           GripperActionController;

--- a/gripper_action_controller/src/gripper_action_controller.cpp
+++ b/gripper_action_controller/src/gripper_action_controller.cpp
@@ -1,0 +1,57 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2014, SRI International
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of SRI International nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Sachin Chitta
+
+// Pluginlib
+#include <pluginlib/class_list_macros.h>
+
+// Project
+#include <gripper_action_controller/gripper_action_controller.h>
+
+namespace position_controllers
+{
+  /**
+   * \brief Gripper action controller that sends
+   * commands to a \b position interface.
+   */
+  typedef gripper_action_controller::GripperActionController<hardware_interface::PositionJointInterface>
+          GripperActionController;
+}
+
+namespace effort_controllers
+{
+  /**
+   * \brief Gripper action controller that sends
+   * commands to a \b position interface.
+   */
+  typedef gripper_action_controller::GripperActionController<hardware_interface::EffortJointInterface>
+          GripperActionController;
+}
+
+PLUGINLIB_EXPORT_CLASS(position_controllers::GripperActionController, controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(effort_controllers::GripperActionController,   controller_interface::ControllerBase)


### PR DESCRIPTION
There could be an easier way to do this (using one of the effort controllers) but I could not find it so I implemented a simple version. This should service the GripperCommandAction that MoveIt! expects as well. So far, I have only tested in Gazebo with a PR2 gripper so it would be good to have this tried out on a real robot. 

The main difference for this action is limiting the max effort on a per call basis (which the other controllers are currently not setup to do). 
