### PR TITLE
Enable usage of namespaces for joint position controllers.

### DIFF
--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -39,6 +39,7 @@
  Desc: Effort(force)-based position controller using basic PID loop
 */
 
+#include <string>
 #include <effort_controllers/joint_position_controller.h>
 #include <angles/angles.h>
 #include <pluginlib/class_list_macros.h>
@@ -80,7 +81,9 @@ bool JointPositionController::init(hardware_interface::EffortJointInterface *rob
 
   // Get URDF info about joint
   urdf::Model urdf;
-  if (!urdf.initParam("robot_description"))
+  std::string rob_descr = n.getNamespace();
+  rob_descr = rob_descr.erase(rob_descr.find_last_of('/') + 1) + "robot_description";
+  if (!urdf.initParam(rob_descr.c_str()))
   {
     ROS_ERROR("Failed to parse urdf file");
     return false;

--- a/velocity_controllers/src/joint_position_controller.cpp
+++ b/velocity_controllers/src/joint_position_controller.cpp
@@ -40,6 +40,7 @@
  Desc: Velocity-based position controller using basic PID loop
 */
 
+#include <string>
 #include <velocity_controllers/joint_position_controller.h>
 #include <angles/angles.h>
 #include <pluginlib/class_list_macros.h>
@@ -81,7 +82,9 @@ bool JointPositionController::init(hardware_interface::VelocityJointInterface *r
 
   // Get URDF info about joint
   urdf::Model urdf;
-  if (!urdf.initParam("robot_description"))
+  std::string rob_descr = n.getNamespace();
+  rob_descr = rob_descr.erase(rob_descr.find_last_of('/') + 1) + "robot_description";
+  if (!urdf.initParam(rob_descr.c_str()))
   {
     ROS_ERROR("Failed to parse urdf file");
     return false;


### PR DESCRIPTION
In order to be able to use namespaces e.g. for multiple robots, the joint position controllers in effort_controllers and velocity_controllers need a possibility to load the robot_description from the parameter server located inside of a namespace. The best would be to also remove the hard coded "robot_description" in future.
The URDF model has to be loaded in <namespace>/robot_description on the parameter server.
