### PR TITLE
Added a feedforward term for velocity commands in PID loop

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -79,7 +79,7 @@ public:
  *   joints:
  *     - head_1_joint
  *     - head_2_joint
- *   
+ *
  *   constraints:
  *     goal_time: 0.6
  *     stopped_velocity_tolerance: 0.02
@@ -203,7 +203,14 @@ public:
     // Update PIDs
     for (unsigned int i = 0; i < n_joints; ++i)
     {
-      const double command = pids_[i]->computeCommand(state_error.position[i], state_error.velocity[i], period);
+      // Compute error feedback WITH velocity feed-forward term
+      // The upside of this approach is that if the robot has a velocity controller with good tracking,
+      // the feed-forward component will be realized with high accuracy. In such a case, and in the absence of important
+      // external disturbances, the feedback term should be doing very little
+      const double feed_fwd_vel = desired_state.velocity[i];
+      const double feedback_vel = pids_[i]->computeCommand(state_error.position[i], state_error.velocity[i], period);
+      const double command = feed_fwd_vel + feedback_vel;
+
       (*joint_handles_ptr_)[i].setCommand(command);
     }
   }


### PR DESCRIPTION
In reference to @adolfo-rt 's comments last year:
https://github.com/ros-controls/ros_controllers/pull/64#discussion_r7727093
and
https://github.com/ros-controls/ros_controllers/commit/533ff43be53ea4996ffa9b2e079f889857e97483#joint_trajectory_controller-include-joint_trajectory_controller-hardware_interface_adapter-h-P14

Unfortuantly these changes were never made and when the PR was split up and refactored it was forgotten. 

Running this on Baxter, I saw huge improvements. 
