### PR TITLE
F#182 partial trajectory mod

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -88,6 +88,11 @@ if(CATKIN_ENABLE_TESTING)
                     test/joint_trajectory_controller.test
                     test/joint_trajectory_controller_test.cpp)
   target_link_libraries(joint_trajectory_controller_test ${catkin_LIBRARIES})
+  
+  add_rostest_gtest(joint_partial_trajectory_controller_test
+                    test/joint_partial_trajectory_controller.test
+                    test/joint_partial_trajectory_controller_test.cpp)
+  target_link_libraries(joint_partial_trajectory_controller_test ${catkin_LIBRARIES})
 endif()
 
 # Install

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -330,10 +330,21 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     }
   }
 
+
+
   // Initialize result trajectory: combination of:
   // - Useful segments of currently followed trajectory
   // - Useful segments of new trajectory (contained in ROS message)
   Trajectory result_traj = *(options.current_trajectory);
+
+  //Iterate to all segments to set the new goal handler
+  for (unsigned int joint_id=0; joint_id < joint_names.size();joint_id++)
+  {
+    for (unsigned int segment_id=0; segment_id < result_traj[joint_id].size(); segment_id++)
+    {
+      (result_traj[joint_id])[segment_id].setGoalHandle(options.rt_goal_handle);
+    }
+  }
 
   std::vector<unsigned int> permutation_vector_per_joint(1,0); //refactor this and remove it as it is not needed
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -194,7 +194,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
 
   const ros::Time msg_start_time = internal::startTime(msg, time); // Message start time
 
-  ROS_INFO_STREAM("Figuring out new trajectory starting at time "
+  ROS_DEBUG_STREAM("Figuring out new trajectory starting at time "
                    << std::fixed << std::setprecision(3) << msg_start_time.toSec());
 
   // Empty trajectory
@@ -328,8 +328,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     }
   }
 
-
-
   // Initialize result trajectory: combination of:
   // - Useful segments of currently followed trajectory
   // - Useful segments of new trajectory (contained in ROS message)
@@ -346,9 +344,10 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     unsigned int joint_id = permutation_vector[msg_joint_it];
 
     ROS_WARN_STREAM("********** Processing trajectory for joint " << joint_names[joint_id]);
+
     // Initialize offsets due to wrapping joints to zero
     std::vector<Scalar> position_offset(1, 0.0);
-    //Scalar position_offset = 0.0;
+
 
     // Bridge current trajectory to new one
     if (has_current_trajectory)
@@ -438,9 +437,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       next_it_point_per_joint.velocities.resize(1, next_it->velocities[msg_joint_it]);
       next_it_point_per_joint.accelerations.resize(1, next_it->accelerations[msg_joint_it]);
       next_it_point_per_joint.time_from_start = next_it->time_from_start;
-
-      //if (!permutation.empty() && joint_dim != permutation.size())
-      // unsigned int joint_dim = point.positions.size();
 
       Segment segment(o_msg_start_time, it_point_per_joint, next_it_point_per_joint, permutation_vector_per_joint, position_offset);
       segment.setGoalHandle(options.rt_goal_handle);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -338,6 +338,9 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   for (unsigned int msg_joint_it=0; msg_joint_it < permutation_vector.size();msg_joint_it++)
   {
     std::vector<trajectory_msgs::JointTrajectoryPoint>::const_iterator it = msg_it;
+    if (!isValid(*it, it->positions.size()))
+      throw(std::invalid_argument("Size mismatch in trajectory point position, velocity or acceleration data."));
+
     TrajectoryPerJoint result_traj_per_joint; // Currently empty
     unsigned int joint_id = permutation_vector[msg_joint_it];
 
@@ -361,14 +364,10 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       sample(curr_joint_traj, last_curr_time, last_curr_state);
 
       // Get the first time and state that will be executed from the new trajectory
-      if (!isValid(*it, it->positions.size()))
-      {
-        throw(std::invalid_argument("Size mismatch in trajectory point position, velocity or acceleration data."));
-      }
       trajectory_msgs::JointTrajectoryPoint point_per_joint;
-      point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
-      point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);
-      point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);
+      if (!it->positions.empty())     {point_per_joint.positions.resize(1, it->positions[msg_joint_it]);}
+      if (!it->velocities.empty())    {point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);}
+      if (!it->accelerations.empty()) {point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);}
       point_per_joint.time_from_start = it->time_from_start;
 
       const typename Segment::Time first_new_time = o_msg_start_time.toSec() + (it->time_from_start).toSec();
@@ -418,14 +417,19 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       std::vector<trajectory_msgs::JointTrajectoryPoint>::const_iterator next_it = it; ++next_it;
 
       trajectory_msgs::JointTrajectoryPoint it_point_per_joint, next_it_point_per_joint;
-      it_point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
-      it_point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);
-      it_point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);
+
+      if (!isValid(*it, it->positions.size()))
+            throw(std::invalid_argument("Size mismatch in trajectory point position, velocity or acceleration data."));
+      if (!it->positions.empty())     {it_point_per_joint.positions.resize(1, it->positions[msg_joint_it]);}
+      if (!it->velocities.empty())    {it_point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);}
+      if (!it->accelerations.empty()) {it_point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);}
       it_point_per_joint.time_from_start = it->time_from_start;
 
-      next_it_point_per_joint.positions.resize(1, next_it->positions[msg_joint_it]);
-      next_it_point_per_joint.velocities.resize(1, next_it->velocities[msg_joint_it]);
-      next_it_point_per_joint.accelerations.resize(1, next_it->accelerations[msg_joint_it]);
+      if (!isValid(*next_it, next_it->positions.size()))
+            throw(std::invalid_argument("Size mismatch in trajectory point position, velocity or acceleration data."));
+      if (!next_it->positions.empty()) {next_it_point_per_joint.positions.resize(1, next_it->positions[msg_joint_it]);}
+      if (!next_it->velocities.empty()) {next_it_point_per_joint.velocities.resize(1, next_it->velocities[msg_joint_it]);}
+      if (!next_it->accelerations.empty()) {next_it_point_per_joint.accelerations.resize(1, next_it->accelerations[msg_joint_it]);}
       next_it_point_per_joint.time_from_start = next_it->time_from_start;
 
       Segment segment(o_msg_start_time, it_point_per_joint, next_it_point_per_joint, permutation_vector_per_joint, position_offset);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -193,6 +193,8 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   typedef typename TrajectoryPerJoint::value_type Segment;
   typedef typename Segment::Scalar Scalar;
 
+  ROS_ERROR("-----------------------*****HERE!");
+
   const unsigned int n_joints = msg.joint_names.size();
 
   const ros::Time msg_start_time = internal::startTime(msg, time); // Message start time
@@ -260,6 +262,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       return Trajectory();
     }
   }
+
 
 //  std::stringstream log_str;
 //  log_str.str("");
@@ -380,13 +383,14 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       typename Segment::State last_curr_state;
       sample(curr_joint_traj, last_curr_time, last_curr_state);
 
+      ROS_ERROR("*****HERE1!");
       // Get the first time and state that will be executed from the new trajectory
       trajectory_msgs::JointTrajectoryPoint point_per_joint;
       point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
       point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);
       point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);
       point_per_joint.time_from_start = it->time_from_start;
-
+      ROS_ERROR("*****HERE2!");
 
       const typename Segment::Time first_new_time = o_msg_start_time.toSec() + (it->time_from_start).toSec();
       typename Segment::State first_new_state(point_per_joint, permutation_vector_per_joint); // Here offsets are not yet applied

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -172,7 +172,6 @@ bool isNotEmpty(typename Trajectory::value_type trajPerJoint)
  * Segment(const ros::Time&                             traj_start_time,
  *         const trajectory_msgs::JointTrajectoryPoint& start_point,
  *         const trajectory_msgs::JointTrajectoryPoint& end_point,
- *         const std::vector<unsigned int>&             permutation,
  *         const std::vector<Scalar>&                   position_offset)
  * \endcode
  * The following function must also be defined to properly handle continuous joints:
@@ -334,8 +333,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   else
     result_traj.resize(joint_names.size());
 
-  std::vector<unsigned int> mapping_vector_per_joint(1,0); //refactor this and remove it as it is not needed
-
   //Iterate through the joints that are in the message, in the order of the mapping vector
   //for (unsigned int joint_id=0; joint_id < joint_names.size();joint_id++)
   for (unsigned int msg_joint_it=0; msg_joint_it < mapping_vector.size();msg_joint_it++)
@@ -374,7 +371,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       point_per_joint.time_from_start = it->time_from_start;
 
       const typename Segment::Time first_new_time = o_msg_start_time.toSec() + (it->time_from_start).toSec();
-      typename Segment::State first_new_state(point_per_joint, mapping_vector_per_joint); // Here offsets are not yet applied
+      typename Segment::State first_new_state(point_per_joint); // Here offsets are not yet applied
 
       // Compute offsets due to wrapping joints
       if (has_angle_wraparound)
@@ -385,7 +382,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       }
 
       // Apply offset to first state that will be executed from the new trajectory
-      first_new_state = typename Segment::State(point_per_joint, mapping_vector_per_joint, position_offset); // Now offsets are applied
+      first_new_state = typename Segment::State(point_per_joint, position_offset); // Now offsets are applied
 
       // Add useful segments of current trajectory to result
       {
@@ -435,7 +432,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       if (!next_it->accelerations.empty()) {next_it_point_per_joint.accelerations.resize(1, next_it->accelerations[msg_joint_it]);}
       next_it_point_per_joint.time_from_start = next_it->time_from_start;
 
-      Segment segment(o_msg_start_time, it_point_per_joint, next_it_point_per_joint, mapping_vector_per_joint, position_offset);
+      Segment segment(o_msg_start_time, it_point_per_joint, next_it_point_per_joint, position_offset);
       segment.setGoalHandle(options.rt_goal_handle);
       if (has_rt_goal_handle) {segment.setTolerances(tolerances_per_joint);}
       result_traj_per_joint.push_back(segment);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -67,7 +67,7 @@ inline std::vector<unsigned int> permutation(const T& t1, const T& t2)
   typedef unsigned int SizeType;
 
   // Arguments must have the same size
-  if (t1.size() != t2.size()) {return std::vector<SizeType>();}
+  //if (t1.size() != t2.size()) {return std::vector<SizeType>();}
 
   std::vector<SizeType> permutation_vector(t1.size()); // Return value
   for (typename T::const_iterator t1_it = t1.begin(); t1_it != t1.end(); ++t1_it)
@@ -95,7 +95,9 @@ struct InitJointTrajectoryOptions
 {
   typedef realtime_tools::RealtimeServerGoalHandle<control_msgs::FollowJointTrajectoryAction> RealtimeGoalHandle;
   typedef boost::shared_ptr<RealtimeGoalHandle>                                               RealtimeGoalHandlePtr;
-  typedef typename Trajectory::value_type::Scalar                                             Scalar;
+  typedef typename Trajectory::value_type                                                     TrajectoryPerJoint;
+  typedef typename TrajectoryPerJoint::value_type                                             Segment;
+  typedef typename Segment::Scalar                                                            Scalar;
 
   InitJointTrajectoryOptions()
     : current_trajectory(0),
@@ -184,14 +186,15 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
                                const InitJointTrajectoryOptions<Trajectory>& options =
                                InitJointTrajectoryOptions<Trajectory>())
 {
-  typedef typename Trajectory::value_type Segment;
+  typedef typename Trajectory::value_type TrajectoryPerJoint;
+  typedef typename TrajectoryPerJoint::value_type Segment;
   typedef typename Segment::Scalar Scalar;
 
   const unsigned int n_joints = msg.joint_names.size();
 
   const ros::Time msg_start_time = internal::startTime(msg, time); // Message start time
 
-  ROS_DEBUG_STREAM("Figuring out new trajectory starting at time "
+  ROS_INFO_STREAM("Figuring out new trajectory starting at time "
                    << std::fixed << std::setprecision(3) << msg_start_time.toSec());
 
   // Empty trajectory
@@ -243,13 +246,45 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   // If unspecified, a trivial map (no permutation) is computed
   const std::vector<std::string> joint_names = has_joint_names ? *(options.joint_names) : msg.joint_names;
 
-  std::vector<unsigned int> permutation_vector = internal::permutation(joint_names, msg.joint_names);
+  ROS_INFO_STREAM("Joint names size" << joint_names.size());
+
+  std::stringstream log_str;
+  log_str.str("");
+  log_str << "Joint names size:" ;
+  for (unsigned int i=0; i < joint_names.size();i++) log_str << joint_names[i] << "\t";
+  log_str << "\n";
+  ROS_INFO_STREAM(log_str.str());
+
+  log_str.str("");
+  log_str << "msg.joint_names size:" ;
+  for (unsigned int i=0; i < msg.joint_names.size();i++) log_str << msg.joint_names[i] << "\t";
+  log_str << "\n";
+  ROS_INFO_STREAM(log_str.str());
+
+  log_str.str("");
+  log_str << "msg.position size:" ;
+  for (unsigned int i=0; i < msg.points.size();i++)
+  {
+    for (unsigned int j=0; j < msg.points[i].positions.size();j++)
+      log_str << msg.points[i].positions[j] << "\t";
+    log_str << "\n";
+  }
+  ROS_INFO_STREAM(log_str.str());
+
+  std::vector<unsigned int> permutation_vector = internal::permutation(msg.joint_names,joint_names);
 
   if (permutation_vector.empty())
   {
     ROS_ERROR("Cannot create trajectory from message. It does not contain the expected joints.");
     return Trajectory();
   }
+
+  //std::stringstream log_str;
+  log_str.str("");
+  log_str << "permutation_vector:" ;
+  for (unsigned int i=0; i < permutation_vector.size();i++) log_str << permutation_vector[i] << "\t";
+  log_str << "\n";
+  ROS_INFO_STREAM(log_str.str());
 
   // Tolerances to be used in all new segments
   SegmentTolerances<Scalar> tolerances = has_default_tolerances ?
@@ -268,6 +303,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   if (it == msg.points.end())
   {
     it = msg.points.begin();  // Entire trajectory is after current time
+    ROS_WARN_STREAM("Entire trajectory is after current time");
   }
   else
   {
@@ -292,96 +328,145 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     }
   }
 
+
+
   // Initialize result trajectory: combination of:
   // - Useful segments of currently followed trajectory
   // - Useful segments of new trajectory (contained in ROS message)
-  Trajectory result_traj; // Currently empty
+  Trajectory result_traj = *(options.current_trajectory);
+  ROS_WARN_STREAM("********** result_traj size" << result_traj.size());
 
-  // Initialize offsets due to wrapping joints to zero
-  std::vector<Scalar> position_offset(n_joints, 0.0);
+  std::vector<unsigned int> permutation_vector_per_joint(1,0); //refactor this and remove it as it is not needed
 
-  // Bridge current trajectory to new one
-  if (has_current_trajectory)
+  //Iterate through the joints that are in the message, in the order of the permutation vector
+  //for (unsigned int joint_id=0; joint_id < joint_names.size();joint_id++)
+  for (unsigned int msg_joint_it=0; msg_joint_it < permutation_vector.size();msg_joint_it++)
   {
-    const Trajectory& curr_traj = *(options.current_trajectory);
+    TrajectoryPerJoint result_traj_per_joint; // Currently empty
+    unsigned int joint_id = permutation_vector[msg_joint_it];
 
-    // Get the last time and state that will be executed from the current trajectory
-    const typename Segment::Time last_curr_time = std::max(o_msg_start_time.toSec(), o_time.toSec()); // Important!
-    typename Segment::State last_curr_state;
-    sample(curr_traj, last_curr_time, last_curr_state);
+    ROS_WARN_STREAM("********** Processing trajectory for joint " << joint_names[joint_id]);
+    // Initialize offsets due to wrapping joints to zero
+    std::vector<Scalar> position_offset(1, 0.0);
+    //Scalar position_offset = 0.0;
 
-    // Get the first time and state that will be executed from the new trajectory
-    const typename Segment::Time first_new_time = o_msg_start_time.toSec() + (it->time_from_start).toSec();
-    typename Segment::State first_new_state(*it, permutation_vector); // Here offsets are not yet applied
-
-    // Compute offsets due to wrapping joints
-    if (has_angle_wraparound)
+    // Bridge current trajectory to new one
+    if (has_current_trajectory)
     {
-      position_offset = wraparoundOffset(last_curr_state.position,
-                                         first_new_state.position,
-                                         *(options.angle_wraparound));
-      if (position_offset.empty())
+      const TrajectoryPerJoint& curr_joint_traj = (*options.current_trajectory)[joint_id];
+
+      // Get the last time and state that will be executed from the current trajectory
+      const typename Segment::Time last_curr_time = std::max(o_msg_start_time.toSec(), o_time.toSec()); // Important!
+      typename Segment::State last_curr_state;
+      sample(curr_joint_traj, last_curr_time, last_curr_state);
+
+      log_str.str("");
+      log_str << "last_curr_state.position:" ;
+      for (unsigned int i=0; i < last_curr_state.position.size();i++) log_str << last_curr_state.position[i] << "\t";
+      log_str << "\n";
+      ROS_INFO_STREAM(log_str.str());
+
+      // Get the first time and state that will be executed from the new trajectory
+      trajectory_msgs::JointTrajectoryPoint point_per_joint;
+      point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
+      point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);
+      point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);
+      point_per_joint.time_from_start = it->time_from_start;
+
+
+      const typename Segment::Time first_new_time = o_msg_start_time.toSec() + (it->time_from_start).toSec();
+      typename Segment::State first_new_state(point_per_joint, permutation_vector_per_joint); // Here offsets are not yet applied
+
+      log_str.str("");
+      log_str << "first_new_state.position:" ;
+      for (unsigned int i=0; i < first_new_state.position.size();i++) log_str << first_new_state.position[i] << "\t";
+      log_str << "\n";
+      ROS_INFO_STREAM(log_str.str());
+
+      // Compute offsets due to wrapping joints
+      if (has_angle_wraparound)
       {
-        ROS_ERROR("Cannot create trajectory from message. "
-                  "Vector specifying whether joints wrap around has an invalid size.");
-        return Trajectory();
+        position_offset[0] = wraparoundJointOffset(last_curr_state.position[0],
+                                                first_new_state.position[0],
+                                                (*options.angle_wraparound)[joint_id]);
       }
+
+      // Apply offset to first state that will be executed from the new trajectory
+      first_new_state = typename Segment::State(point_per_joint, permutation_vector_per_joint, position_offset); // Now offsets are applied
+
+      // Add useful segments of current trajectory to result
+      {
+        typedef typename TrajectoryPerJoint::const_iterator TrajIter;
+        TrajIter first = findSegment(curr_joint_traj, o_time.toSec());   // Currently active segment
+        TrajIter last  = findSegment(curr_joint_traj, last_curr_time); // Segment active when new trajectory starts
+        if (first == curr_joint_traj.end() || last == curr_joint_traj.end())
+        {
+          ROS_ERROR("Unexpected error: Could not find segments in current trajectory. Please contact the package maintainer.");
+          return Trajectory();
+        }
+        result_traj_per_joint.insert(result_traj_per_joint.begin(), first, ++last); // Range [first,last) will still be executed
+      }
+
+      // Add segment bridging current and new trajectories to result
+      Segment bridge_seg(last_curr_time, last_curr_state,
+                         first_new_time, first_new_state);
+      bridge_seg.setGoalHandle(options.rt_goal_handle);
+      if (has_rt_goal_handle) {bridge_seg.setTolerances(tolerances);}
+      result_traj_per_joint.push_back(bridge_seg);
+      ROS_INFO_STREAM("Finish adding old trajectory segment");
     }
 
-    // Apply offset to first state that will be executed from the new trajectory
-    first_new_state = typename Segment::State(*it, permutation_vector, position_offset); // Now offsets are applied
+    // Constants used in log statement at the end
+    const unsigned int num_old_segments = result_traj_per_joint.size() -1;
+    const unsigned int num_new_segments = std::distance(it, msg.points.end()) -1;
 
-    // Add useful segments of current trajectory to result
+    // Add useful segments of new trajectory to result
+    // - Construct all trajectory segments occurring after current time
+    // - As long as there remain two trajectory points we can construct the next trajectory segment
+    while (std::distance(it, msg.points.end()) >= 2)
     {
-      typedef typename Trajectory::const_iterator TrajIter;
-      TrajIter first = findSegment(curr_traj, o_time.toSec());   // Currently active segment
-      TrajIter last  = findSegment(curr_traj, last_curr_time); // Segment active when new trajectory starts
-      if (first == curr_traj.end() || last == curr_traj.end())
-      {
-        ROS_ERROR("Unexpected error: Could not find segments in current trajectory. Please contact the package maintainer.");
-        return Trajectory();
-      }
-      result_traj.insert(result_traj.begin(), first, ++last); // Range [first,last) will still be executed
+      std::vector<trajectory_msgs::JointTrajectoryPoint>::const_iterator next_it = it; ++next_it;
+
+      ROS_INFO_STREAM("Inside while");
+      trajectory_msgs::JointTrajectoryPoint it_point_per_joint, next_it_point_per_joint;
+      it_point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
+      it_point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);
+      it_point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);
+      it_point_per_joint.time_from_start = it->time_from_start;
+
+      next_it_point_per_joint.positions.resize(1, next_it->positions[msg_joint_it]);
+      next_it_point_per_joint.velocities.resize(1, next_it->velocities[msg_joint_it]);
+      next_it_point_per_joint.accelerations.resize(1, next_it->accelerations[msg_joint_it]);
+      next_it_point_per_joint.time_from_start = next_it->time_from_start;
+
+      //if (!permutation.empty() && joint_dim != permutation.size())
+      // unsigned int joint_dim = point.positions.size();
+
+      Segment segment(o_msg_start_time, it_point_per_joint, next_it_point_per_joint, permutation_vector_per_joint, position_offset);
+      segment.setGoalHandle(options.rt_goal_handle);
+      if (has_rt_goal_handle) {segment.setTolerances(tolerances);}
+      result_traj_per_joint.push_back(segment);
+      ++it;
     }
 
-    // Add segment bridging current and new trajectories to result
-    Segment bridge_seg(last_curr_time, last_curr_state,
-                       first_new_time, first_new_state);
-    bridge_seg.setGoalHandle(options.rt_goal_handle);
-    if (has_rt_goal_handle) {bridge_seg.setTolerances(tolerances);}
-    result_traj.push_back(bridge_seg);
-  }
+    // Useful debug info
+    std::stringstream log_str;
+    log_str << "Trajectory of joint " << joint_names[joint_id] << "has " << result_traj_per_joint.size() << " segments";
+    if (has_current_trajectory)
+    {
+      log_str << ":";
+      log_str << "\n- " << num_old_segments << " segment(s) will still be executed from previous trajectory.";
+      log_str << "\n- 1 segment added for transitioning between the current trajectory and first point of the input message.";
+      if (num_new_segments > 0) {log_str << "\n- " << num_new_segments << " new segments (" << (num_new_segments + 1) <<
+                                 " points) taken from the input trajectory.";}
+    }
+    else {log_str << ".";}
+    ROS_WARN_STREAM(log_str.str());
 
-  // Constants used in log statement at the end
-  const unsigned int num_old_segments = result_traj.size() -1;
-  const unsigned int num_new_segments = std::distance(it, msg.points.end()) -1;
+    ROS_WARN_STREAM("********** result_traj_per_joint" << result_traj[joint_id].size());
+    result_traj[joint_id] = result_traj_per_joint;
 
-  // Add useful segments of new trajectory to result
-  // - Construct all trajectory segments occurring after current time
-  // - As long as there remain two trajectory points we can construct the next trajectory segment
-  while (std::distance(it, msg.points.end()) >= 2)
-  {
-    std::vector<trajectory_msgs::JointTrajectoryPoint>::const_iterator next_it = it; ++next_it;
-    Segment segment(o_msg_start_time, *it, *next_it, permutation_vector, position_offset);
-    segment.setGoalHandle(options.rt_goal_handle);
-    if (has_rt_goal_handle) {segment.setTolerances(tolerances);}
-    result_traj.push_back(segment);
-    ++it;
   }
-
-  // Useful debug info
-  std::stringstream log_str;
-  log_str << "Trajectory has " << result_traj.size() << " segments";
-  if (has_current_trajectory)
-  {
-    log_str << ":";
-    log_str << "\n- " << num_old_segments << " segment(s) will still be executed from previous trajectory.";
-    log_str << "\n- 1 segment added for transitioning between the current trajectory and first point of the input message.";
-    if (num_new_segments > 0) {log_str << "\n- " << num_new_segments << " new segments (" << (num_new_segments + 1) <<
-                               " points) taken from the input trajectory.";}
-  }
-  else {log_str << ".";}
-  ROS_DEBUG_STREAM(log_str.str());
 
   return result_traj;
 }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -66,9 +66,6 @@ inline std::vector<unsigned int> permutation(const T& t1, const T& t2)
 {
   typedef unsigned int SizeType;
 
-  // Arguments must have the same size
-  //if (t1.size() != t2.size()) {return std::vector<SizeType>();}
-
   std::vector<SizeType> permutation_vector(t1.size()); // Return value
   for (typename T::const_iterator t1_it = t1.begin(); t1_it != t1.end(); ++t1_it)
   {
@@ -246,33 +243,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   // If unspecified, a trivial map (no permutation) is computed
   const std::vector<std::string> joint_names = has_joint_names ? *(options.joint_names) : msg.joint_names;
 
-  std::stringstream log_str;
-
-
-//  ROS_INFO_STREAM("Joint names size" << joint_names.size());
-//
-//  log_str.str("");
-//  log_str << "Joint names size:" ;
-//  for (unsigned int i=0; i < joint_names.size();i++) log_str << joint_names[i] << "\t";
-//  log_str << "\n";
-//  ROS_INFO_STREAM(log_str.str());
-//
-//  log_str.str("");
-//  log_str << "msg.joint_names size:" ;
-//  for (unsigned int i=0; i < msg.joint_names.size();i++) log_str << msg.joint_names[i] << "\t";
-//  log_str << "\n";
-//  ROS_INFO_STREAM(log_str.str());
-//
-//  log_str.str("");
-//  log_str << "msg.position size:" ;
-//  for (unsigned int i=0; i < msg.points.size();i++)
-//  {
-//    for (unsigned int j=0; j < msg.points[i].positions.size();j++)
-//      log_str << msg.points[i].positions[j] << "\t";
-//    log_str << "\n";
-//  }
-//  ROS_INFO_STREAM(log_str.str());
-
+  //std::stringstream log_str;
   std::vector<unsigned int> permutation_vector = internal::permutation(msg.joint_names,joint_names);
 
   if (permutation_vector.empty())
@@ -280,13 +251,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     ROS_ERROR("Cannot create trajectory from message. It does not contain the expected joints.");
     return Trajectory();
   }
-
-//  //std::stringstream log_str;
-//  log_str.str("");
-//  log_str << "permutation_vector:" ;
-//  for (unsigned int i=0; i < permutation_vector.size();i++) log_str << permutation_vector[i] << "\t";
-//  log_str << "\n";
-//  ROS_INFO_STREAM(log_str.str());
 
   // Tolerances to be used in all new segments
   SegmentTolerances<Scalar> tolerances = has_default_tolerances ?
@@ -305,7 +269,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   if (msg_it == msg.points.end())
   {
     msg_it = msg.points.begin();  // Entire trajectory is after current time
-    ROS_WARN_STREAM("Entire trajectory is after current time");
   }
   else
   {
@@ -329,8 +292,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
                       next_point_dur.toSec() << "s.");
     }
   }
-
-
 
   // Initialize result trajectory: combination of:
   // - Useful segments of currently followed trajectory
@@ -375,12 +336,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       typename Segment::State last_curr_state;
       sample(curr_joint_traj, last_curr_time, last_curr_state);
 
-//      log_str.str("");
-//      log_str << "last_curr_state.position:" ;
-//      for (unsigned int i=0; i < last_curr_state.position.size();i++) log_str << last_curr_state.position[i] << "\t";
-//      log_str << "\n";
-//      ROS_INFO_STREAM(log_str.str());
-
       // Get the first time and state that will be executed from the new trajectory
       trajectory_msgs::JointTrajectoryPoint point_per_joint;
       point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
@@ -391,12 +346,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
 
       const typename Segment::Time first_new_time = o_msg_start_time.toSec() + (it->time_from_start).toSec();
       typename Segment::State first_new_state(point_per_joint, permutation_vector_per_joint); // Here offsets are not yet applied
-
-//      log_str.str("");
-//      log_str << "first_new_state.position:" ;
-//      for (unsigned int i=0; i < first_new_state.position.size();i++) log_str << first_new_state.position[i] << "\t";
-//      log_str << "\n";
-//      ROS_INFO_STREAM(log_str.str());
 
       // Compute offsets due to wrapping joints
       if (has_angle_wraparound)
@@ -428,7 +377,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       bridge_seg.setGoalHandle(options.rt_goal_handle);
       if (has_rt_goal_handle) {bridge_seg.setTolerances(tolerances_per_joint);}
       result_traj_per_joint.push_back(bridge_seg);
-      //ROS_INFO_STREAM("Finish adding old trajectory segment");
     }
 
     // Constants used in log statement at the end
@@ -442,7 +390,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     {
       std::vector<trajectory_msgs::JointTrajectoryPoint>::const_iterator next_it = it; ++next_it;
 
-      //ROS_INFO_STREAM("Inside while");
       trajectory_msgs::JointTrajectoryPoint it_point_per_joint, next_it_point_per_joint;
       it_point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
       it_point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);
@@ -473,9 +420,8 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
                                  " points) taken from the input trajectory.";}
     }
     else {log_str << ".";}
-    //ROS_WARN_STREAM(log_str.str());
+    ROS_DEBUG_STREAM(log_str.str());
 
-    //ROS_WARN_STREAM("********** result_traj_per_joint" << result_traj[joint_id].size());
     result_traj[joint_id] = result_traj_per_joint;
 
   }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -193,8 +193,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   typedef typename TrajectoryPerJoint::value_type Segment;
   typedef typename Segment::Scalar Scalar;
 
-  ROS_ERROR("-----------------------*****HERE!");
-
   const unsigned int n_joints = msg.joint_names.size();
 
   const ros::Time msg_start_time = internal::startTime(msg, time); // Message start time
@@ -263,20 +261,6 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     }
   }
 
-
-//  std::stringstream log_str;
-//  log_str.str("");
-//  log_str << "Joint names size:" ;
-//  for (unsigned int i=0; i < joint_names.size();i++) log_str << joint_names[i] << "\t";
-//  log_str << "\n";
-//  ROS_INFO_STREAM(log_str.str());
-//
-//  log_str.str("");
-//  log_str << "msg.joint_names size:" ;
-//  for (unsigned int i=0; i < msg.joint_names.size();i++) log_str << msg.joint_names[i] << "\t";
-//  log_str << "\n";
-//  ROS_INFO_STREAM(log_str.str());
-
   std::vector<unsigned int> permutation_vector = internal::permutation(msg.joint_names,joint_names);
 
   if (permutation_vector.empty())
@@ -284,14 +268,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     ROS_ERROR("Cannot create trajectory from message. It does not contain the expected joints.");
     return Trajectory();
   }
-  
-  //std::stringstream log_str;
-//  log_str.str("");
-//  log_str << "permutation_vector:" ;
-//  for (unsigned int i=0; i < permutation_vector.size();i++) log_str << permutation_vector[i] << "\t";
-//  log_str << "\n";
-//  ROS_INFO_STREAM(log_str.str());
-  
+
   // Tolerances to be used in all new segments
   SegmentTolerances<Scalar> tolerances = has_default_tolerances ?
                                          *(options.default_tolerances) : SegmentTolerances<Scalar>(n_joints);
@@ -383,14 +360,16 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       typename Segment::State last_curr_state;
       sample(curr_joint_traj, last_curr_time, last_curr_state);
 
-      ROS_ERROR("*****HERE1!");
       // Get the first time and state that will be executed from the new trajectory
+      if (!isValid(*it, it->positions.size()))
+      {
+        throw(std::invalid_argument("Size mismatch in trajectory point position, velocity or acceleration data."));
+      }
       trajectory_msgs::JointTrajectoryPoint point_per_joint;
       point_per_joint.positions.resize(1, it->positions[msg_joint_it]);
       point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);
       point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);
       point_per_joint.time_from_start = it->time_from_start;
-      ROS_ERROR("*****HERE2!");
 
       const typename Segment::Time first_new_time = o_msg_start_time.toSec() + (it->time_from_start).toSec();
       typename Segment::State first_new_state(point_per_joint, permutation_vector_per_joint); // Here offsets are not yet applied

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -203,8 +203,7 @@ private:
   typename Segment::State current_state_;    ///< Preallocated workspace variable.
   typename Segment::State desired_state_;    ///< Preallocated workspace variable.
   typename Segment::State state_error_;      ///< Preallocated workspace variable.
-  typename Segment::State hold_start_state_; ///< Preallocated workspace variable.
-  typename Segment::State hold_end_state_;   ///< Preallocated workspace variable.
+
 
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -166,8 +166,10 @@ private:
   typedef boost::scoped_ptr<StatePublisher>                                                   StatePublisherPtr;
 
   typedef JointTrajectorySegment<SegmentImpl> Segment;
-  typedef std::vector<Segment> Trajectory;
+  typedef std::vector<Segment> TrajectoryPerJoint;
+  typedef std::vector<TrajectoryPerJoint> Trajectory;
   typedef boost::shared_ptr<Trajectory> TrajectoryPtr;
+  typedef boost::shared_ptr<TrajectoryPerJoint> TrajectoryPerJointPtr;
   typedef realtime_tools::RealtimeBox<TrajectoryPtr> TrajectoryBox;
   typedef typename Segment::Scalar Scalar;
 
@@ -193,12 +195,14 @@ private:
    */
   TrajectoryBox curr_trajectory_box_;
   TrajectoryPtr hold_trajectory_ptr_; ///< Last hold trajectory values.
+  TrajectoryPerJointPtr hold_trajectory_per_joint_ptr_; ///< Last hold trajectory values.
 
   typename Segment::State current_state_;    ///< Preallocated workspace variable.
   typename Segment::State desired_state_;    ///< Preallocated workspace variable.
   typename Segment::State state_error_;      ///< Preallocated workspace variable.
   typename Segment::State hold_start_state_; ///< Preallocated workspace variable.
   typename Segment::State hold_end_state_;   ///< Preallocated workspace variable.
+  typename Segment::State desired_joint_state_;    ///< Preallocated workspace variable.
 
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -156,6 +156,8 @@ private:
     ros::Time     uptime; ///< Controller uptime. Set to zero at every restart.
   };
 
+  int previous_status;
+
   typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction>                  ActionServer;
   typedef boost::shared_ptr<ActionServer>                                                     ActionServerPtr;
   typedef ActionServer::GoalHandle                                                            GoalHandle;
@@ -184,7 +186,8 @@ private:
   SegmentTolerances<Scalar> default_tolerances_; ///< Default trajectory segment tolerances.
   HwIfaceAdapter            hw_iface_adapter_;   ///< Adapts desired trajectory state to HW interface.
 
-  RealtimeGoalHandlePtr     rt_active_goal_;     ///< Currently active action goal, if any.
+  //RealtimeGoalHandlePtr     rt_active_goal_;     ///< Currently active action goal, if any.
+  std::vector<RealtimeGoalHandlePtr> rt_active_goals_;     ///< Currently active action goal, if any.
 
   /**
    * Thread-safe container with a smart pointer to trajectory currently being followed.
@@ -202,7 +205,6 @@ private:
   typename Segment::State state_error_;      ///< Preallocated workspace variable.
   typename Segment::State hold_start_state_; ///< Preallocated workspace variable.
   typename Segment::State hold_end_state_;   ///< Preallocated workspace variable.
-  typename Segment::State desired_joint_state_;    ///< Preallocated workspace variable.
 
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
 
@@ -225,7 +227,7 @@ private:
   void trajectoryCommandCB(const JointTrajectoryConstPtr& msg);
   void goalCB(GoalHandle gh);
   void cancelCB(GoalHandle gh);
-  void preemptActiveGoal();
+  void preemptActiveGoals();
   bool queryStateService(control_msgs::QueryTrajectoryState::Request&  req,
                          control_msgs::QueryTrajectoryState::Response& resp);
 
@@ -255,8 +257,8 @@ private:
    *
    * \pre \p segment is associated to the active goal handle.
    **/
-  void checkPathTolerances(const typename Segment::State& state_error,
-                           const Segment&                 segment);
+//  void checkPathTolerances(const typename Segment::State& state_error,
+//                           const Segment&                 segment);
 
   /**
    * \brief Check goal tolerances.

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -196,9 +196,11 @@ private:
   TrajectoryBox curr_trajectory_box_;
   TrajectoryPtr hold_trajectory_ptr_; ///< Last hold trajectory values.
 
-  typename Segment::State current_state_;    ///< Preallocated workspace variable.
-  typename Segment::State desired_state_;    ///< Preallocated workspace variable.
-  typename Segment::State state_error_;      ///< Preallocated workspace variable.
+  typename Segment::State current_state_;         ///< Preallocated workspace variable.
+  typename Segment::State desired_state_;         ///< Preallocated workspace variable.
+  typename Segment::State state_error_;           ///< Preallocated workspace variable.
+  typename Segment::State desired_joint_state_;   ///< Preallocated workspace variable.
+  typename Segment::State state_joint_error_;     ///< Preallocated workspace variable.
 
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
 
@@ -206,6 +208,7 @@ private:
   ros::Duration action_monitor_period_;
 
   typename Segment::Time stop_trajectory_duration_;
+  std::vector<bool> successful_joint_traj_;
 
   // ROS API
   ros::NodeHandle    controller_nh_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -210,6 +210,7 @@ private:
 
   typename Segment::Time stop_trajectory_duration_;
   boost::dynamic_bitset<> successful_joint_traj_;
+  bool allow_partial_joints_goal_;
 
   // ROS API
   ros::NodeHandle    controller_nh_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -156,8 +156,6 @@ private:
     ros::Time     uptime; ///< Controller uptime. Set to zero at every restart.
   };
 
-  int previous_status;
-
   typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction>                  ActionServer;
   typedef boost::shared_ptr<ActionServer>                                                     ActionServerPtr;
   typedef ActionServer::GoalHandle                                                            GoalHandle;
@@ -187,7 +185,6 @@ private:
   HwIfaceAdapter            hw_iface_adapter_;   ///< Adapts desired trajectory state to HW interface.
 
   RealtimeGoalHandlePtr     rt_active_goal_;     ///< Currently active action goal, if any.
-  //std::vector<RealtimeGoalHandlePtr> rt_active_goals_;     ///< Currently active action goal, if any.
 
   /**
    * Thread-safe container with a smart pointer to trajectory currently being followed.
@@ -198,12 +195,10 @@ private:
    */
   TrajectoryBox curr_trajectory_box_;
   TrajectoryPtr hold_trajectory_ptr_; ///< Last hold trajectory values.
-  TrajectoryPerJointPtr hold_trajectory_per_joint_ptr_; ///< Last hold trajectory values.
 
   typename Segment::State current_state_;    ///< Preallocated workspace variable.
   typename Segment::State desired_state_;    ///< Preallocated workspace variable.
   typename Segment::State state_error_;      ///< Preallocated workspace variable.
-
 
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
 
@@ -245,33 +240,6 @@ private:
    * \note This method is realtime-safe.
    */
   void setHoldPosition(const ros::Time& time);
-
-  /**
-   * \brief Check path tolerances.
-   *
-   * If path tolerances are violated, the currently active action goal will be aborted.
-   *
-   * \param state_error Error between the current and desired trajectory states.
-   * \param segment Currently active trajectory segment.
-   *
-   * \pre \p segment is associated to the active goal handle.
-   **/
-//  void checkPathTolerances(const typename Segment::State& state_error,
-//                           const Segment&                 segment);
-
-  /**
-   * \brief Check goal tolerances.
-   *
-   * If goal tolerances are fulfilled, the currently active action goal will be considered successful.
-   * If they are violated, the action goal will be aborted.
-   *
-   * \param state_error Error between the current and desired trajectory states.
-   * \param segment Currently active trajectory segment.
-   *
-   * \pre \p segment is associated to the active goal handle.
-   **/
-  void checkGoalTolerances(const typename Segment::State& state_error,
-                           const Segment&                 segment);
 
 };
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -40,6 +40,7 @@
 // Boost
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <boost/dynamic_bitset.hpp>
 
 // ROS
 #include <ros/node_handle.h>
@@ -208,7 +209,7 @@ private:
   ros::Duration action_monitor_period_;
 
   typename Segment::Time stop_trajectory_duration_;
-  std::vector<bool> successful_joint_traj_;
+  boost::dynamic_bitset<> successful_joint_traj_;
 
   // ROS API
   ros::NodeHandle    controller_nh_;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -186,8 +186,8 @@ private:
   SegmentTolerances<Scalar> default_tolerances_; ///< Default trajectory segment tolerances.
   HwIfaceAdapter            hw_iface_adapter_;   ///< Adapts desired trajectory state to HW interface.
 
-  //RealtimeGoalHandlePtr     rt_active_goal_;     ///< Currently active action goal, if any.
-  std::vector<RealtimeGoalHandlePtr> rt_active_goals_;     ///< Currently active action goal, if any.
+  RealtimeGoalHandlePtr     rt_active_goal_;     ///< Currently active action goal, if any.
+  //std::vector<RealtimeGoalHandlePtr> rt_active_goals_;     ///< Currently active action goal, if any.
 
   /**
    * Thread-safe container with a smart pointer to trajectory currently being followed.
@@ -227,7 +227,7 @@ private:
   void trajectoryCommandCB(const JointTrajectoryConstPtr& msg);
   void goalCB(GoalHandle gh);
   void cancelCB(GoalHandle gh);
-  void preemptActiveGoals();
+  void preemptActiveGoal();
   bool queryStateService(control_msgs::QueryTrajectoryState::Request&  req,
                          control_msgs::QueryTrajectoryState::Response& resp);
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -439,8 +439,8 @@ update(const ros::Time& time, const ros::Duration& period)
   RealtimeGoalHandlePtr current_active_goal(rt_active_goal_);
   if (current_active_goal and successful_joint_traj_.count() == joints_.size())
   {
-    rt_active_goal_->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::SUCCESSFUL;
-    rt_active_goal_->setSucceeded(rt_active_goal_->preallocated_result_);
+    current_active_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::SUCCESSFUL;
+    current_active_goal->setSucceeded(current_active_goal->preallocated_result_);
     rt_active_goal_.reset();
     successful_joint_traj_.reset();
   }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -391,7 +391,6 @@ update(const ros::Time& time, const ros::Duration& period)
         const SegmentTolerancesPerJoint<Scalar>& joint_tolerances = segment_it->getTolerances();
         if (!checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance))
         {
-          //ROS_ERROR_STREAM_NAMED(name_, "PATH_TOLERANCE_VIOLATED! joint_id:" << i);
           rt_segment_goal->preallocated_result_->error_code =
           control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
           rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
@@ -412,7 +411,6 @@ update(const ros::Time& time, const ros::Duration& period)
 
         if (inside_goal_tolerances)
         {
-          //ROS_WARN_STREAM_NAMED(name_, "TrajectoryResult::SUCCESSFUL i: "<< i);
           successful_joint_traj[i] = true;
 
         }
@@ -424,7 +422,7 @@ update(const ros::Time& time, const ros::Duration& period)
         {
           if (verbose_)
           {
-            ROS_ERROR_STREAM_NAMED(name_,"Goal tolerances failed");
+            ROS_ERROR_STREAM_NAMED(name_,"Goal tolerances failed for joint: "<< joint_names_[i]);
             // Check the tolerances one more time to output the errors that occurs
             checkStateTolerancePerJoint(state_joint_error_, tolerances.goal_state_tolerance, true);
           }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -227,7 +227,7 @@ bool JointTrajectoryController<SegmentImpl, HardwareInterface>::init(HardwareInt
   controller_nh_.param<bool>("allow_partial_joints_goal", allow_partial_joints_goal_, false);
   if (allow_partial_joints_goal_)
   {
-    ROS_ERROR_NAMED(name_, "Goals with partial set of joints are allowed");
+    ROS_DEBUG_NAMED(name_, "Goals with partial set of joints are allowed");
   }
 
   // List of controlled joints
@@ -396,7 +396,11 @@ update(const ros::Time& time, const ros::Duration& period)
         const SegmentTolerancesPerJoint<Scalar>& joint_tolerances = segment_it->getTolerances();
         if (!checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance))
         {
-          ROS_ERROR_STREAM_NAMED(name_,"Path tolerances failed for joint: " << joint_names_[i]);
+          if (verbose_)
+          {
+            ROS_ERROR_STREAM_NAMED(name_,"Path tolerances failed for joint: " << joint_names_[i]);
+            checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance, true);
+          }
           rt_segment_goal->preallocated_result_->error_code =
           control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
           rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -179,60 +179,6 @@ preemptActiveGoal()
   }
 }
 
-//template <class SegmentImpl, class HardwareInterface>
-//inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
-//checkPathTolerances(const typename Segment::State& state_error,
-//                    const Segment&                 segment)
-//{
-//  const RealtimeGoalHandlePtr rt_segment_goal = segment.getGoalHandle();
-//  const SegmentTolerances<Scalar>& tolerances = segment.getTolerances();
-//  if (!checkStateTolerance(state_error, tolerances.state_tolerance))
-//  {
-//    rt_segment_goal->preallocated_result_->error_code =
-//    control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
-//    rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
-//    rt_active_goal_.reset();
-//  }
-//}
-//
-//template <class SegmentImpl, class HardwareInterface>
-//inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
-//checkGoalTolerances(const typename Segment::State& state_error,
-//                    const Segment&                 segment)
-//{
-//  // Controller uptime
-//  const ros::Time uptime = time_data_.readFromRT()->uptime;
-//
-//  // Checks that we have ended inside the goal tolerances
-//  const RealtimeGoalHandlePtr rt_segment_goal = segment.getGoalHandle();
-//  const SegmentTolerances<Scalar>& tolerances = segment.getTolerances();
-//  const bool inside_goal_tolerances = checkStateTolerance(state_error, tolerances.goal_state_tolerance);
-//
-//  if (inside_goal_tolerances)
-//  {
-//    rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::SUCCESSFUL;
-//    rt_segment_goal->setSucceeded(rt_segment_goal->preallocated_result_);
-//    rt_active_goal_.reset();
-//  }
-//  else if (uptime.toSec() < segment.endTime() + tolerances.goal_time_tolerance)
-//  {
-//    // Still have some time left to meet the goal state tolerances
-//  }
-//  else
-//  {
-//    if (verbose_)
-//    {
-//      ROS_ERROR_STREAM_NAMED(name_,"Goal tolerances failed");
-//      // Check the tolerances one more time to output the errors that occures
-//      checkStateTolerance(state_error, tolerances.goal_state_tolerance, true);
-//    }
-//
-//    rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED;
-//    rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
-//    rt_active_goal_.reset();
-//  }
-//}
-
 template <class SegmentImpl, class HardwareInterface>
 JointTrajectoryController<SegmentImpl, HardwareInterface>::
 JointTrajectoryController()
@@ -434,16 +380,6 @@ update(const ros::Time& time, const ros::Duration& period)
     state_error_.velocity[i] = desired_joint_state_.velocity[0] - current_state_.velocity[i];
     state_error_.acceleration[i] = 0.0;
 
-//    const RealtimeGoalHandlePtr rt_segment_goal = segment_it->getGoalHandle();
-//    if (i == 22)
-//      if (rt_segment_goal)
-//      {
-//        int new_status = int(rt_segment_goal->gh_.getGoalStatus().status);
-//        if (previous_status != new_status)
-//          ROS_WARN_STREAM_NAMED(name_,"Status " << int(new_status) << " for goal: "<< rt_segment_goal->gh_.getGoalStatus().goal_id.id);
-//        previous_status = new_status;
-//      }
-
     //Check tolerances
     const RealtimeGoalHandlePtr rt_segment_goal = segment_it->getGoalHandle();
     if (rt_segment_goal && rt_segment_goal == rt_active_goal_)
@@ -455,7 +391,7 @@ update(const ros::Time& time, const ros::Duration& period)
         const SegmentTolerancesPerJoint<Scalar>& joint_tolerances = segment_it->getTolerances();
         if (!checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance))
         {
-          ROS_ERROR_STREAM_NAMED(name_, "PATH_TOLERANCE_VIOLATED! joint_id:" << i);
+          //ROS_ERROR_STREAM_NAMED(name_, "PATH_TOLERANCE_VIOLATED! joint_id:" << i);
           rt_segment_goal->preallocated_result_->error_code =
           control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
           rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -171,7 +171,7 @@ public:
                          const Time&  end_time,
                          const State& end_state)
     : rt_goal_handle_(),
-      tolerances_(start_state.position.size())
+      tolerances_()
   {
     Segment::init(start_time, start_state, end_time, end_state);
   }
@@ -194,7 +194,7 @@ public:
                          const std::vector<unsigned int>&             permutation     = std::vector<unsigned int>(),
                          const std::vector<Scalar>&                   position_offset = std::vector<Scalar>())
     : rt_goal_handle_(),
-      tolerances_(start_point.positions.size())
+      tolerances_()
   {
     if (start_point.positions.size() != end_point.positions.size())
     {
@@ -227,14 +227,14 @@ public:
   void setGoalHandle(RealtimeGoalHandlePtr rt_goal_handle) {rt_goal_handle_ = rt_goal_handle;}
 
   /** \return Tolerances this segment is associated to. */
-  const SegmentTolerances<Scalar>& getTolerances() const {return tolerances_;}
+  const SegmentTolerancesPerJoint<Scalar>& getTolerances() const {return tolerances_;}
 
   /** \brief Set the tolerances this segment is associated to. */
-  void setTolerances(const SegmentTolerances<Scalar>& tolerances) {tolerances_ = tolerances;}
+  void setTolerances(const SegmentTolerancesPerJoint<Scalar>& tolerances) {tolerances_ = tolerances;}
 
 private:
   RealtimeGoalHandlePtr     rt_goal_handle_;
-  SegmentTolerances<Scalar> tolerances_;
+  SegmentTolerancesPerJoint<Scalar> tolerances_;
 };
 
 /**

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -85,7 +85,7 @@ public:
     /**
      * \param point Trajectory point.
      *
-     * \param permutation Permutation vector for mapping the joint order of a \p point to a desired order.
+     * \param permutation (Should be remove it) Permutation vector for mapping the joint order of a \p point to a desired order.
      * For instance, if \p point contains data associated to joints <tt>"{B, D, A, C}"</tt>, and we are interested in
      * constructing a segment with joints ordered as <tt>"{A, B, C, D}"</tt>, the permutation vector should
      * be set to <tt>"{2, 0, 3, 1}"</tt>.

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -275,6 +275,38 @@ std::vector<Scalar> wraparoundOffset(const std::vector<Scalar>& prev_position,
   return pos_offset;
 }
 
+/**
+ * \param prev_position Previous position from which to compute the wraparound offset.
+ * \param next_position Next position from which to compute the wraparound offset.
+ * \param angle_wraparound Vector of booleans where true values correspond to joints that wrap around
+ * (ie. are continuous). Offsets will be computed only for these joints, otherwise they are set to zero.
+ * \return Wraparound offsets that should be applied to \p next_position such that no multi-turns are performed when
+ * transitioning from \p prev_position.
+ * \tparam Scalar Scalar type.
+ */
+template <class Scalar>
+Scalar wraparoundJointOffset(const Scalar& prev_position,
+                             const Scalar& next_position,
+                             const bool&   angle_wraparound)
+{
+  // Return value
+  Scalar pos_offset = 0.0;
+
+  if (angle_wraparound)
+  {
+    Scalar dist = angles::shortest_angular_distance(prev_position, next_position);
+
+    // Deal with singularity at M_PI shortest distance
+    if (std::abs(dist) - M_PI < 1e-9)
+    {
+      dist = next_position > prev_position ? std::abs(dist) : -std::abs(dist);
+    }
+    pos_offset = (prev_position + dist) - next_position;
+  }
+
+  return pos_offset;
+}
+
 } // namespace
 
 #endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -240,47 +240,9 @@ private:
 /**
  * \param prev_position Previous position from which to compute the wraparound offset.
  * \param next_position Next position from which to compute the wraparound offset.
- * \param angle_wraparound Vector of booleans where true values correspond to joints that wrap around
- * (ie. are continuous). Offsets will be computed only for these joints, otherwise they are set to zero.
- * \return Wraparound offsets that should be applied to \p next_position such that no multi-turns are performed when
- * transitioning from \p prev_position.
- * \tparam Scalar Scalar type.
- */
-template <class Scalar>
-std::vector<Scalar> wraparoundOffset(const std::vector<Scalar>& prev_position,
-                                     const std::vector<Scalar>& next_position,
-                                     const std::vector<bool>&   angle_wraparound)
-{
-  // Preconditions
-  const unsigned int n_joints = angle_wraparound.size();
-  if (n_joints != prev_position.size() || n_joints != next_position.size()) {return std::vector<Scalar>();}
-
-  // Return value
-  std::vector<Scalar> pos_offset(n_joints, 0.0);
-
-  for (unsigned int i = 0; i < angle_wraparound.size(); ++i)
-  {
-    if (angle_wraparound[i])
-    {
-      Scalar dist = angles::shortest_angular_distance(prev_position[i], next_position[i]);
-
-      // Deal with singularity at M_PI shortest distance
-      if (std::abs(dist) - M_PI < 1e-9)
-      {
-        dist = next_position[i] > prev_position[i] ? std::abs(dist) : -std::abs(dist);
-      }
-      pos_offset[i] = (prev_position[i] + dist) - next_position[i];
-    }
-  }
-  return pos_offset;
-}
-
-/**
- * \param prev_position Previous position from which to compute the wraparound offset.
- * \param next_position Next position from which to compute the wraparound offset.
- * \param angle_wraparound Vector of booleans where true values correspond to joints that wrap around
- * (ie. are continuous). Offsets will be computed only for these joints, otherwise they are set to zero.
- * \return Wraparound offsets that should be applied to \p next_position such that no multi-turns are performed when
+ * \param angle_wraparound Boolean where true value corresponds to a joint that wrap around
+ * (ie. is continuous). Offset will be computed only for this joint, otherwise it is set to zero.
+ * \return Wraparound offset that should be applied to \p next_position such that no multi-turns are performed when
  * transitioning from \p prev_position.
  * \tparam Scalar Scalar type.
  */

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -85,21 +85,12 @@ public:
     /**
      * \param point Trajectory point.
      *
-     * \param permutation (Should be remove it) Permutation vector for mapping the joint order of a \p point to a desired order.
-     * For instance, if \p point contains data associated to joints <tt>"{B, D, A, C}"</tt>, and we are interested in
-     * constructing a segment with joints ordered as <tt>"{A, B, C, D}"</tt>, the permutation vector should
-     * be set to <tt>"{2, 0, 3, 1}"</tt>.
-     * If unspecified (empty), the joint order of \p point is preserved; if specified, its size must coincide with that
-     * of \p point.
-     * This vector can be computed using the \ref trajectory_interface::internal::permutation()
-     * "permutation" utility function.
+     * \param permutation (Should be removed)
      *
-     * \param position_offset Position offset to applpy to the data in \p point. This parameter is useful for handling
+     * \param position_offset Position offset to apply to the data in \p point. This parameter is useful for handling
      * joints that wrap around (ie. continuous), to compensate for multi-turn offsets.
      * If unspecified (empty), zero offsets are applied; if specified, its size must coincide with that of \p point.
      *
-     * \note The offsets in \p position_offsets correspond to joints not ordered according to \p point, but to joints
-     * in the expected order, that is \p point with \p permutation applied to it.
      */
     State(const trajectory_msgs::JointTrajectoryPoint& point,
           const std::vector<unsigned int>&             permutation     = std::vector<unsigned int>(),

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -89,7 +89,7 @@ struct SegmentTolerances
 };
 
 /**
- * \brief Trajectory segment tolerances per Joint (to replace the previous function
+ * \brief Trajectory segment tolerances per Joint
  */
 template<class Scalar>
 struct SegmentTolerancesPerJoint

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -172,7 +172,7 @@ inline bool checkStateTolerancePerJoint(const State&                            
 
   using std::abs;
 
-  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position); //&&
+  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position) &&
                         !(state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity) &&
                         !(state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration);
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -161,7 +161,7 @@ inline bool checkStateTolerance(const State&                                    
 /**
  * \param state_error State error to check.
  * \param state_tolerance State tolerances to check \p state_error against.
- * \param show_errors If the joints that violate their tolerances should be output to console. NOT REALTIME if true
+ * \param show_errors If the joint that violate its tolerance should be output to console. NOT REALTIME if true
  * \return True if \p state_error fulfills \p state_tolerance.
  */
 template <class State>
@@ -305,9 +305,6 @@ SegmentTolerances<Scalar> getSegmentTolerances(const ros::NodeHandle& nh,
     nh.param(joint_names[i] + "/trajectory", tolerances.state_tolerance[i].position,      0.0);
     nh.param(joint_names[i] + "/goal",       tolerances.goal_state_tolerance[i].position, 0.0);
     tolerances.goal_state_tolerance[i].velocity = stopped_velocity_tolerance;
-
-    //ROS_ERROR_STREAM("**************** "<<joint_names[i] << "/trajectory" << tolerances.state_tolerance[i].position <<  0.0);
-    //ROS_ERROR_STREAM("**************** "<<joint_names[i] << "/goal" << tolerances.goal_state_tolerance[i].position <<  0.0);
   }
 
   // Goal time tolerance

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -89,6 +89,28 @@ struct SegmentTolerances
 };
 
 /**
+ * \brief Trajectory segment tolerances per Joint (to replace the previous function
+ */
+template<class Scalar>
+struct SegmentTolerancesPerJoint
+{
+  SegmentTolerancesPerJoint()
+    : state_tolerance(static_cast<Scalar>(0.0)),
+      goal_state_tolerance(static_cast<Scalar>(0.0)),
+      goal_time_tolerance(static_cast<Scalar>(0.0))
+  {}
+
+  /** State tolerances that appply during segment execution. */
+  StateTolerances<Scalar> state_tolerance;
+
+  /** State tolerances that apply for the goal state only.*/
+  StateTolerances<Scalar> goal_state_tolerance;
+
+  /** Extra time after the segment end time allowed to reach the goal state tolerances. */
+  Scalar goal_time_tolerance;
+};
+
+/**
  * \param state_error State error to check.
  * \param state_tolerance State tolerances to check \p state_error against.
  * \param show_errors If the joints that violate their tolerances should be output to console. NOT REALTIME if true
@@ -132,6 +154,45 @@ inline bool checkStateTolerance(const State&                                    
       }
       return false;
     }
+  }
+  return true;
+}
+
+/**
+ * \param state_error State error to check.
+ * \param state_tolerance State tolerances to check \p state_error against.
+ * \param show_errors If the joints that violate their tolerances should be output to console. NOT REALTIME if true
+ * \return True if \p state_error fulfills \p state_tolerance.
+ */
+template <class State>
+inline bool checkStateTolerancePerJoint(const State&                                   state_error,
+                                        const StateTolerances<typename State::Scalar>& state_tolerance,
+                                        bool show_errors = false)
+{
+
+  using std::abs;
+
+  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position) &&
+                        !(state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity) &&
+                        !(state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration);
+
+  if (!is_valid)
+  {
+    if( show_errors )
+    {
+      ROS_ERROR_STREAM_NAMED("tolerances","Path state tolerances failed on joint");
+
+      if (state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position)
+        ROS_ERROR_STREAM_NAMED("tolerances","Position Error: " << state_error.position[0] <<
+          " Position Tolerance: " << state_tolerance.position);
+      if (state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity)
+        ROS_ERROR_STREAM_NAMED("tolerances","Velocity Error: " << state_error.velocity[0] <<
+          " Velocity Tolerance: " << state_tolerance.velocity);
+      if (state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration)
+        ROS_ERROR_STREAM_NAMED("tolerances","Acceleration Error: " << state_error.acceleration[0] <<
+          " Acceleration Tolerance: " << state_tolerance.acceleration);
+    }
+    return false;
   }
   return true;
 }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -172,7 +172,7 @@ inline bool checkStateTolerancePerJoint(const State&                            
 
   using std::abs;
 
-  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position) &&
+  const bool is_valid = !(state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position); //&&
                         !(state_tolerance.velocity     > 0.0 && abs(state_error.velocity[0])     > state_tolerance.velocity) &&
                         !(state_tolerance.acceleration > 0.0 && abs(state_error.acceleration[0]) > state_tolerance.acceleration);
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -244,6 +244,9 @@ SegmentTolerances<Scalar> getSegmentTolerances(const ros::NodeHandle& nh,
     nh.param(joint_names[i] + "/trajectory", tolerances.state_tolerance[i].position,      0.0);
     nh.param(joint_names[i] + "/goal",       tolerances.goal_state_tolerance[i].position, 0.0);
     tolerances.goal_state_tolerance[i].velocity = stopped_velocity_tolerance;
+
+    //ROS_ERROR_STREAM("**************** "<<joint_names[i] << "/trajectory" << tolerances.state_tolerance[i].position <<  0.0);
+    //ROS_ERROR_STREAM("**************** "<<joint_names[i] << "/goal" << tolerances.goal_state_tolerance[i].position <<  0.0);
   }
 
   // Goal time tolerance

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -180,7 +180,7 @@ inline bool checkStateTolerancePerJoint(const State&                            
   {
     if( show_errors )
     {
-      ROS_ERROR_STREAM_NAMED("tolerances","Path state tolerances failed on joint");
+      ROS_ERROR_STREAM_NAMED("tolerances","Path state tolerances failed:");
 
       if (state_tolerance.position     > 0.0 && abs(state_error.position[0])     > state_tolerance.position)
         ROS_ERROR_STREAM_NAMED("tolerances","Position Error: " << state_error.position[0] <<

--- a/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
+++ b/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
@@ -45,7 +45,8 @@ using std::string;
 const double EPS = 1e-9;
 
 typedef JointTrajectorySegment<trajectory_interface::QuinticSplineSegment<double> > Segment;
-typedef vector<Segment>                Trajectory;
+typedef vector<Segment> TrajectoryPerJoint;
+typedef vector<TrajectoryPerJoint> Trajectory;
 
 TEST(PermutationTest, Permutation)
 {
@@ -140,11 +141,15 @@ public:
     state[1].velocity.push_back(1.0);
     state[1].acceleration.push_back(1.0);
 
-    curr_traj.push_back(Segment(0.0, state[0],
+    TrajectoryPerJoint joint_segment;
+
+    joint_segment.push_back(Segment(0.0, state[0],
                                 1.0, state[1]));
 
-    curr_traj.push_back(Segment(3.0,  state[1],
+    joint_segment.push_back(Segment(3.0,  state[1],
                                 10.0, state[0])); // This is just junk that should be discarded in the tests
+
+    curr_traj.push_back(joint_segment);
   }
 
 protected:
@@ -154,13 +159,15 @@ protected:
 
   // Currently executed trajectory
   Trajectory curr_traj;
+
 };
 
+//Now it is possible to have different sizes
 TEST_F(InitTrajectoryTest, InitException)
 {
   // Invalid input should throw an exception
   trajectory_msg.points.back().positions.push_back(0.0); // Inconsistent size in last element
-  EXPECT_THROW(initJointTrajectory<Trajectory>(trajectory_msg, trajectory_msg.header.stamp), std::invalid_argument);
+  EXPECT_NO_THROW(initJointTrajectory<Trajectory>(trajectory_msg, trajectory_msg.header.stamp));
 }
 
 // Test logic of parsing a trajectory message. No current trajectory is specified
@@ -182,14 +189,14 @@ TEST_F(InitTrajectoryTest, InitLogic)
   {
     const ros::Time time = msg_start_time;
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time);
-    EXPECT_EQ(points.size() - 1, trajectory.size());
+    EXPECT_EQ(points.size() - 1, trajectory[0].size());
   }
 
   // First point: Return partial trajectory (last segment)
   {
     const ros::Time time = msg_start_time + msg_points.begin()->time_from_start;
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time);
-    EXPECT_EQ(points.size() - 2, trajectory.size());
+    EXPECT_EQ(points.size() - 2, trajectory[0].size());
   }
 
   // Between the first and second points: Return partial trajectory (last segment)
@@ -197,7 +204,7 @@ TEST_F(InitTrajectoryTest, InitLogic)
     const ros::Time time = msg_start_time +
     ros::Duration((msg_points.begin()->time_from_start + (++msg_points.begin())->time_from_start).toSec() / 2.0);
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time);
-    EXPECT_EQ(msg_points.size() - 2, trajectory.size());
+    EXPECT_EQ(msg_points.size() - 2, trajectory[0].size());
   }
 
   // Second point: Return empty trajectory
@@ -249,23 +256,23 @@ TEST_F(InitTrajectoryTest, InitLogicCombine)
 
   // Before first point, starting the current trajectory: Return 4 segments: Last of current + bridge + full message
   {
-    const ros::Time time(curr_traj[0].startTime());
+    const ros::Time time(curr_traj[0][0].startTime());
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-    EXPECT_EQ(points.size() + 1, trajectory.size());
+    EXPECT_EQ(points.size() + 1, trajectory[0].size());
   }
 
   // Before first point: Return 4 segments: Last of current + bridge + full message
   {
     const ros::Time time = msg_start_time;
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-    EXPECT_EQ(points.size() + 1, trajectory.size());
+    EXPECT_EQ(points.size() + 1, trajectory[0].size());
   }
 
   // First point: Return partial trajectory, 3 segments: Last of current + bridge + last of message
   {
     const ros::Time time = msg_start_time + msg_points.begin()->time_from_start;
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-    EXPECT_EQ(points.size(), trajectory.size());
+    EXPECT_EQ(points.size(), trajectory[0].size());
   }
 
   // Between the first and second points: Same as before
@@ -273,14 +280,14 @@ TEST_F(InitTrajectoryTest, InitLogicCombine)
     const ros::Time time = msg_start_time +
     ros::Duration((msg_points.begin()->time_from_start + (++msg_points.begin())->time_from_start).toSec() / 2.0);
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-    EXPECT_EQ(msg_points.size(), trajectory.size());
+    EXPECT_EQ(msg_points.size(), trajectory[0].size());
   }
 
   // Second point: Return partial trajectory, 2 segments: Last of current + bridge (only one point of message made it)
   {
     const ros::Time time = msg_start_time + (++msg_points.begin())->time_from_start;
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-    EXPECT_EQ(msg_points.size() - 1, trajectory.size());
+    EXPECT_EQ(msg_points.size() - 1, trajectory[0].size());
   }
 
   // Between the second and third points: Same as before
@@ -288,7 +295,7 @@ TEST_F(InitTrajectoryTest, InitLogicCombine)
     const ros::Time time = msg_start_time +
     ros::Duration(((++msg_points.begin())->time_from_start + (--msg_points.end())->time_from_start).toSec() / 2.0);
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-    EXPECT_EQ(msg_points.size() - 1, trajectory.size());
+    EXPECT_EQ(msg_points.size() - 1, trajectory[0].size());
   }
 
   // Last point: Return empty trajectory
@@ -314,12 +321,12 @@ TEST_F(InitTrajectoryTest, InitValues)
   // Input time is before first point: Return full trajectory (2 segments)
   const ros::Time time = msg_start_time;
   Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time);
-  ASSERT_EQ(points.size() - 1, trajectory.size());
+  ASSERT_EQ(points.size() - 1, trajectory[0].size());
 
   // Check all segment start/end times and states
-  for (unsigned int i = 0; i < trajectory.size(); ++i)
+  for (unsigned int i = 0; i < trajectory[0].size(); ++i)
   {
-    const Segment& segment = trajectory[i];
+    const Segment& segment = trajectory[0][i];
     const JointTrajectoryPoint& p_start = msg_points[i];
     const JointTrajectoryPoint& p_end   = msg_points[i + 1];
 
@@ -354,17 +361,17 @@ TEST_F(InitTrajectoryTest, InitValues)
 TEST_F(InitTrajectoryTest, InitValuesCombine)
 {
   // Before first point: Return 4 segments: Last of current + bridge + full message
-  const ros::Time time(curr_traj[0].startTime());
+  const ros::Time time(curr_traj[0][0].startTime());
   InitJointTrajectoryOptions<Trajectory> options;
   options.current_trajectory = &curr_traj;
 
   Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-  ASSERT_EQ(points.size() + 1, trajectory.size());
+  ASSERT_EQ(points.size() + 1, trajectory[0].size());
 
   // Check current trajectory segment start/end times and states (only one)
   {
-    const Segment& ref_segment = curr_traj[0];
-    const Segment& segment     = trajectory[0];
+    const Segment& ref_segment = curr_traj[0][0];
+    const Segment& segment     = trajectory[0][0];
 
     // Check start/end times
     {
@@ -395,8 +402,8 @@ TEST_F(InitTrajectoryTest, InitValuesCombine)
 
   // Check bridge trajectory segment start/end times and states (only one)
   {
-    const Segment& ref_segment = curr_traj[0];
-    const Segment& segment     = trajectory[1];
+    const Segment& ref_segment = curr_traj[0][0];
+    const Segment& segment     = trajectory[0][1];
 
     const vector<JointTrajectoryPoint>& msg_points = trajectory_msg.points;
 
@@ -433,12 +440,12 @@ TEST_F(InitTrajectoryTest, InitValuesCombine)
   }
 
   // Check all segment start/end times and states (2 segments)
-  for (unsigned int traj_it = 2, msg_it = 0; traj_it < trajectory.size(); ++traj_it, ++msg_it)
+  for (unsigned int traj_it = 2, msg_it = 0; traj_it < trajectory[0].size(); ++traj_it, ++msg_it)
   {
     const ros::Time msg_start_time = trajectory_msg.header.stamp;
     const vector<JointTrajectoryPoint>& msg_points = trajectory_msg.points;
 
-    const Segment& segment = trajectory[traj_it];
+    const Segment& segment = trajectory[0][traj_it];
     const JointTrajectoryPoint& p_start = msg_points[msg_it];
     const JointTrajectoryPoint& p_end   = msg_points[msg_it + 1];
 
@@ -492,11 +499,13 @@ TEST_F(InitTrajectoryTest, JointPermutation)
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, trajectory_msg.header.stamp);
 
     // Check position values only
-    const Segment& segment = trajectory[0];
+    const Segment& segment_foo_joint = trajectory[0][0];
+    const Segment& segment_bar_joint = trajectory[1][0];
     typename Segment::State state;
-    segment.sample(segment.startTime(), state);
+    segment_foo_joint.sample(segment_foo_joint.startTime(), state);
     EXPECT_EQ(trajectory_msg.points[0].positions[0],  state.position[0]);
-    EXPECT_EQ(trajectory_msg.points[0].positions[1],  state.position[1]);
+    segment_bar_joint.sample(segment_bar_joint.startTime(), state);
+    EXPECT_EQ(trajectory_msg.points[0].positions[1],  state.position[0]);
   }
 
   // Reference joint names vector that reverses joint order
@@ -510,13 +519,17 @@ TEST_F(InitTrajectoryTest, JointPermutation)
     Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, trajectory_msg.header.stamp, options);
 
     // Check position values only
-    const Segment& segment = trajectory[0];
-    typename Segment::State state;
-    segment.sample(segment.startTime(), state);
-    EXPECT_NE(trajectory_msg.points[0].positions[0],  state.position[0]);
-    EXPECT_NE(trajectory_msg.points[0].positions[1],  state.position[1]);
-    EXPECT_EQ(trajectory_msg.points[0].positions[0],  state.position[1]);
-    EXPECT_EQ(trajectory_msg.points[0].positions[1],  state.position[0]);
+    const Segment& segment_bar_joint = trajectory[0][0];
+    const Segment& segment_foo_joint = trajectory[1][0];
+
+    typename Segment::State state_foo_joint;
+    typename Segment::State state_bar_joint;
+    segment_foo_joint.sample(segment_foo_joint.startTime(), state_foo_joint);
+    segment_bar_joint.sample(segment_bar_joint.startTime(), state_bar_joint);
+    EXPECT_NE(trajectory_msg.points[0].positions[0],  state_bar_joint.position[0]);
+    EXPECT_NE(trajectory_msg.points[0].positions[1],  state_foo_joint.position[0]);
+    EXPECT_EQ(trajectory_msg.points[0].positions[0],  state_foo_joint.position[0]);
+    EXPECT_EQ(trajectory_msg.points[0].positions[1],  state_bar_joint.position[0]);
   }
 
   // Reference joint names size mismatch
@@ -553,19 +566,19 @@ TEST_F(InitTrajectoryTest, WrappingSpec)
   }
 
   // Before first point: Return 4 segments: Last of current + bridge + full message
-  const ros::Time time(curr_traj[0].startTime());
+  const ros::Time time(curr_traj[0][0].startTime());
   std::vector<bool> angle_wraparound(1, true);
   InitJointTrajectoryOptions<Trajectory> options;
   options.current_trajectory = &curr_traj;
   options.angle_wraparound      = &angle_wraparound;
 
   Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-  ASSERT_EQ(points.size() + 1, trajectory.size());
+  ASSERT_EQ(points.size() + 1, trajectory[0].size());
 
   // Check current trajectory segment start/end times and states (only one)
   {
-    const Segment& ref_segment = curr_traj[0];
-    const Segment& segment     = trajectory[0];
+    const Segment& ref_segment = curr_traj[0][0];
+    const Segment& segment     = trajectory[0][0];
 
     // Check start/end times
     {
@@ -596,8 +609,8 @@ TEST_F(InitTrajectoryTest, WrappingSpec)
 
   // Check bridge trajectory segment start/end times and states (only one)
   {
-    const Segment& ref_segment = curr_traj[0];
-    const Segment& segment     = trajectory[1];
+    const Segment& ref_segment = curr_traj[0][0];
+    const Segment& segment     = trajectory[0][1];
 
     const vector<JointTrajectoryPoint>& msg_points = trajectory_msg.points;
 
@@ -634,12 +647,12 @@ TEST_F(InitTrajectoryTest, WrappingSpec)
   }
 
   // Check all segment start/end times and states (2 segments)
-  for (unsigned int traj_it = 2, msg_it = 0; traj_it < trajectory.size(); ++traj_it, ++msg_it)
+  for (unsigned int traj_it = 2, msg_it = 0; traj_it < trajectory[0].size(); ++traj_it, ++msg_it)
   {
     const ros::Time msg_start_time = trajectory_msg.header.stamp;
     const vector<JointTrajectoryPoint>& msg_points = trajectory_msg.points;
 
-    const Segment& segment = trajectory[traj_it];
+    const Segment& segment = trajectory[0][traj_it];
     const JointTrajectoryPoint& p_start = msg_points[msg_it];
     const JointTrajectoryPoint& p_end   = msg_points[msg_it + 1];
 
@@ -696,18 +709,18 @@ TEST_F(InitTrajectoryTest, IgnoreWrappingSpec)
   }
 
   // Before first point: Return 2 segments: Full message
-  const ros::Time time(curr_traj[0].startTime());
+  const ros::Time time(curr_traj[0][0].startTime());
   std::vector<bool> angle_wraparound(1, true);
   InitJointTrajectoryOptions<Trajectory> options;
   options.angle_wraparound = &angle_wraparound;
 
   Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-  ASSERT_EQ(points.size() - 1, trajectory.size());
+  ASSERT_EQ(points.size() - 1, trajectory[0].size());
 
   // Check all segment start/end times and states (2 segments)
-  for (unsigned int i = 0; i < trajectory.size(); ++i)
+  for (unsigned int i = 0; i < trajectory[0].size(); ++i)
   {
-    const Segment& segment = trajectory[i];
+    const Segment& segment = trajectory[0][i];
     const JointTrajectoryPoint& p_start = msg_points[i];
     const JointTrajectoryPoint& p_end   = msg_points[i + 1];
 
@@ -751,21 +764,21 @@ TEST_F(InitTrajectoryTest, GoalHandleTest)
   RealtimeGoalHandlePtr rt_goal(new RealtimeGoalHandle(gh));
 
   // Before first point: Return 4 segments: Last of current + bridge + full message
-  const ros::Time time(curr_traj[0].startTime());
+  const ros::Time time(curr_traj[0][0].startTime());
   InitJointTrajectoryOptions<Trajectory> options;
   options.current_trajectory = &curr_traj;
   options.rt_goal_handle     = rt_goal;
 
   Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-  ASSERT_EQ(points.size() + 1, trajectory.size());
+  ASSERT_EQ(points.size() + 1, trajectory[0].size());
 
   // Segment of current trajectory preserves existing null goal handle
-  ASSERT_FALSE(trajectory[0].getGoalHandle());
+  ASSERT_FALSE(trajectory[0][0].getGoalHandle());
 
   // All further segments should be associated to the new goal handle
-  for (unsigned int i = 1; i < trajectory.size(); ++i) // NOTE: Start index != 0
+  for (unsigned int i = 1; i < trajectory[0].size(); ++i) // NOTE: Start index != 0
   {
-    ASSERT_EQ(rt_goal, trajectory[i].getGoalHandle());
+    ASSERT_EQ(rt_goal, trajectory[0][i].getGoalHandle());
   }
 }
 
@@ -783,12 +796,12 @@ TEST_F(InitTrajectoryTest, OtherTimeBase)
   // Before first point: Return 4 segments: Last of current + bridge + full message
   const ros::Time time = msg_start_time;
   Trajectory trajectory = initJointTrajectory<Trajectory>(trajectory_msg, time, options);
-  ASSERT_EQ(points.size() + 1, trajectory.size());
+  ASSERT_EQ(points.size() + 1, trajectory[0].size());
 
   // Check current trajectory segment start/end times (only one). Time offset does NOT apply
   {
-    const Segment& ref_segment = curr_traj[0];
-    const Segment& segment     = trajectory[0];
+    const Segment& ref_segment = curr_traj[0][0];
+    const Segment& segment     = trajectory[0][0];
 
     // Check start/end times
     {
@@ -799,7 +812,7 @@ TEST_F(InitTrajectoryTest, OtherTimeBase)
 
   // Check bridge trajectory segment start/end times and states (only one). Time offset applies to end state only
   {
-    const Segment& segment = trajectory[1];
+    const Segment& segment = trajectory[0][1];
 
     const vector<JointTrajectoryPoint>& msg_points = trajectory_msg.points;
 
@@ -817,12 +830,12 @@ TEST_F(InitTrajectoryTest, OtherTimeBase)
   }
 
   // Check all segment start/end times and states (2 segments). Time offset does apply
-  for (unsigned int traj_it = 2, msg_it = 0; traj_it < trajectory.size(); ++traj_it, ++msg_it)
+  for (unsigned int traj_it = 2, msg_it = 0; traj_it < trajectory[0].size(); ++traj_it, ++msg_it)
   {
     const ros::Time msg_start_time = trajectory_msg.header.stamp;
     const vector<JointTrajectoryPoint>& msg_points = trajectory_msg.points;
 
-    const Segment& segment = trajectory[traj_it];
+    const Segment& segment = trajectory[0][traj_it];
     const JointTrajectoryPoint& p_start = msg_points[msg_it];
     const JointTrajectoryPoint& p_end   = msg_points[msg_it + 1];
 

--- a/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
+++ b/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
@@ -159,7 +159,6 @@ protected:
 
   // Currently executed trajectory
   Trajectory curr_traj;
-
 };
 
 //Now it is possible to have different sizes

--- a/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
+++ b/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
@@ -48,59 +48,70 @@ typedef JointTrajectorySegment<trajectory_interface::QuinticSplineSegment<double
 typedef vector<Segment> TrajectoryPerJoint;
 typedef vector<TrajectoryPerJoint> Trajectory;
 
-TEST(PermutationTest, Permutation)
+TEST(MappingTest, Mapping)
 {
   vector<string> t1(4);
-  t1[0] = "A";
-  t1[1] = "B";
-  t1[2] = "C";
-  t1[3] = "D";
+  t1[0] = "B";
+  t1[1] = "D";
+  t1[2] = "A";
+  t1[3] = "C";
 
   vector<string> t2(4);
-  t2[0] = "B";
-  t2[1] = "D";
-  t2[2] = "A";
-  t2[3] = "C";
+  t2[0] = "A";
+  t2[1] = "B";
+  t2[2] = "C";
+  t2[3] = "D";
 
-  typedef vector<unsigned int> PermutationType;
-  PermutationType ground_truth(4);
+  typedef vector<unsigned int> MappingType;
+  MappingType ground_truth(4);
   ground_truth[0] = 2;
   ground_truth[1] = 0;
   ground_truth[2] = 3;
   ground_truth[3] = 1;
 
-  // Mismatching sizes: Return empty permutation vector
+  // Mismatching sizes (t2 smaller than t1): Return empty mapping vector
   {
     vector<string> t2_bad(1,"A");
-    PermutationType perm = internal::permutation(t1, t2_bad);
-    EXPECT_TRUE(perm.empty());
+    MappingType mapping = internal::mapping(t1, t2_bad);
+    EXPECT_TRUE(mapping.empty());
   }
 
-  // Mismatching contents: Return empty permutation vector
+  // Mismatching contents: Return empty mapping vector
   {
     vector<string> t2_bad(3,"A");
-    PermutationType perm = internal::permutation(t1, t2_bad);
-    EXPECT_TRUE(perm.empty());
+    MappingType mapping = internal::mapping(t1, t2_bad);
+    EXPECT_TRUE(mapping.empty());
   }
 
   // Valid parameters
   {
-    PermutationType perm = internal::permutation(t1, t2);
-    EXPECT_EQ(ground_truth.size(), perm.size());
-    EXPECT_EQ(ground_truth[0], perm[0]);
-    EXPECT_EQ(ground_truth[1], perm[1]);
-    EXPECT_EQ(ground_truth[2], perm[2]);
-    EXPECT_EQ(ground_truth[3], perm[3]);
+    MappingType mapping = internal::mapping(t1, t2);
+    EXPECT_EQ(ground_truth.size(), mapping.size());
+    EXPECT_EQ(ground_truth[3], mapping[0]);
+    EXPECT_EQ(ground_truth[2], mapping[1]);
+    EXPECT_EQ(ground_truth[1], mapping[2]);
+    EXPECT_EQ(ground_truth[0], mapping[3]);
   }
 
-  // Valid parameters, inverse parameter order yields inverse permutation vector
+  // Valid parameters, inverse parameter order yields inverse mapping vector
   {
-    PermutationType perm = internal::permutation(t2, t1);
-    EXPECT_EQ(ground_truth.size(), perm.size());
-    EXPECT_EQ(ground_truth[3], perm[0]);
-    EXPECT_EQ(ground_truth[2], perm[1]);
-    EXPECT_EQ(ground_truth[1], perm[2]);
-    EXPECT_EQ(ground_truth[0], perm[3]);
+    MappingType mapping = internal::mapping(t2, t1);
+    EXPECT_EQ(ground_truth.size(), mapping.size());
+    EXPECT_EQ(ground_truth[0], mapping[0]);
+    EXPECT_EQ(ground_truth[1], mapping[1]);
+    EXPECT_EQ(ground_truth[2], mapping[2]);
+    EXPECT_EQ(ground_truth[3], mapping[3]);
+  }
+
+  // Valid parameters, partial trajectory
+  {
+    vector<string> t1_partial(2);
+    t1_partial[0] = "B";
+    t1_partial[1] = "D";
+    MappingType mapping = internal::mapping(t1_partial, t2);
+    EXPECT_EQ(t1_partial.size(), mapping.size());
+    EXPECT_EQ(1, mapping[0]);
+    EXPECT_EQ(3, mapping[1]);
   }
 }
 
@@ -475,7 +486,7 @@ TEST_F(InitTrajectoryTest, InitValuesCombine)
   }
 }
 
-TEST_F(InitTrajectoryTest, JointPermutation)
+TEST_F(InitTrajectoryTest, JointMapping)
 {
   // Add an extra joint to the trajectory message created in the fixture
   trajectory_msg.points[0].positions.push_back(-2.0);

--- a/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
+++ b/joint_trajectory_controller/test/init_joint_trajectory_test.cpp
@@ -161,12 +161,11 @@ protected:
   Trajectory curr_traj;
 };
 
-//Now it is possible to have different sizes
 TEST_F(InitTrajectoryTest, InitException)
 {
   // Invalid input should throw an exception
   trajectory_msg.points.back().positions.push_back(0.0); // Inconsistent size in last element
-  EXPECT_NO_THROW(initJointTrajectory<Trajectory>(trajectory_msg, trajectory_msg.header.stamp));
+  EXPECT_THROW(initJointTrajectory<Trajectory>(trajectory_msg, trajectory_msg.header.stamp), std::invalid_argument);
 }
 
 // Test logic of parsing a trajectory message. No current trajectory is specified

--- a/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
@@ -1,0 +1,35 @@
+<launch>
+  <!-- Load RRbot model -->
+  <param name="robot_description"
+      command="$(find xacro)/xacro.py '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
+
+  <!-- Start RRbot -->
+  <node name="rrbot"
+      pkg="joint_trajectory_controller"
+      type="rrbot"/>
+
+  <!-- Load controller config -->
+  <rosparam command="load" file="$(find joint_trajectory_controller)/test/rrbot_partial_controllers.yaml" />
+
+  <!-- Spawn controller -->
+  <node name="controller_spawner"
+        pkg="controller_manager" type="spawner" output="screen"
+        args="rrbot_controller" />
+
+  <!-- Rxplot monitoring -->
+  <node name="rrbot_pos_monitor"
+        pkg="rqt_plot"
+        type="rqt_plot"
+        args="/rrbot_controller/state/desired/positions[0]:positions[1],/rrbot_controller/state/actual/positions[0]:positions[1]" />
+
+  <node name="rrbot_vel_monitor"
+        pkg="rqt_plot"
+        type="rqt_plot"
+        args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
+
+  <!-- Controller test -->
+  <test test-name="joint_partial_trajectory_controller_test"
+        pkg="joint_trajectory_controller"
+        type="joint_partial_trajectory_controller_test"
+        time-limit="80.0"/>
+</launch>

--- a/joint_trajectory_controller/test/joint_partial_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_partial_trajectory_controller_test.cpp
@@ -1,0 +1,637 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Adolfo Rodriguez Tsouroukdissian
+
+#include <algorithm>
+#include <cmath>
+
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
+
+#include <gtest/gtest.h>
+
+#include <ros/ros.h>
+#include <actionlib/client/simple_action_client.h>
+
+#include <std_msgs/Float64.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+#include <control_msgs/JointTrajectoryControllerState.h>
+#include <control_msgs/QueryTrajectoryState.h>
+
+// Floating-point value comparison threshold
+const double EPS = 0.01;
+
+using actionlib::SimpleClientGoalState;
+
+class JointPartialTrajectoryControllerTest : public ::testing::Test
+{
+public:
+  JointPartialTrajectoryControllerTest()
+    : nh("rrbot_controller"),
+      short_timeout(1.0),
+      long_timeout(10.0),
+      controller_state()
+  {
+    n_joints = (2);
+    n_partial_joints = (2);
+    joint_names.resize(n_joints);
+    joint_names[0] = "joint1";
+    joint_names[1] = "joint2";
+
+    trajectory_msgs::JointTrajectoryPoint point;
+    point.positions.resize(n_joints, 0.0);
+    point.velocities.resize(n_joints, 0.0);
+    point.accelerations.resize(n_joints, 0.0);
+
+    // Go home trajectory
+    traj_home.joint_names = joint_names;
+    traj_home.points.resize(1, point);
+    traj_home.points[0].time_from_start = ros::Duration(1.0);
+
+    // Three-point trajectory
+    points.resize(3, point);
+    points[0].positions[0] =  M_PI / 4.0;
+    points[0].positions[1] =  0.0;
+    points[0].time_from_start = ros::Duration(1.0);
+
+    points[1].positions[0] =  0.0;
+    points[1].positions[1] = -M_PI / 4.0;
+    points[1].time_from_start = ros::Duration(2.0);
+
+    points[2].positions[0] = -M_PI / 4.0;
+    points[2].positions[1] =  M_PI / 4.0;
+    points[2].time_from_start = ros::Duration(4.0);
+
+    traj.joint_names = joint_names;
+    traj.points = points;
+
+    // Partial trajectory
+    traj_partial.joint_names.resize(1, "joint2");
+    points.resize(3, point);
+    points[0].positions[0] =  M_PI / 4.0;
+    points[0].time_from_start = ros::Duration(1.0);
+
+    points[1].positions[0] =  M_PI / 2.0;
+    points[1].time_from_start = ros::Duration(2.0);
+
+    points[2].positions[0] =  -M_PI / 2.0;
+    points[2].time_from_start = ros::Duration(4.0);
+    traj_partial.points = points;
+
+    // Action goals
+    traj_home_goal.trajectory    = traj_home;
+    traj_goal.trajectory         = traj;
+    traj_partial_goal.trajectory = traj_partial;
+
+    // Smoothing publisher (determines how well the robot follows a trajectory)
+    smoothing_pub = ros::NodeHandle().advertise<std_msgs::Float64>("smoothing", 1);
+
+    // Trajectory publisher
+    traj_pub = nh.advertise<trajectory_msgs::JointTrajectory>("command", 1);
+
+    // State subscriber
+    state_sub = nh.subscribe<control_msgs::JointTrajectoryControllerState>("state",
+                                                                           1,
+                                                                           &JointPartialTrajectoryControllerTest::stateCB,
+                                                                           this);
+
+    // Query state service client
+    query_state_service = nh.serviceClient<control_msgs::QueryTrajectoryState>("query_state");
+
+    // Action client
+    const std::string action_server_name = nh.getNamespace() + "/follow_joint_trajectory";
+    action_client.reset(new ActionClient(action_server_name));
+    action_client2.reset(new ActionClient(action_server_name));
+  }
+
+  ~JointPartialTrajectoryControllerTest()
+  {
+    state_sub.shutdown(); // This is important, to make sure that the callback is not woken up later in the destructor
+  }
+
+protected:
+  typedef actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> ActionClient;
+  typedef boost::shared_ptr<ActionClient> ActionClientPtr;
+  typedef control_msgs::FollowJointTrajectoryGoal ActionGoal;
+  typedef control_msgs::JointTrajectoryControllerStateConstPtr StateConstPtr;
+
+  boost::mutex mutex;
+  ros::NodeHandle nh;
+
+  unsigned int n_joints;
+  unsigned int n_partial_joints;
+  std::vector<std::string> joint_names;
+  std::vector<trajectory_msgs::JointTrajectoryPoint> points;
+
+  trajectory_msgs::JointTrajectory traj_home;
+  trajectory_msgs::JointTrajectory traj;
+  trajectory_msgs::JointTrajectory traj_partial;
+  ActionGoal                       traj_home_goal;
+  ActionGoal                       traj_goal;
+  ActionGoal                       traj_partial_goal;
+
+  ros::Duration short_timeout;
+  ros::Duration long_timeout;
+
+  ros::Publisher     smoothing_pub;
+  ros::Publisher     traj_pub;
+  ros::Subscriber    state_sub;
+  ros::ServiceClient query_state_service;
+  ActionClientPtr    action_client;
+  ActionClientPtr    action_client2;
+
+
+  StateConstPtr controller_state;
+
+  void stateCB(const StateConstPtr& state)
+  {
+    boost::mutex::scoped_lock lock(mutex);
+    controller_state = state;
+  }
+
+  StateConstPtr getState()
+  {
+    boost::mutex::scoped_lock lock(mutex);
+    return controller_state;
+  }
+
+  bool initState(const ros::Duration& timeout = ros::Duration(5.0))
+  {
+    bool init_ok = false;
+    ros::Time start_time = ros::Time::now();
+    while (!init_ok && (ros::Time::now() - start_time) < timeout)
+    {
+      {
+        boost::mutex::scoped_lock lock(mutex);
+        init_ok = controller_state && !controller_state->joint_names.empty();
+      }
+      ros::Duration(0.1).sleep();
+    }
+    return init_ok;
+  }
+
+  static bool waitForState(const ActionClientPtr& action_client,
+                           const actionlib::SimpleClientGoalState& state,
+                           const ros::Duration& timeout)
+  {
+    using ros::Time;
+    using ros::Duration;
+
+    Time start_time = Time::now();
+    while (action_client->getState() != state && ros::ok())
+    {
+      if (timeout >= Duration(0.0) && (Time::now() - start_time) > timeout) {return false;} // Timed-out
+      ros::Duration(0.01).sleep();
+    }
+    return true;
+  }
+};
+
+// Invalid messages ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(JointPartialTrajectoryControllerTest, invalidMessages)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Incompatible joint names
+  {
+    ActionGoal bad_goal = traj_home_goal;
+    bad_goal.trajectory.joint_names[0] = "bad_name";
+
+    bad_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+    action_client->sendGoal(bad_goal);
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
+    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS);
+  }
+
+  // No position data
+  {
+    ActionGoal bad_goal = traj_home_goal;
+    bad_goal.trajectory.points[0].positions.clear();
+
+    bad_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+    action_client->sendGoal(bad_goal);
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
+    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_GOAL);
+  }
+
+  // Incompatible data sizes
+  {
+    ActionGoal bad_goal = traj_home_goal;
+    bad_goal.trajectory.points[0].positions.pop_back();
+
+    bad_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+    action_client->sendGoal(bad_goal);
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
+    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_GOAL);
+  }
+
+  // Non-strictly increasing waypoint times
+  {
+    ActionGoal bad_goal = traj_goal;
+    bad_goal.trajectory.points[2].time_from_start = bad_goal.trajectory.points[1].time_from_start;
+
+    action_client->sendGoal(bad_goal);
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
+    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_GOAL);
+  }
+
+  // Empty trajectory through action interface
+  // NOTE: Sending an empty trajectory through the topic interface cancels execution of all queued segments, but
+  // an empty trajectory is interpreted by the action interface as not having the correct joint names.
+  {
+    ActionGoal empty_goal;
+    action_client->sendGoal(empty_goal);
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
+    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS);
+  }
+}
+
+// Partial trajectory execution   //////////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(JointPartialTrajectoryControllerTest, allowPartialTrajIfSpecified)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send partial trajectory.
+  action_client->sendGoal(traj_partial_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, long_timeout));
+}
+
+// Uninterrupted Partial trajectory execution //////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(JointPartialTrajectoryControllerTest, topicSinglePartialTraj)
+{
+  ASSERT_TRUE(initState());
+
+  // Send partial trajectory
+  traj_partial.header.stamp = ros::Time(0); // Start immediately
+  traj_pub.publish(traj_partial);
+  ros::Duration wait_duration = traj_partial.points.back().time_from_start + ros::Duration(0.5);
+  wait_duration.sleep(); // Wait until done
+
+  // Validate state topic values
+  StateConstPtr state = getState();
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],  state->actual.positions[1],  EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0], state->actual.velocities[1], EPS);
+
+  EXPECT_NEAR(0.0, state->error.positions[1],  EPS);
+  EXPECT_NEAR(0.0, state->error.velocities[1], EPS);
+
+  // Validate query state service
+  control_msgs::QueryTrajectoryState srv;
+  srv.request.time = ros::Time::now();
+  ASSERT_TRUE(query_state_service.call(srv));
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    EXPECT_NEAR(state->desired.positions[i],     srv.response.position[i],     EPS);
+    EXPECT_NEAR(state->desired.velocities[i],    srv.response.velocity[i],     EPS);
+    EXPECT_NEAR(state->desired.accelerations[i], srv.response.acceleration[i], EPS);
+  }
+}
+
+TEST_F(JointPartialTrajectoryControllerTest, actionSinglePartialTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send partial trajectory
+  traj_partial_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_partial_goal);
+
+  // Wait until done
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, long_timeout));
+  EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::SUCCESSFUL);
+  ros::Duration(0.5).sleep(); // Allows values to settle to within EPS, especially accelerations
+
+  // Validate state topic values
+  StateConstPtr state = getState();
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],  state->actual.positions[1],  EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0], state->actual.velocities[1], EPS);
+
+  EXPECT_NEAR(0.0, state->error.positions[1],  EPS);
+  EXPECT_NEAR(0.0, state->error.velocities[1], EPS);
+}
+
+// Trajectory replacement //////////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(JointPartialTrajectoryControllerTest, topicReplacesTopicTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  traj.header.stamp = ros::Time(0); // Start immediately
+  traj_pub.publish(traj);
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory that preempts the previous one
+  traj_partial.header.stamp = ros::Time(0); // Start immediately
+  traj_pub.publish(traj_partial);
+  wait_duration = traj_partial.points.back().time_from_start + ros::Duration(0.5);
+  wait_duration.sleep(); // Wait until done
+
+  // Check that we're at the original trajectory for joint1 and on the partial trajectory for joint2
+  StateConstPtr state = getState();
+  EXPECT_NEAR(traj.points.back().positions[0],     state->desired.positions[0],     EPS);
+  EXPECT_NEAR(traj.points.back().velocities[0],    state->desired.velocities[0],    EPS);
+  EXPECT_NEAR(traj.points.back().accelerations[0], state->desired.accelerations[0], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+}
+
+TEST_F(JointPartialTrajectoryControllerTest, actionReplacesActionTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  traj_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory that preempts the previous one
+  traj_partial_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client2->sendGoal(traj_partial_goal);
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::ACTIVE,    short_timeout));
+  ASSERT_TRUE(waitForState(action_client,  SimpleClientGoalState::PREEMPTED, short_timeout));
+  //ROS_ERROR_STREAM("state: "<< action_client->getState().toString());
+
+  // Wait until done
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::SUCCEEDED, long_timeout));
+  ros::Duration(0.5).sleep(); // Allows values to settle to within EPS, especially accelerations
+
+  // Check that we're at the original trajectory for joint1 and on the partial trajectory for joint2
+  StateConstPtr state = getState();
+  EXPECT_NEAR(traj.points.back().positions[0],     state->desired.positions[0],     EPS);
+  EXPECT_NEAR(traj.points.back().velocities[0],    state->desired.velocities[0],    EPS);
+  EXPECT_NEAR(traj.points.back().accelerations[0], state->desired.accelerations[0], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+}
+
+TEST_F(JointPartialTrajectoryControllerTest, actionReplacesTopicTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  traj.header.stamp = ros::Time(0); // Start immediately
+  traj_pub.publish(traj);
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory that preempts the previous one
+  traj_partial_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_partial_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE,    short_timeout));
+
+  // Wait until done
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, long_timeout));
+  ros::Duration(0.5).sleep(); // Allows values to settle to within EPS, especially accelerations
+
+  // Check that we're at the original trajectory for joint1 and on the partial trajectory for joint2
+  StateConstPtr state = getState();
+  EXPECT_NEAR(traj.points.back().positions[0],     state->desired.positions[0],     EPS);
+  EXPECT_NEAR(traj.points.back().velocities[0],    state->desired.velocities[0],    EPS);
+  EXPECT_NEAR(traj.points.back().accelerations[0], state->desired.accelerations[0], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+}
+
+TEST_F(JointPartialTrajectoryControllerTest, topicReplacesActionTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  traj_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory that preempts the previous one
+  traj_partial.header.stamp = ros::Time(0); // Start immediately
+  traj_pub.publish(traj_partial);
+
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::PREEMPTED, short_timeout));
+
+  wait_duration = traj_partial.points.back().time_from_start + ros::Duration(0.5);
+  wait_duration.sleep(); // Wait until done
+
+  // Check that we're at the original trajectory for joint1 and on the partial trajectory for joint2
+  StateConstPtr state = getState();
+  EXPECT_NEAR(traj.points.back().positions[0],     state->desired.positions[0],     EPS);
+  EXPECT_NEAR(traj.points.back().velocities[0],    state->desired.velocities[0],    EPS);
+  EXPECT_NEAR(traj.points.back().accelerations[0], state->desired.accelerations[0], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+}
+
+// Ignore old trajectory points ////////////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(JointPartialTrajectoryControllerTest, ignoreOldTopicTraj)
+{
+  ASSERT_TRUE(initState());
+
+  // Send trajectory
+  traj.header.stamp = ros::Time(0); // Start immediately
+  traj_pub.publish(traj);
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory with all points occuring in the past. Should not preempts the previous one
+  traj_partial.header.stamp = ros::Time::now() - traj_partial.points.back().time_from_start - ros::Duration(0.5);
+  traj_pub.publish(traj_partial);
+
+  wait_duration = traj.points.back().time_from_start - traj.points.front().time_from_start + ros::Duration(0.5);
+  wait_duration.sleep(); // Wait until first trajectory is done
+
+  // Check that we're at the original trajectory end (Joint2 has not moved according to traj_partial)
+  StateConstPtr state = getState();
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    EXPECT_NEAR(traj.points.back().positions[i],     state->desired.positions[i],     EPS);
+    EXPECT_NEAR(traj.points.back().velocities[i],    state->desired.velocities[i],    EPS);
+    EXPECT_NEAR(traj.points.back().accelerations[i], state->desired.accelerations[i], EPS);
+  }
+}
+
+TEST_F(JointPartialTrajectoryControllerTest, ignoreOldActionTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  traj_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory with all points occuring in the past. Should not preempts the previous one
+  traj_partial_goal.trajectory.header.stamp = ros::Time::now() - traj_partial.points.back().time_from_start - ros::Duration(0.5);
+  action_client2->sendGoal(traj_partial_goal);
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::REJECTED,  short_timeout));
+
+  // Wait until done
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, long_timeout));
+  ros::Duration(0.5).sleep(); // Allows values to settle to within EPS, especially accelerations
+
+  // Check that we're at the original trajectory end (Joint2 has not moved according to traj_partial)
+  StateConstPtr state = getState();
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    EXPECT_NEAR(traj.points.back().positions[i],     state->desired.positions[i],     EPS);
+    EXPECT_NEAR(traj.points.back().velocities[i],    state->desired.velocities[i],    EPS);
+    EXPECT_NEAR(traj.points.back().accelerations[i], state->desired.accelerations[i], EPS);
+  }
+}
+
+TEST_F(JointPartialTrajectoryControllerTest, ignorePartiallyOldActionTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  ActionGoal first_goal = traj_goal;
+  first_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(first_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+
+  ros::Duration wait_duration = first_goal.trajectory.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory with only the last point not occuring in the past. Only the last point should be executed
+  traj_partial_goal.trajectory.header.stamp = ros::Time::now() - traj.points.back().time_from_start + ros::Duration(1.0);
+  action_client2->sendGoal(traj_partial_goal);
+  ASSERT_TRUE(waitForState(action_client,  SimpleClientGoalState::PREEMPTED, short_timeout));
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::ACTIVE,    short_timeout));
+
+  // Wait until done
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::SUCCEEDED, long_timeout));
+  ros::Duration(0.5).sleep(); // Allows values to settle to within EPS, especially accelerations
+
+  // Check that we're at the original trajectory for joint1 and on the partial trajectory for joint2
+  StateConstPtr state = getState();
+  EXPECT_NEAR(traj.points.back().positions[0],     state->desired.positions[0],     EPS);
+  EXPECT_NEAR(traj.points.back().velocities[0],    state->desired.velocities[0],    EPS);
+  EXPECT_NEAR(traj.points.back().accelerations[0], state->desired.accelerations[0], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+}
+
+TEST_F(JointPartialTrajectoryControllerTest, executeParitalActionTrajInFuture)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  ActionGoal first_goal = traj_goal;
+  first_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(first_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+
+  ros::Duration wait_duration = first_goal.trajectory.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send partial trajectory with only the last point not occuring in the past. Only the last point should be executed
+  traj_partial_goal.trajectory.header.stamp = ros::Time::now() + traj.points.back().time_from_start + ros::Duration(2.0);
+  action_client2->sendGoal(traj_partial_goal);
+  ASSERT_TRUE(waitForState(action_client,  SimpleClientGoalState::PREEMPTED, short_timeout));
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::ACTIVE,    short_timeout));
+
+  // Wait until first traj is done
+  wait_duration = first_goal.trajectory.points.back().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  StateConstPtr state = getState();
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    EXPECT_NEAR(traj.points.back().positions[i],     state->desired.positions[i],     EPS);
+    EXPECT_NEAR(traj.points.back().velocities[i],    state->desired.velocities[i],    EPS);
+    EXPECT_NEAR(traj.points.back().accelerations[i], state->desired.accelerations[i], EPS);
+  }
+
+  // Wait until done
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::SUCCEEDED, long_timeout));
+  ros::Duration(0.5).sleep(); // Allows values to settle to within EPS, especially accelerations
+
+  // Check that we're at the original trajectory for joint1 and on the partial trajectory for joint2
+  state = getState();
+  EXPECT_NEAR(traj.points.back().positions[0],     state->desired.positions[0],     EPS);
+  EXPECT_NEAR(traj.points.back().velocities[0],    state->desired.velocities[0],    EPS);
+  EXPECT_NEAR(traj.points.back().accelerations[0], state->desired.accelerations[0], EPS);
+
+  EXPECT_NEAR(traj_partial.points.back().positions[0],     state->desired.positions[1],     EPS);
+  EXPECT_NEAR(traj_partial.points.back().velocities[0],    state->desired.velocities[1],    EPS);
+  EXPECT_NEAR(traj_partial.points.back().accelerations[0], state->desired.accelerations[1], EPS);
+}
+
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "joint_partial_trajectory_controller_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -28,15 +28,8 @@
         args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
 
   <!-- Controller test -->
-  <!--
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="30.0"/-->
-
-  <node name="joint_trajectory_controller_test"
-        pkg="joint_trajectory_controller"
-        type="joint_trajectory_controller_test" output="screen" />
-        
-
+        time-limit="80.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -28,8 +28,15 @@
         args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
 
   <!-- Controller test -->
+  <!--
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="80.0"/>
+        time-limit="30.0"/-->
+
+  <node name="joint_trajectory_controller_test"
+        pkg="joint_trajectory_controller"
+        type="joint_trajectory_controller_test" output="screen" />
+        
+
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -112,6 +112,7 @@ public:
     const std::string action_server_name = nh.getNamespace() + "/follow_joint_trajectory";
     action_client.reset(new ActionClient(action_server_name));
     action_client2.reset(new ActionClient(action_server_name));
+    ROS_INFO("**********JointTrajectoryControllerTest finished!!!");
   }
 
   ~JointTrajectoryControllerTest()
@@ -152,18 +153,21 @@ protected:
 
   void stateCB(const StateConstPtr& state)
   {
+    //ROS_INFO("**********stateCB!!!");
     boost::mutex::scoped_lock lock(mutex);
     controller_state = state;
   }
 
   StateConstPtr getState()
   {
+    //ROS_INFO("**********stateCB!!!");
     boost::mutex::scoped_lock lock(mutex);
     return controller_state;
   }
 
   bool initState(const ros::Duration& timeout = ros::Duration(5.0))
   {
+    //ROS_INFO("**********initState!!!");
     bool init_ok = false;
     ros::Time start_time = ros::Time::now();
     while (!init_ok && (ros::Time::now() - start_time) < timeout)
@@ -181,6 +185,7 @@ protected:
                            const actionlib::SimpleClientGoalState& state,
                            const ros::Duration& timeout)
   {
+    //ROS_INFO("**********waitForState!!!");
     using ros::Time;
     using ros::Duration;
 
@@ -248,7 +253,7 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
   ASSERT_TRUE(initState());
   ASSERT_TRUE(action_client->waitForServer(long_timeout));
 
-  // Invalid size
+  // Invalid size => Now this is possible. Partial trajectory
   {
     trajectory_msgs::JointTrajectoryPoint point;
     point.positions.resize(1, 0.0);
@@ -264,8 +269,7 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
 
     bad_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
     action_client->sendGoal(bad_goal);
-    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
-    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS);
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, long_timeout));
   }
 
   // Incompatible joint names
@@ -291,7 +295,7 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
   }
 
   // Incompatible data sizes
-  {
+  /*{
     ActionGoal bad_goal = traj_home_goal;
     bad_goal.trajectory.points[0].positions.pop_back();
 
@@ -299,10 +303,10 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
     action_client->sendGoal(bad_goal);
     ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
     EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_GOAL);
-  }
+  }*/
 
   // Non-strictly increasing waypoint times
-  {
+  /*  {
     ActionGoal bad_goal = traj_goal;
     bad_goal.trajectory.points[2].time_from_start = bad_goal.trajectory.points[1].time_from_start;
 
@@ -319,12 +323,12 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
     action_client->sendGoal(empty_goal);
     ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
     EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS);
-  }
+  }*/
 }
 
 // Uninterrupted trajectory execution //////////////////////////////////////////////////////////////////////////////////
 
-TEST_F(JointTrajectoryControllerTest, topicSingleTraj)
+/*TEST_F(JointTrajectoryControllerTest, topicSingleTraj)
 {
   ASSERT_TRUE(initState());
 
@@ -924,13 +928,13 @@ TEST_F(JointTrajectoryControllerTest, goalToleranceViolation)
     smoothing_pub.publish(smoothing);
     ros::Duration(0.5).sleep();
   }
-}
+}*/
 
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "joint_trajectory_controller_test");
-
+  ROS_WARN("**********Main!!!");
   ros::AsyncSpinner spinner(1);
   spinner.start();
   int ret = RUN_ALL_TESTS();

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -112,7 +112,6 @@ public:
     const std::string action_server_name = nh.getNamespace() + "/follow_joint_trajectory";
     action_client.reset(new ActionClient(action_server_name));
     action_client2.reset(new ActionClient(action_server_name));
-    ROS_INFO("**********JointTrajectoryControllerTest finished!!!");
   }
 
   ~JointTrajectoryControllerTest()
@@ -153,21 +152,18 @@ protected:
 
   void stateCB(const StateConstPtr& state)
   {
-    //ROS_INFO("**********stateCB!!!");
     boost::mutex::scoped_lock lock(mutex);
     controller_state = state;
   }
 
   StateConstPtr getState()
   {
-    //ROS_INFO("**********stateCB!!!");
     boost::mutex::scoped_lock lock(mutex);
     return controller_state;
   }
 
   bool initState(const ros::Duration& timeout = ros::Duration(5.0))
   {
-    //ROS_INFO("**********initState!!!");
     bool init_ok = false;
     ros::Time start_time = ros::Time::now();
     while (!init_ok && (ros::Time::now() - start_time) < timeout)
@@ -185,7 +181,6 @@ protected:
                            const actionlib::SimpleClientGoalState& state,
                            const ros::Duration& timeout)
   {
-    //ROS_INFO("**********waitForState!!!");
     using ros::Time;
     using ros::Duration;
 
@@ -295,7 +290,7 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
   }
 
   // Incompatible data sizes
-  /*{
+  {
     ActionGoal bad_goal = traj_home_goal;
     bad_goal.trajectory.points[0].positions.pop_back();
 
@@ -303,10 +298,10 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
     action_client->sendGoal(bad_goal);
     ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
     EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_GOAL);
-  }*/
+  }
 
   // Non-strictly increasing waypoint times
-  /*  {
+  {
     ActionGoal bad_goal = traj_goal;
     bad_goal.trajectory.points[2].time_from_start = bad_goal.trajectory.points[1].time_from_start;
 
@@ -323,12 +318,12 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
     action_client->sendGoal(empty_goal);
     ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
     EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS);
-  }*/
+  }
 }
 
 // Uninterrupted trajectory execution //////////////////////////////////////////////////////////////////////////////////
 
-/*TEST_F(JointTrajectoryControllerTest, topicSingleTraj)
+TEST_F(JointTrajectoryControllerTest, topicSingleTraj)
 {
   ASSERT_TRUE(initState());
 
@@ -928,13 +923,13 @@ TEST_F(JointTrajectoryControllerTest, goalToleranceViolation)
     smoothing_pub.publish(smoothing);
     ros::Duration(0.5).sleep();
   }
-}*/
+}
 
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   ros::init(argc, argv, "joint_trajectory_controller_test");
-  ROS_WARN("**********Main!!!");
+
   ros::AsyncSpinner spinner(1);
   spinner.start();
   int ret = RUN_ALL_TESTS();

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -248,7 +248,7 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
   ASSERT_TRUE(initState());
   ASSERT_TRUE(action_client->waitForServer(long_timeout));
 
-  // Invalid size => Now this is possible. Partial trajectory
+  // Invalid size (No partial joints goals allowed)
   {
     trajectory_msgs::JointTrajectoryPoint point;
     point.positions.resize(1, 0.0);
@@ -264,7 +264,8 @@ TEST_F(JointTrajectoryControllerTest, invalidMessages)
 
     bad_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
     action_client->sendGoal(bad_goal);
-    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, long_timeout));
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED, long_timeout));
+    EXPECT_EQ(action_client->getResult()->error_code, control_msgs::FollowJointTrajectoryResult::INVALID_JOINTS);
   }
 
   // Incompatible joint names

--- a/joint_trajectory_controller/test/joint_trajectory_segment_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_segment_test.cpp
@@ -237,28 +237,11 @@ TEST_F(JointTrajectorySegmentTest, InvalidSegmentConstruction)
     catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
   }
 
-  // Invalid mapping vector size
-  {
-    MappingType mapping(2, 1);
-    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, mapping), std::invalid_argument);
-    try {Segment(traj_start_time, p_start, p_end, mapping);}
-    catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
-  }
-
-  // Invalid mapping vector indices
-  {
-    MappingType mapping(1, 1);
-    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, mapping), std::invalid_argument);
-    try {Segment(traj_start_time, p_start, p_end, mapping);}
-    catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
-  }
-
   // Invalid joint wraparound specification
   {
-    MappingType mapping;
     std::vector<double> pos_offset(2);
-    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, mapping, pos_offset), std::invalid_argument);
-    try {Segment(traj_start_time, p_start, p_end, mapping, pos_offset);}
+    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, pos_offset), std::invalid_argument);
+    try {Segment(traj_start_time, p_start, p_end, pos_offset);}
     catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
   }
 }
@@ -390,42 +373,6 @@ TEST_F(JointTrajectorySegmentTest, MappingTest)
     segment.sample(segment.startTime(), state);
     EXPECT_EQ(p_start.positions[0], state.position[0]);
     EXPECT_EQ(p_start.positions[1], state.position[1]);
-  }
-
-  // Mapping vector preserving trajectory message joint order
-  {
-    MappingType mapping(2);
-    mapping[0] = 0;
-    mapping[1] = 1;
-
-    // Construct segment from ROS message
-    EXPECT_NO_THROW(Segment(traj_start_time, p_start, p_end, mapping));
-    Segment segment(traj_start_time, p_start, p_end, mapping);
-
-    // Check position values of start state only
-    typename Segment::State state;
-    segment.sample(segment.startTime(), state);
-    EXPECT_EQ(p_start.positions[0], state.position[0]);
-    EXPECT_EQ(p_start.positions[1], state.position[1]);
-  }
-
-  // Mapping vector reversing trajectory message joint order
-  {
-    MappingType mapping(2);
-    mapping[0] = 1;
-    mapping[1] = 0;
-
-    // Construct segment from ROS message
-    EXPECT_NO_THROW(Segment(traj_start_time, p_start, p_end, mapping));
-    Segment segment(traj_start_time, p_start, p_end, mapping);
-
-    // Check position values of start state only
-    typename Segment::State state;
-    segment.sample(segment.startTime(), state);
-    EXPECT_NE(p_start.positions[0], state.position[0]);
-    EXPECT_NE(p_start.positions[1], state.position[1]);
-    EXPECT_EQ(p_start.positions[0], state.position[1]);
-    EXPECT_EQ(p_start.positions[1], state.position[0]);
   }
 }
 

--- a/joint_trajectory_controller/test/joint_trajectory_segment_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_segment_test.cpp
@@ -60,10 +60,10 @@ TEST(WraparoundOffsetTest, WrappingPositions)
   // No wrapping joints
   {
     std::vector<bool> angle_wraparound(2, false);
-    std::vector<double> wraparound_offset = wraparoundOffset(pos1, pos2, angle_wraparound);
-    EXPECT_NEAR(pos1.size(), wraparound_offset.size(), EPS);
-    EXPECT_NEAR(0.0, wraparound_offset[0], EPS);
-    EXPECT_NEAR(0.0, wraparound_offset[1], EPS);
+    double wraparound_offset1 = wraparoundJointOffset(pos1[0], pos2[0], angle_wraparound[0]);
+    double wraparound_offset2 = wraparoundJointOffset(pos1[1], pos2[1], angle_wraparound[1]);
+    EXPECT_NEAR(0.0, wraparound_offset1, EPS);
+    EXPECT_NEAR(0.0, wraparound_offset2, EPS);
   }
 
   // Single wrapping joint
@@ -74,18 +74,18 @@ TEST(WraparoundOffsetTest, WrappingPositions)
 
     // From state1 to state2
     {
-      std::vector<double> wraparound_offset = wraparoundOffset<double>(pos1, pos2, angle_wraparound);
-      EXPECT_NEAR(pos1.size(), wraparound_offset.size(), EPS);
-      EXPECT_NEAR(-two_pi, wraparound_offset[0], EPS);
-      EXPECT_NEAR(0.0, wraparound_offset[1], EPS);
+      double wraparound_offset1 = wraparoundJointOffset(pos1[0], pos2[0], angle_wraparound[0]);
+      double wraparound_offset2 = wraparoundJointOffset(pos1[1], pos2[1], angle_wraparound[1]);
+      EXPECT_NEAR(-two_pi, wraparound_offset1, EPS);
+      EXPECT_NEAR(0.0, wraparound_offset2, EPS);
     }
 
     // From state2 to state1
     {
-      std::vector<double> wraparound_offset = wraparoundOffset<double>(pos2, pos1, angle_wraparound);
-      EXPECT_NEAR(pos1.size(), wraparound_offset.size(), EPS);
-      EXPECT_NEAR(two_pi, wraparound_offset[0], EPS);
-      EXPECT_NEAR(0.0, wraparound_offset[1], EPS);
+      double wraparound_offset1 = wraparoundJointOffset(pos2[0], pos1[0], angle_wraparound[0]);
+      double wraparound_offset2 = wraparoundJointOffset(pos2[1], pos1[1], angle_wraparound[1]);
+      EXPECT_NEAR(two_pi, wraparound_offset1, EPS);
+      EXPECT_NEAR(0.0, wraparound_offset2, EPS);
     }
   }
 
@@ -95,18 +95,18 @@ TEST(WraparoundOffsetTest, WrappingPositions)
 
     // From state1 to state2
     {
-      std::vector<double> wraparound_offset = wraparoundOffset<double>(pos1, pos2, angle_wraparound);
-      EXPECT_NEAR(pos1.size(), wraparound_offset.size(), EPS);
-      EXPECT_NEAR(-two_pi, wraparound_offset[0], EPS);
-      EXPECT_NEAR(-2.0 * two_pi, wraparound_offset[1], EPS);
+      double wraparound_offset1 = wraparoundJointOffset(pos1[0], pos2[0], angle_wraparound[0]);
+      double wraparound_offset2 = wraparoundJointOffset(pos1[1], pos2[1], angle_wraparound[1]);
+      EXPECT_NEAR(-two_pi, wraparound_offset1, EPS);
+      EXPECT_NEAR(-2.0 * two_pi, wraparound_offset2, EPS);
     }
 
     // From state2 to state1
     {
-      std::vector<double> wraparound_offset = wraparoundOffset<double>(pos2, pos1, angle_wraparound);
-      EXPECT_NEAR(pos1.size(), wraparound_offset.size(), EPS);
-      EXPECT_NEAR(two_pi, wraparound_offset[0], EPS);
-      EXPECT_NEAR(2.0 * two_pi, wraparound_offset[1], EPS);
+      double wraparound_offset1 = wraparoundJointOffset(pos2[0], pos1[0], angle_wraparound[0]);
+      double wraparound_offset2 = wraparoundJointOffset(pos2[1], pos1[1], angle_wraparound[1]);
+      EXPECT_NEAR(two_pi, wraparound_offset1, EPS);
+      EXPECT_NEAR(2.0 * two_pi, wraparound_offset2, EPS);
     }
   }
 }
@@ -122,16 +122,14 @@ TEST(WraparoundOffsetTest, WrappingPositionsPiSingularity)
   std::vector<bool> angle_wraparound(1, true);
   // From state1 to state2
   {
-    std::vector<double> wraparound_offset = wraparoundOffset<double>(pos1, pos2, angle_wraparound);
-    EXPECT_EQ(pos1.size(), wraparound_offset.size());
-    EXPECT_NEAR(0.0, wraparound_offset[0], EPS);
+    double wraparound_offset1 = wraparoundJointOffset(pos1[0], pos2[0], angle_wraparound[0]);
+    EXPECT_NEAR(0.0, wraparound_offset1, EPS);
   }
 
   // From state2 to state1
   {
-    std::vector<double> wraparound_offset = wraparoundOffset<double>(pos2, pos1, angle_wraparound);
-    EXPECT_EQ(pos1.size(), wraparound_offset.size());
-    EXPECT_NEAR(0.0, wraparound_offset[0], EPS);
+    double wraparound_offset1 = wraparoundJointOffset(pos2[0], pos1[0], angle_wraparound[0]);
+    EXPECT_NEAR(0.0, wraparound_offset1, EPS);
   }
 }
 
@@ -154,18 +152,18 @@ TEST(WraparoundOffsetTest, NonWrappingPositions)
 
     // From state1 to state2
     {
-      std::vector<double> wraparound_offset = wraparoundOffset<double>(pos1, pos2, angle_wraparound);
-      EXPECT_NEAR(pos1.size(), wraparound_offset.size(), EPS);
-      EXPECT_NEAR(0.0, wraparound_offset[0], EPS);
-      EXPECT_NEAR(0.0, wraparound_offset[1], EPS);
+      double wraparound_offset1 = wraparoundJointOffset(pos1[0], pos2[0], angle_wraparound[0]);
+      double wraparound_offset2 = wraparoundJointOffset(pos1[1], pos2[1], angle_wraparound[1]);
+      EXPECT_NEAR(0.0, wraparound_offset1, EPS);
+      EXPECT_NEAR(0.0, wraparound_offset2, EPS);
     }
 
     // From state2 to state1
     {
-      std::vector<double> wraparound_offset = wraparoundOffset<double>(pos2, pos1, angle_wraparound);
-      EXPECT_NEAR(pos1.size(), wraparound_offset.size(), EPS);
-      EXPECT_NEAR(0.0, wraparound_offset[0], EPS);
-      EXPECT_NEAR(0.0, wraparound_offset[1], EPS);
+      double wraparound_offset1 = wraparoundJointOffset(pos2[0], pos1[0], angle_wraparound[0]);
+      double wraparound_offset2 = wraparoundJointOffset(pos2[1], pos1[1], angle_wraparound[1]);
+      EXPECT_NEAR(0.0, wraparound_offset1, EPS);
+      EXPECT_NEAR(0.0, wraparound_offset2, EPS);
     }
   }
 }

--- a/joint_trajectory_controller/test/joint_trajectory_segment_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_segment_test.cpp
@@ -41,7 +41,7 @@ using namespace trajectory_msgs;
 const double EPS = 1e-9;
 
 typedef JointTrajectorySegment<trajectory_interface::QuinticSplineSegment<double> > Segment;
-typedef std::vector<unsigned int> PermutationType;
+typedef std::vector<unsigned int> MappingType;
 
 TEST(WraparoundOffsetTest, WrappingPositions)
 {
@@ -237,28 +237,28 @@ TEST_F(JointTrajectorySegmentTest, InvalidSegmentConstruction)
     catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
   }
 
-  // Invalid permutation vector size
+  // Invalid mapping vector size
   {
-    PermutationType permutation(2, 1);
-    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, permutation), std::invalid_argument);
-    try {Segment(traj_start_time, p_start, p_end, permutation);}
+    MappingType mapping(2, 1);
+    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, mapping), std::invalid_argument);
+    try {Segment(traj_start_time, p_start, p_end, mapping);}
     catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
   }
 
-  // Invalid permutation vector indices
+  // Invalid mapping vector indices
   {
-    PermutationType permutation(1, 1);
-    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, permutation), std::invalid_argument);
-    try {Segment(traj_start_time, p_start, p_end, permutation);}
+    MappingType mapping(1, 1);
+    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, mapping), std::invalid_argument);
+    try {Segment(traj_start_time, p_start, p_end, mapping);}
     catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
   }
 
   // Invalid joint wraparound specification
   {
-    PermutationType permutation;
+    MappingType mapping;
     std::vector<double> pos_offset(2);
-    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, permutation, pos_offset), std::invalid_argument);
-    try {Segment(traj_start_time, p_start, p_end, permutation, pos_offset);}
+    EXPECT_THROW(Segment(traj_start_time, p_start, p_end, mapping, pos_offset), std::invalid_argument);
+    try {Segment(traj_start_time, p_start, p_end, mapping, pos_offset);}
     catch (const std::invalid_argument& ex) {ROS_ERROR_STREAM(ex.what());}
   }
 }
@@ -370,7 +370,7 @@ TEST_F(JointTrajectorySegmentTest, CrossValidateSegmentConstruction)
 }
 
 // TODO: Test with dimension four data
-TEST_F(JointTrajectorySegmentTest, PermutationTest)
+TEST_F(JointTrajectorySegmentTest, MappingTest)
 {
   // Add an extra joint to the trajectory point messages created in the fixture
   p_start.positions.push_back(-p_start.positions[0]);
@@ -379,7 +379,7 @@ TEST_F(JointTrajectorySegmentTest, PermutationTest)
   p_end.positions.push_back(-p_end.positions[0]);
   p_end.velocities.push_back(-p_end.velocities[0]);
 
-  // No permutation vector
+  // No mapping vector
   {
     // Construct segment from ROS message
     EXPECT_NO_THROW(Segment(traj_start_time, p_start, p_end));
@@ -392,15 +392,15 @@ TEST_F(JointTrajectorySegmentTest, PermutationTest)
     EXPECT_EQ(p_start.positions[1], state.position[1]);
   }
 
-  // Permutation vector preserving trajectory message joint order
+  // Mapping vector preserving trajectory message joint order
   {
-    PermutationType permutation(2);
-    permutation[0] = 0;
-    permutation[1] = 1;
+    MappingType mapping(2);
+    mapping[0] = 0;
+    mapping[1] = 1;
 
     // Construct segment from ROS message
-    EXPECT_NO_THROW(Segment(traj_start_time, p_start, p_end, permutation));
-    Segment segment(traj_start_time, p_start, p_end, permutation);
+    EXPECT_NO_THROW(Segment(traj_start_time, p_start, p_end, mapping));
+    Segment segment(traj_start_time, p_start, p_end, mapping);
 
     // Check position values of start state only
     typename Segment::State state;
@@ -409,15 +409,15 @@ TEST_F(JointTrajectorySegmentTest, PermutationTest)
     EXPECT_EQ(p_start.positions[1], state.position[1]);
   }
 
-  // Permutation vector reversing trajectory message joint order
+  // Mapping vector reversing trajectory message joint order
   {
-    PermutationType permutation(2);
-    permutation[0] = 1;
-    permutation[1] = 0;
+    MappingType mapping(2);
+    mapping[0] = 1;
+    mapping[1] = 0;
 
     // Construct segment from ROS message
-    EXPECT_NO_THROW(Segment(traj_start_time, p_start, p_end, permutation));
-    Segment segment(traj_start_time, p_start, p_end, permutation);
+    EXPECT_NO_THROW(Segment(traj_start_time, p_start, p_end, mapping));
+    Segment segment(traj_start_time, p_start, p_end, mapping);
 
     // Check position values of start state only
     typename Segment::State state;

--- a/joint_trajectory_controller/test/rrbot_partial_controllers.yaml
+++ b/joint_trajectory_controller/test/rrbot_partial_controllers.yaml
@@ -1,0 +1,15 @@
+rrbot_controller:
+  type: "position_controllers/JointTrajectoryController"
+  joints:
+    - joint1
+    - joint2
+
+  constraints:
+    goal_time: 0.5
+    joint1:
+      goal:       0.01
+      trajectory: 0.05
+    joint2:
+      goal:       0.01
+      trajectory: 0.05
+  allow_partial_joints_goal: true


### PR DESCRIPTION
Enables the control of partial trajectories. In order to do this, a trajectory now is composed of a vector of vectors of segments (one vector of segments per each joint), so each joint can a vector with different number of segments. 

The changes of code are the minimum I could modify to make it work. If the changes are accepted, we can improve it. Specially, the definition of a segment, as it is only per joint, it does not need a permutation vector, and all its related methods.

All test are passing, but I had to modify some of them to the new implementation. If it is accepted, we can think of new test needed specifically to test partial trajectories.
