### PR TITLE
Changed test-depend to build-depend for release jobs.

### DIFF
--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -30,8 +30,8 @@
   <!--Tests-->
   <build_depend>rostest</build_depend>
 
-  <test_depend>controller_manager</test_depend>
-  <test_depend>xacro</test_depend>
+  <build_depend>controller_manager</build_depend>
+  <build_depend>xacro</build_depend>
 
   <export>
     <controller_interface plugin="${prefix}/diff_drive_controller_plugins.xml"/>


### PR DESCRIPTION
The ros buildfarm is not taking test-depends into account when setting up the environment for release builds.
