### PR TITLE
Add depend on angles

### DIFF
--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>angles</build_depend>
   <build_depend>controller_interface</build_depend> 
   <build_depend>control_msgs</build_depend> 
   <build_depend>control_toolbox</build_depend> 
@@ -22,6 +23,7 @@
   <build_depend>forward_command_controller</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
 
+  <run_depend>angles</run_depend>
   <run_depend>controller_interface</run_depend> 
   <run_depend>control_msgs</run_depend> 
   <run_depend>control_toolbox</run_depend> 


### PR DESCRIPTION
The `angles` package is clearly referenced in the source at [1] and possible in other places. Therefore, it should `build_depend` and `run_depend` on `angles`.

This is causing failures on the buildfarm, and should be fixed and released.

Thanks!

--scott

[1] https://github.com/ros-controls/ros_controllers/blob/indigo-devel/effort_controllers/src/joint_position_controller.cpp#L43
[2] http://jenkins.ros.org/job/ros-indigo-effort-controllers_binarydeb_saucy_amd64/13/console
