### PR TITLE
Check waypoint timing

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -82,6 +82,7 @@ if(CATKIN_ENABLE_TESTING)
   target_link_libraries(rrbot ${catkin_LIBRARIES})
 
   add_dependencies(tests rrbot)
+  add_dependencies(tests ${PROJECT_NAME})
 
   add_rostest_gtest(joint_trajectory_controller_test
                     test/joint_trajectory_controller.test

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -194,10 +194,17 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   ROS_DEBUG_STREAM("Figuring out new trajectory starting at time "
                    << std::fixed << std::setprecision(3) << msg_start_time.toSec());
 
-  //Empty trajectory
+  // Empty trajectory
   if (msg.points.empty())
   {
     ROS_DEBUG("Trajectory message contains empty trajectory. Nothing to convert.");
+    return Trajectory();
+  }
+
+  // Non strictly-monotonic waypoints
+  if (!isTimeStrictlyIncreasing(msg))
+  {
+    ROS_ERROR("Trajectory message contains waypoints that are not strictly increasing in time.");
     return Trajectory();
   }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_msg_utils.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_msg_utils.h
@@ -113,6 +113,27 @@ inline bool isValid(const trajectory_msgs::JointTrajectory& msg)
 }
 
 /**
+ * \param msg Trajectory message.
+ * \return True if each trajectory waypoint is reached at a later time than its predecessor.
+ */
+inline bool isTimeStrictlyIncreasing(const trajectory_msgs::JointTrajectory& msg)
+{
+  if (msg.points.size() < 2) {return true;}
+
+  typedef std::vector<trajectory_msgs::JointTrajectoryPoint>::const_iterator PointConstIterator;
+
+  PointConstIterator it = msg.points.begin();
+  PointConstIterator end_it = --msg.points.end();
+  while (it != end_it)
+  {
+    const ros::Duration& t1 = it->time_from_start;
+    const ros::Duration& t2 = (++it)->time_from_start;
+    if (t1 >= t2) {return false;}
+  }
+  return true;
+}
+
+/**
  * \brief Find an iterator to the trajectory point with the greatest start time < \p time.
  *
  * \param msg Trajectory message.

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -301,6 +301,16 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
     EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_GOAL);
   }
 
+  // Non-strictly increasing waypoint times
+  {
+    ActionGoal bad_goal = traj_goal;
+    bad_goal.trajectory.points[2].time_from_start = bad_goal.trajectory.points[1].time_from_start;
+
+    action_client->sendGoal(bad_goal);
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
+    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_GOAL);
+  }
+
   // Empty trajectory through action interface
   // NOTE: Sending an empty trajectory through the topic interface cancels execution of all queued segments, but
   // an empty trajectory is interpreted by the action interface as not having the correct joint names.

--- a/joint_trajectory_controller/test/joint_trajectory_msg_utils_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_msg_utils_test.cpp
@@ -144,6 +144,43 @@ TEST_F(TrajectoryInterfaceRosTest, IsValid)
   }
 }
 
+TEST_F(TrajectoryInterfaceRosTest, IsTimeStrictlyIncreasing)
+{
+  // Empty trajectory
+  {
+    JointTrajectory msg;
+    EXPECT_TRUE(isTimeStrictlyIncreasing(msg));
+  }
+
+  // Single-waypoint trajectory
+  {
+    JointTrajectory msg;
+    msg.points.push_back(points[0]);
+    EXPECT_TRUE(isTimeStrictlyIncreasing(msg));
+  }
+
+  // Multi-waypoint tajectory with strictly increasing times
+  {
+    EXPECT_TRUE(isTimeStrictlyIncreasing(trajectory_msg));
+  }
+
+  // Multi-waypoint tajectory with monotonically increasing (non-decreasing) times
+  {
+    JointTrajectory msg;
+    msg = trajectory_msg;
+    msg.points[2].time_from_start = msg.points[1].time_from_start;
+    EXPECT_FALSE(isTimeStrictlyIncreasing(msg));
+  }
+
+  // Multi-waypoint tajectory with non-monotonic times
+  {
+    JointTrajectory msg;
+    msg = trajectory_msg;
+    msg.points[2].time_from_start = msg.points[0].time_from_start;
+    EXPECT_FALSE(isTimeStrictlyIncreasing(msg));
+  }
+}
+
 TEST_F(TrajectoryInterfaceRosTest, FindPoint)
 {
   const ros::Time msg_start_time = trajectory_msg.header.stamp;


### PR DESCRIPTION
A precondition for all trajectories executed by the
joint_trajectory_controller is that waypoints must have strictly
increasing reach times. This changeset validates the precondition and
rejects commands that don't satisfy it.
