### PR TITLE
Allow an initial value in position controllers

### DIFF
--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.h
@@ -79,12 +79,20 @@ public:
       ROS_ERROR("No joint given (namespace: %s)", n.getNamespace().c_str());
       return false;
     }
+    
+    
+    initial_val_ = 0.0;
+    if (!n.getParam("initial"), initial_val_)
+    {
+      ROS_INFO("No initial value given (namespace: %s); using 0.0", n.getNamespace().c_str())
+    }
+    
     joint_ = hw->getHandle(joint_name);
     sub_command_ = n.subscribe<std_msgs::Float64>("command", 1, &ForwardCommandController::commandCB, this);
     return true;
   }
 
-  void starting(const ros::Time& time) {command_ = 0.0;}
+  void starting(const ros::Time& time) {command_ = initial_val_;}
   void update(const ros::Time& time, const ros::Duration& period) {joint_.setCommand(command_);}
 
   hardware_interface::JointHandle joint_;
@@ -93,6 +101,7 @@ public:
 private:
   ros::Subscriber sub_command_;
   void commandCB(const std_msgs::Float64ConstPtr& msg) {command_ = msg->data;}
+  double initial_val_;
 };
 
 }

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.h
@@ -82,7 +82,7 @@ public:
     
     
     initial_val_ = 0.0;
-    if (!n.getParam("initial"), initial_val_)
+    if (!n.getParam("initial", initial_val_))
     {
       ROS_INFO("No initial value given (namespace: %s); using 0.0", n.getNamespace().c_str())
     }

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.h
@@ -84,7 +84,7 @@ public:
     initial_val_ = 0.0;
     if (!n.getParam("initial", initial_val_))
     {
-      ROS_INFO("No initial value given (namespace: %s); using 0.0", n.getNamespace().c_str())
+      ROS_INFO("No initial value given (namespace: %s); using 0.0", n.getNamespace().c_str());
     }
     
     joint_ = hw->getHandle(joint_name);


### PR DESCRIPTION
We (Personal Robotics Lab at CMU) were attempting to use a position controller for a robot with starting positions other than 0. This change doesn't change the implementation of any existing setup; it only allows users to specify arbitrary starting values for controllers based on forward_command_controller.
