### PR TITLE
Add base_frame_id param (defaults to base_link)

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -138,6 +138,9 @@ namespace diff_drive_controller{
     /// Timeout to consider cmd_vel commands old:
     double cmd_vel_timeout_;
 
+    /// Frame to use for the robot base:
+    std::string base_frame_id_;
+
     // speed limiters
     Commands last_cmd_;
     SpeedLimiter limiter_lin_;


### PR DESCRIPTION
The `nav_msgs/Odometry` message specifies the `child_frame_id` field, which was previously not set.

This PR creates a parameter to replace the previously hard-coded value of the `child_frame_id` of the published `tf` frame, and uses it in the `odom` message as well.

Opened against `hydro-devel` because this change is minor. It does change the default value of a field, though, which is noteworthy.
