### PR TITLE
Set hold using desired - only for discussion first

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -696,18 +696,12 @@ setHoldPosition(const ros::Time& time)
   const unsigned int n_joints = joints_.size();
   for (unsigned int i = 0; i < n_joints; ++i)
   {
-    //    hold_start_state_.position[i]     =  joints_[i].getPosition();
-    //    hold_start_state_.velocity[i]     =  joints_[i].getVelocity();
     hold_start_state_.position[i] = desired_state_.position[i];
     hold_start_state_.velocity[i] = desired_state_.velocity[i];
-
     hold_start_state_.acceleration[i] =  0.0;
 
-    //    hold_end_state_.position[i]       =  joints_[i].getPosition();
-    //    hold_end_state_.velocity[i]       = -joints_[i].getVelocity();
     hold_end_state_.position[i] = desired_state_.position[i];
     hold_end_state_.velocity[i] = -desired_state_.velocity[i];
-
     hold_end_state_.acceleration[i]   =  0.0;
   }
   hold_trajectory_ptr_->front().init(start_time,  hold_start_state_,
@@ -719,19 +713,6 @@ setHoldPosition(const ros::Time& time)
   // Now create segment that goes from current state to one with zero end velocity
   hold_trajectory_ptr_->front().init(start_time, hold_start_state_,
                                      end_time,   hold_end_state_);
-
-  for (unsigned int i = 0; i < n_joints; ++i)
-  {
-    ROS_INFO("Hold start state: %d ( %f, %f, %f ) :: ( %f, %f, %f ) :: %f", 
-	     i,
-	     hold_start_state_.position[i], 
-	     hold_start_state_.velocity[i],
-	     hold_start_state_.acceleration[i],
-	     hold_end_state_.position[i], 
-	     hold_end_state_.velocity[i],
-	     hold_end_state_.acceleration[i],
-	     time.toSec());
-  }
 
   curr_trajectory_box_.set(hold_trajectory_ptr_);
 }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -139,6 +139,15 @@ starting(const ros::Time& time)
   time_data.uptime = ros::Time(0.0);
   time_data_.initRT(time_data);
 
+  // Update current state and state error
+  for (unsigned int i = 0; i < joints_.size(); ++i)
+  {
+    current_state_.position[i] = joints_[i].getPosition();
+    current_state_.velocity[i] = joints_[i].getVelocity();
+  }
+
+  desired_state_ = current_state_;
+
   // Hold current position
   setHoldPosition(time_data.uptime);
 
@@ -147,6 +156,7 @@ starting(const ros::Time& time)
 
   // Hardware interface adapter
   hw_iface_adapter_.starting(time_data.uptime);
+
 }
 
 template <class SegmentImpl, class HardwareInterface>
@@ -686,12 +696,18 @@ setHoldPosition(const ros::Time& time)
   const unsigned int n_joints = joints_.size();
   for (unsigned int i = 0; i < n_joints; ++i)
   {
-    hold_start_state_.position[i]     =  joints_[i].getPosition();
-    hold_start_state_.velocity[i]     =  joints_[i].getVelocity();
+    //    hold_start_state_.position[i]     =  joints_[i].getPosition();
+    //    hold_start_state_.velocity[i]     =  joints_[i].getVelocity();
+    hold_start_state_.position[i] = desired_state_.position[i];
+    hold_start_state_.velocity[i] = desired_state_.velocity[i];
+
     hold_start_state_.acceleration[i] =  0.0;
 
-    hold_end_state_.position[i]       =  joints_[i].getPosition();
-    hold_end_state_.velocity[i]       = -joints_[i].getVelocity();
+    //    hold_end_state_.position[i]       =  joints_[i].getPosition();
+    //    hold_end_state_.velocity[i]       = -joints_[i].getVelocity();
+    hold_end_state_.position[i] = desired_state_.position[i];
+    hold_end_state_.velocity[i] = -desired_state_.velocity[i];
+
     hold_end_state_.acceleration[i]   =  0.0;
   }
   hold_trajectory_ptr_->front().init(start_time,  hold_start_state_,
@@ -703,6 +719,19 @@ setHoldPosition(const ros::Time& time)
   // Now create segment that goes from current state to one with zero end velocity
   hold_trajectory_ptr_->front().init(start_time, hold_start_state_,
                                      end_time,   hold_end_state_);
+
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    ROS_INFO("Hold start state: %d ( %f, %f, %f ) :: ( %f, %f, %f ) :: %f", 
+	     i,
+	     hold_start_state_.position[i], 
+	     hold_start_state_.velocity[i],
+	     hold_start_state_.acceleration[i],
+	     hold_end_state_.position[i], 
+	     hold_end_state_.velocity[i],
+	     hold_end_state_.acceleration[i],
+	     time.toSec());
+  }
 
   curr_trajectory_box_.set(hold_trajectory_ptr_);
 }


### PR DESCRIPTION
I am creating this PR mainly to discuss the way setHold operates. Here's how I came to this PR:

I am working with an industrial robot using a position command interface constantly streaming points. When I abort a trajectory that had already been sent, I found that the industrial controller would complain and shut down with an "acceleration command exceeded" error message. Digging a little deeper, I realized that the robot was lagging the given command. When the trajectory was aborted, setHold uses the actual robot position to generate a new segment that will stop the robot. However, this creates a discontinuity in the command to the robot (since actual was lagging command) creating a request that seems to require a large velocity/acceleration. Naturally, the robot controller complains and shuts down. 

I have seen this happen on other robots too (in a different context not using this particular controller) when they have trouble tracking and the command gets reset using actual instead of the previous command. The particular behavior, of course, depends on how the internal robot controllers act  - asking for a big jump in command triggers errors on some controllers. 

This PR contains my fix (but probably requires some changes to be realtime correct). I am using desired (instead of actual) to generate the new segment in setHold. This works for me right now but putting it up for discussion. Note this PR also depends on #176. 
