### PR TITLE
diff drive remove angles

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -4,7 +4,6 @@ project(diff_drive_controller)
 find_package(catkin REQUIRED COMPONENTS
     controller_interface
     urdf
-    angles
     realtime_tools
     tf
     nav_msgs)

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -61,5 +61,6 @@ if (CATKIN_ENABLE_TESTING)
     test/diff_drive_odom_tf.test
     test/diff_drive_odom_tf_test.cpp)
   target_link_libraries(diff_drive_odom_tf_test ${catkin_LIBRARIES})
+  add_rostest(test/diff_drive_open_loop.test)
 
 endif()

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -98,9 +98,10 @@ namespace diff_drive_controller{
   private:
     std::string name_;
 
-    /// Publish rate related:
+    /// Odometry related:
     ros::Duration publish_period_;
     ros::Time last_state_publish_time_;
+    bool open_loop_;
 
     /// Hardware handles:
     hardware_interface::JointHandle left_wheel_joint_;

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -145,7 +145,7 @@ namespace diff_drive_controller{
     /// Whether to publish odometry to tf or not:
     bool enable_odom_tf_;
 
-    // speed limiters
+    // Speed limiters:
     Commands last_cmd_;
     SpeedLimiter limiter_lin_;
     SpeedLimiter limiter_ang_;

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -72,6 +72,12 @@ namespace diff_drive_controller
     Odometry(size_t velocity_rolling_window_size = 10);
 
     /**
+     * \brief Initialize the odometry
+     * \param time Current time
+     */
+    void init(const ros::Time &time);
+
+    /**
      * \brief Updates the odometry class with latest wheels position
      * \param left_pos  Left  wheel position [rad]
      * \param right_pos Right wheel position [rad]
@@ -180,7 +186,8 @@ namespace diff_drive_controller
     double left_wheel_old_pos_;
     double right_wheel_old_pos_;
 
-    /// Rolling meand accumulators for the linar and angular velocities:
+    /// Rolling mean accumulators for the linar and angular velocities:
+    size_t velocity_rolling_window_size_;
     RollingMeanAcc linear_acc_;
     RollingMeanAcc angular_acc_;
 

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -35,6 +35,8 @@
 /*
  * Author: Luca Marchionni
  * Author: Bence Magyar
+ * Author: Enrique Fernández
+ * Author: Paul Mathieu
  */
 
 #ifndef ODOMETRY_H_
@@ -83,9 +85,8 @@ namespace diff_drive_controller
      * \param linear  Linear velocity [m/s]
      * \param angular Angular velocity [rad/s]
      * \param time    Current time
-     * \return true if the odometry is actually updated
      */
-    bool update_open_loop(double linear, double angular, const ros::Time &time);
+    void updateOpenLoop(double linear, double angular, const ros::Time &time);
 
     /**
      * \brief heading getter
@@ -133,27 +134,6 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief timestamp getter
-     * \return timestamp
-     */
-    ros::Time getTimestamp() const
-    {
-      return timestamp_;
-    }
-
-    /**
-     * \brief Retrieves the linear velocity estimation
-     * \return Rolling mean estimation of the linear velocity [m]
-     */
-    double getLinearEstimated() const;
-
-    /**
-     * \brief Retrieves the angular velocity estimation
-     * \return Rolling mean estimation of the angular velocity [rad/s]
-     */
-    double getAngularEstimated() const;
-
-    /**
      * \brief Sets the wheel parameters: radius and separation
      * \param wheel_separation Seperation between left and right wheels [m]
      * \param wheel_radius     Wheel radius [m]
@@ -188,7 +168,7 @@ namespace diff_drive_controller
     double y_;        //   [m]
     double heading_;  // [rad]
 
-    /// Current velocity (for open loop mode):
+    /// Current velocity:
     double linear_;  //   [m/s]
     double angular_; // [rad/s]
 

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -79,6 +79,15 @@ namespace diff_drive_controller
     bool update(double left_pos, double right_pos, const ros::Time &time);
 
     /**
+     * \brief Updates the odometry class with latest velocity command
+     * \param linear  Linear velocity [m/s]
+     * \param angular Angular velocity [rad/s]
+     * \param time    Current time
+     * \return true if the odometry is actually updated
+     */
+    bool update_open_loop(double linear, double angular, const ros::Time &time);
+
+    /**
      * \brief heading getter
      * \return heading [rad]
      */
@@ -98,11 +107,29 @@ namespace diff_drive_controller
 
     /**
      * \brief y position getter
-     * \return y positioin [m]
+     * \return y position [m]
      */
     double getY() const
     {
       return y_;
+    }
+
+    /**
+     * \brief linear velocity getter
+     * \return linear velocity [m/s]
+     */
+    double getLinear() const
+    {
+      return linear_;
+    }
+
+    /**
+     * \brief angular velocity getter
+     * \return angular velocity [rad/s]
+     */
+    double getAngular() const
+    {
+      return angular_;
     }
 
     /**
@@ -160,6 +187,10 @@ namespace diff_drive_controller
     double x_;        //   [m]
     double y_;        //   [m]
     double heading_;  // [rad]
+
+    /// Current velocity (for open loop mode):
+    double linear_;  //   [m/s]
+    double angular_; // [rad/s]
 
     /// Wheel kinematic parameters [m]:
     double wheel_separation_;

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -19,7 +19,6 @@
   <build_depend>realtime_tools</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>urdf</build_depend>
-  <build_depend>angles</build_depend>
 
   <run_depend>controller_interface</run_depend>
   <run_depend>nav_msgs</run_depend>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -288,6 +288,8 @@ namespace diff_drive_controller{
 
     // Register starting time used to keep fixed rate
     last_state_publish_time_ = time;
+
+    odometry_.init(time);
   }
 
   void DiffDriveController::stopping(const ros::Time& time)

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -211,7 +211,7 @@ namespace diff_drive_controller{
     else
     {
       const double left_pos  = left_wheel_joint_.getPosition();
-      double right_pos = right_wheel_joint_.getPosition();
+      const double right_pos = right_wheel_joint_.getPosition();
       if (std::isnan(left_pos) || std::isnan(right_pos))
         return;
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -41,7 +41,6 @@
 
 #include <diff_drive_controller/odometry.h>
 
-#include <angles/angles.h>
 #include <boost/bind.hpp>
 
 namespace diff_drive_controller
@@ -140,9 +139,6 @@ namespace diff_drive_controller
     x_       += linear * cos(direction);
     y_       += linear * sin(direction);
     heading_ += angular;
-
-    /// Normalization of angle to [-Pi, Pi]:
-    heading_ = angles::normalize_angle(heading_);
   }
 
   /**
@@ -160,8 +156,8 @@ namespace diff_drive_controller
       const double heading_old = heading_;
       const double r = linear/angular;
       heading_ += angular;
-      x_ +=  r * (sin(heading_) - sin(thetaOld));
-      y_ += -r * (cos(heading_) - cos(thetaOld));
+      x_       +=  r * (sin(heading_) - sin(heading_old));
+      y_       += -r * (cos(heading_) - cos(heading_old));
     }
   }
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -60,7 +60,7 @@ namespace diff_drive_controller
   {
   }
 
-  bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)
+  bool Odometry::update(double left_pos, double right_pos, const ros::Time& time)
   {
     /// Get current wheel joint positions:
     const double left_wheel_cur_pos  = left_pos  * wheel_radius_;
@@ -91,6 +91,21 @@ namespace diff_drive_controller
     /// Estimate speeds using a rolling mean to filter them out:
     linear_acc_(linear/dt);
     angular_acc_(angular/dt);
+
+    return true;
+  }
+
+  bool Odometry::update_open_loop(double linear, double angular, const ros::Time& time)
+  {
+    /// Save last linear and angular velocity:
+    linear_ = linear;
+    angular_ = angular;
+
+    const double dt = (time - timestamp_).toSec();
+    timestamp_ = time;
+
+    /// Integrate odometry:
+    integrate_fun_(linear * dt, angular * dt);
 
     return true;
   }

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -134,7 +134,7 @@ namespace diff_drive_controller
 
   void Odometry::integrateRungeKutta2(double linear, double angular)
   {
-    double direction = heading_ + angular*0.5;
+    const double direction = heading_ + angular * 0.5;
 
     /// Runge-Kutta 2nd order integration:
     x_       += linear * cos(direction);
@@ -157,7 +157,7 @@ namespace diff_drive_controller
     else
     {
       /// Exact integration (should solve problems when angular is zero):
-      const double thetaOld = heading_;
+      const double heading_old = heading_;
       const double r = linear/angular;
       heading_ += angular;
       x_ +=  r * (sin(heading_) - sin(thetaOld));

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -33,7 +33,10 @@
  *********************************************************************/
 
 /*
+ * Author: Luca Marchionni
+ * Author: Bence Magyar
  * Author: Enrique Fernández
+ * Author: Paul Mathieu
  */
 
 #include <diff_drive_controller/odometry.h>
@@ -46,21 +49,23 @@ namespace diff_drive_controller
   namespace bacc = boost::accumulators;
 
   Odometry::Odometry(size_t velocity_rolling_window_size)
-  : timestamp_(0.0),
-    x_(0.0),
-    y_(0.0),
-    heading_(0.0),
-    wheel_separation_(0.0),
-    wheel_radius_(0.0),
-    left_wheel_old_pos_(0.0),
-    right_wheel_old_pos_(0.0),
-    linear_acc_(RollingWindow::window_size = velocity_rolling_window_size),
-    angular_acc_(RollingWindow::window_size = velocity_rolling_window_size),
-    integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
+  : timestamp_(0.0)
+  , x_(0.0)
+  , y_(0.0)
+  , heading_(0.0)
+  , linear_(0.0)
+  , angular_(0.0)
+  , wheel_separation_(0.0)
+  , wheel_radius_(0.0)
+  , left_wheel_old_pos_(0.0)
+  , right_wheel_old_pos_(0.0)
+  , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
+  , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
+  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
   {
   }
 
-  bool Odometry::update(double left_pos, double right_pos, const ros::Time& time)
+  bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)
   {
     /// Get current wheel joint positions:
     const double left_wheel_cur_pos  = left_pos  * wheel_radius_;
@@ -92,32 +97,22 @@ namespace diff_drive_controller
     linear_acc_(linear/dt);
     angular_acc_(angular/dt);
 
+    linear_ = bacc::rolling_mean(linear_acc_);
+    angular_ = bacc::rolling_mean(angular_acc_);
+
     return true;
   }
 
-  bool Odometry::update_open_loop(double linear, double angular, const ros::Time& time)
+  void Odometry::updateOpenLoop(double linear, double angular, const ros::Time &time)
   {
     /// Save last linear and angular velocity:
     linear_ = linear;
     angular_ = angular;
 
+    /// Integrate odometry:
     const double dt = (time - timestamp_).toSec();
     timestamp_ = time;
-
-    /// Integrate odometry:
     integrate_fun_(linear * dt, angular * dt);
-
-    return true;
-  }
-
-  double Odometry::getLinearEstimated() const
-  {
-    return bacc::rolling_mean(linear_acc_);
-  }
-
-  double Odometry::getAngularEstimated() const
-  {
-    return bacc::rolling_mean(angular_acc_);
   }
 
   void Odometry::setWheelParams(double wheel_separation, double wheel_radius)

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -59,10 +59,21 @@ namespace diff_drive_controller
   , wheel_radius_(0.0)
   , left_wheel_old_pos_(0.0)
   , right_wheel_old_pos_(0.0)
+  , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
   {
+  }
+
+  void Odometry::init(const ros::Time& time)
+  {
+    // Reset accumulators:
+    linear_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+    angular_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+
+    // Reset timestamp:
+    timestamp_ = time;
   }
 
   bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)

--- a/diff_drive_controller/test/diff_drive_open_loop.test
+++ b/diff_drive_controller/test/diff_drive_open_loop.test
@@ -1,0 +1,16 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Load diff drive parameter open loop -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_open_loop.yaml" />
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diffbot_open_loop.yaml
+++ b/diff_drive_controller/test/diffbot_open_loop.yaml
@@ -1,0 +1,2 @@
+diffbot_controller:
+  open_loop: true


### PR DESCRIPTION
This PR is an update from the hydro-devel branch of ros_controllers from PAL Robotics, and it depends on https://github.com/ros-controls/ros_controllers/pull/136.

It eliminates the dependency on `angles`.

Related PR:
https://github.com/pal-robotics/ros_controllers/pull/40
