### PR TITLE
Base class for ForwardJointGroupCommandController

### DIFF
--- a/effort_controllers/src/joint_group_effort_controller.cpp
+++ b/effort_controllers/src/joint_group_effort_controller.cpp
@@ -38,12 +38,4 @@
 #include <effort_controllers/joint_group_effort_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-template <class T>
-void forward_command_controller::ForwardJointGroupCommandController<T>::starting(const ros::Time& time)
-{
-  // Start controller with 0.0 efforts
-  commands_buffer_.readFromRT()->assign(n_joints_, 0.0);
-}
-
-
 PLUGINLIB_EXPORT_CLASS(effort_controllers::JointGroupEffortController,controller_interface::ControllerBase)

--- a/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
@@ -117,14 +117,14 @@ protected:
   unsigned int n_joints_;
 };
 
-template <> void ForwardJointGroupCommandControllerBase<hardware_interface::EffortJointInterface>::starting(const ros::Time& time)
+template <> inline void ForwardJointGroupCommandControllerBase<hardware_interface::EffortJointInterface>::starting(const ros::Time& time)
 {
   // Start controller with 0.0 efforts
   this->commands_buffer_.readFromRT()->assign(this->n_joints_, 0.0);
 }
 
 
-template <> void ForwardJointGroupCommandControllerBase<hardware_interface::PositionJointInterface>::starting(const ros::Time& time)
+template <> inline void ForwardJointGroupCommandControllerBase<hardware_interface::PositionJointInterface>::starting(const ros::Time& time)
 {
   // Start controller with current joint positions
   std::vector<double> & commands = *this->commands_buffer_.readFromRT();
@@ -134,7 +134,7 @@ template <> void ForwardJointGroupCommandControllerBase<hardware_interface::Posi
   }
 }
 
-template <> void ForwardJointGroupCommandControllerBase<hardware_interface::VelocityJointInterface>::starting(const ros::Time& time)
+template <> inline void ForwardJointGroupCommandControllerBase<hardware_interface::VelocityJointInterface>::starting(const ros::Time& time)
 {
   // Start controller with 0.0 velocities
   this->commands_buffer_.readFromRT()->assign(this->n_joints_, 0.0);

--- a/position_controllers/src/joint_group_position_controller.cpp
+++ b/position_controllers/src/joint_group_position_controller.cpp
@@ -38,16 +38,4 @@
 #include <position_controllers/joint_group_position_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-template <class T>
-void forward_command_controller::ForwardJointGroupCommandController<T>::starting(const ros::Time& time)
-{
-  // Start controller with current joint positions
-  std::vector<double> & commands = *commands_buffer_.readFromRT();
-  for(unsigned int i=0; i<joints_.size(); i++)
-  {
-    commands[i]=joints_[i].getPosition();
-  }
-}
-
-
 PLUGINLIB_EXPORT_CLASS(position_controllers::JointGroupPositionController,controller_interface::ControllerBase)

--- a/velocity_controllers/src/joint_group_velocity_controller.cpp
+++ b/velocity_controllers/src/joint_group_velocity_controller.cpp
@@ -38,12 +38,4 @@
 #include <velocity_controllers/joint_group_velocity_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-template <class T>
-void forward_command_controller::ForwardJointGroupCommandController<T>::starting(const ros::Time& time)
-{
-  // Start controller with 0.0 velocities
-  commands_buffer_.readFromRT()->assign(n_joints_, 0.0);
-}
-
-
 PLUGINLIB_EXPORT_CLASS(velocity_controllers::JointGroupVelocityController,controller_interface::ControllerBase)


### PR DESCRIPTION
As discussed in #184 this patch introduces a base class for ForwardJointGroupCommandController that allows subclassing for various ROS interface types.
- added virtual specifiers to outline the (implicitly) virtual member functions
- all base class data members are protected (instead of public)

I had to move the starting function definitions into the header, but migrated them to template specializations. If needed the implementation could be moved into a library.
