### PR TITLE
addressing test dependencies

### DIFF
--- a/gripper_action_controller/CMakeLists.txt
+++ b/gripper_action_controller/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(catkin
       realtime_tools
       control_msgs
       trajectory_msgs
-      rostest
       controller_manager
       xacro
 )

--- a/gripper_action_controller/package.xml
+++ b/gripper_action_controller/package.xml
@@ -49,7 +49,6 @@
   <build_depend>controller_manager</build_depend>
   <build_depend>hardware_interface</build_depend>
   <build_depend>realtime_tools</build_depend>
-  <build_depend>rostest</build_depend>
   <build_depend>trajectory_msgs</build_depend>
   <build_depend>urdf</build_depend>
   <build_depend>xacro</build_depend>

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -61,7 +61,6 @@ else()
       realtime_tools
       control_msgs
       trajectory_msgs
-      rostest
       controller_manager
       xacro
   )
@@ -79,7 +78,6 @@ else()
     realtime_tools
     control_msgs
     trajectory_msgs
-    rostest
     controller_manager
     xacro
     INCLUDE_DIRS include
@@ -103,6 +101,8 @@ else()
   target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
   if(CATKIN_ENABLE_TESTING)
+    find_package(rostest) 
+
     catkin_add_gtest(quintic_spline_segment_test test/quintic_spline_segment_test.cpp)
     target_link_libraries(quintic_spline_segment_test ${catkin_LIBRARIES})
 


### PR DESCRIPTION
This is a manual backport of the commits submitted in https://github.com/ros-controls/ros_controllers/pull/113 for the indigo-devel branch. The commit for diff_drive_controller is not required because the issue that arised in ros-indigo, is not reproducible on my ros-hydro system.
