### PR TITLE
[Indigo] Reset to semantic zero in HardwareInterfaceAdapter for PositionJointInterface

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -103,7 +103,17 @@ public:
     return true;
   }
 
-  void starting(const ros::Time& time) {}
+  void starting(const ros::Time& time)
+  {
+    if (!joint_handles_ptr_) {return;}
+    
+    // Semantic zero for commands
+    for (unsigned int i = 0; i < joint_handles_ptr_->size(); ++i)
+    {
+      (*joint_handles_ptr_)[i].setCommand((*joint_handles_ptr_)[i].getPosition());
+    }
+  }
+  
   void stopping(const ros::Time& time) {}
 
   void updateCommand(const ros::Time&     /*time*/,


### PR DESCRIPTION
Semantic zero was set for VelocityJointInterface (i.e. 0.0) and EffortJointInterface (i.e. 0.0), but not for PositionJointInterface (i.e. currentPosition)
