### PR TITLE
use current position when starting (forward_command) position_controllers

### DIFF
--- a/effort_controllers/src/joint_effort_controller.cpp
+++ b/effort_controllers/src/joint_effort_controller.cpp
@@ -37,4 +37,12 @@
 #include <effort_controllers/joint_effort_controller.h>
 #include <pluginlib/class_list_macros.h>
 
+template <class T>
+void forward_command_controller::ForwardCommandController<T>::starting(const ros::Time& time)
+{
+  // Start controller with 0.0 effort
+  command_ = 0.0;
+}
+
+
 PLUGINLIB_EXPORT_CLASS(effort_controllers::JointEffortController,controller_interface::ControllerBase)

--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -38,4 +38,12 @@
 #include <effort_controllers/joint_group_effort_controller.h>
 #include <pluginlib/class_list_macros.h>
 
+template <class T>
+void forward_command_controller::ForwardJointGroupCommandController<T>::starting(const ros::Time& time)
+{
+  // Start controller with 0.0 efforts
+  commands_.resize(n_joints_, 0.0);
+}
+
+
 PLUGINLIB_EXPORT_CLASS(effort_controllers::JointGroupEffortController,controller_interface::ControllerBase)

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.h
@@ -84,7 +84,7 @@ public:
     return true;
   }
 
-  void starting(const ros::Time& time) {command_ = 0.0;}
+  void starting(const ros::Time& time);
   void update(const ros::Time& time, const ros::Duration& period) {joint_.setCommand(command_);}
 
   hardware_interface::JointHandle joint_;

--- a/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
@@ -103,7 +103,7 @@ public:
     return true;
   }
 
-  void starting(const ros::Time& time) {commands_.resize(n_joints_, 0.0);}
+  void starting(const ros::Time& time);
   void update(const ros::Time& time, const ros::Duration& period) 
   {
     for(unsigned int i=0; i<n_joints_; i++)

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -38,4 +38,16 @@
 #include <position_controllers/joint_group_position_controller.h>
 #include <pluginlib/class_list_macros.h>
 
+template <class T>
+void forward_command_controller::ForwardJointGroupCommandController<T>::starting(const ros::Time& time)
+{
+  // Start controller with current joint positions
+  commands_.resize(n_joints_, 0.0);
+  for(unsigned int i=0; i<joints_.size(); i++)
+  {
+    commands_[i]=joints_[i].getPosition();
+  }
+}
+
+
 PLUGINLIB_EXPORT_CLASS(position_controllers::JointGroupPositionController,controller_interface::ControllerBase)

--- a/position_controllers/src/joint_position_controller.cpp
+++ b/position_controllers/src/joint_position_controller.cpp
@@ -37,4 +37,11 @@
 #include <position_controllers/joint_position_controller.h>
 #include <pluginlib/class_list_macros.h>
 
+template <class T>
+void forward_command_controller::ForwardCommandController<T>::starting(const ros::Time& time)
+{
+  // Start controller with current joint position
+  command_ = joint_.getPosition();
+}
+
 PLUGINLIB_EXPORT_CLASS(position_controllers::JointPositionController,controller_interface::ControllerBase)

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -38,4 +38,12 @@
 #include <velocity_controllers/joint_group_velocity_controller.h>
 #include <pluginlib/class_list_macros.h>
 
+template <class T>
+void forward_command_controller::ForwardJointGroupCommandController<T>::starting(const ros::Time& time)
+{
+  // Start controller with 0.0 velocities
+  commands_.resize(n_joints_, 0.0);
+}
+
+
 PLUGINLIB_EXPORT_CLASS(velocity_controllers::JointGroupVelocityController,controller_interface::ControllerBase)

--- a/velocity_controllers/src/joint_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_velocity_controller.cpp
@@ -37,4 +37,12 @@
 #include <velocity_controllers/joint_velocity_controller.h>
 #include <pluginlib/class_list_macros.h>
 
+template <class T>
+void forward_command_controller::ForwardCommandController<T>::starting(const ros::Time& time)
+{
+  // Start controller with 0.0 velocity
+  command_ = 0.0;
+}
+
+
 PLUGINLIB_EXPORT_CLASS(velocity_controllers::JointVelocityController,controller_interface::ControllerBase)


### PR DESCRIPTION
effort and velocity (forward_command) controllers still use 0.0

The template class now only contains the declaration for `starting()`. The implementation moved to the respective controllers.

This is related to #104
