### PR TITLE
Fixed incorrect ordering of catkin_package() call that breaks catkin 2.0

### DIFF
--- a/force_torque_sensor_controller/CMakeLists.txt
+++ b/force_torque_sensor_controller/CMakeLists.txt
@@ -4,18 +4,18 @@ project(force_torque_sensor_controller)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS controller_interface hardware_interface geometry_msgs realtime_tools)
 
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
-
-add_library(${PROJECT_NAME}
-  src/force_torque_sensor_controller.cpp include/force_torque_sensor_controller/force_torque_sensor_controller.h)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
 # Declare catkin package
 catkin_package(
   CATKIN_DEPENDS controller_interface hardware_interface geometry_msgs realtime_tools
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   )
+
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME}
+  src/force_torque_sensor_controller.cpp include/force_torque_sensor_controller/force_torque_sensor_controller.h)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 # Install
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/joint_state_controller/CMakeLists.txt
+++ b/joint_state_controller/CMakeLists.txt
@@ -4,16 +4,16 @@ project(joint_state_controller)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS realtime_tools roscpp hardware_interface pluginlib controller_interface sensor_msgs)
 
-include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
-add_library(${PROJECT_NAME} src/joint_state_controller.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
 # Declare catkin package
 catkin_package(
   CATKIN_DEPENDS realtime_tools roscpp hardware_interface pluginlib controller_interface sensor_msgs
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   )
+
+include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
+add_library(${PROJECT_NAME} src/joint_state_controller.cpp)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
 # Install
 install(DIRECTORY include/${PROJECT_NAME}/

--- a/position_controllers/CMakeLists.txt
+++ b/position_controllers/CMakeLists.txt
@@ -4,6 +4,13 @@ project(position_controllers)
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS controller_interface forward_command_controller)
 
+# Declare catkin project
+catkin_package(
+    CATKIN_DEPENDS controller_interface forward_command_controller
+    INCLUDE_DIRS include
+    LIBRARIES ${PROJECT_NAME}
+)
+
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 add_library(${PROJECT_NAME}
   src/joint_position_controller.cpp
@@ -11,12 +18,6 @@ add_library(${PROJECT_NAME}
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
-# Declare catkin project
-catkin_package(
-    CATKIN_DEPENDS controller_interface forward_command_controller
-    INCLUDE_DIRS include
-    LIBRARIES ${PROJECT_NAME}
-)
 
 # Install
 install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
Several controllers had incorrect ordering of `catkin_package` call that occured after `add_library`. This worked in catkin_make but breaks in the new [catkin_tools](https://github.com/catkin/catkin_tools) project (still in beta). 

This should be fixed despite what build system one is using. Sigh... several hours of broken ros_control because of bad CMake configurations.
