### PR TITLE
Fix missing trajectory segment bug, removed deprecated code

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -146,7 +146,7 @@ struct InitJointTrajectoryOptions
  * a pointer to it, and to the trajectory tolerances it contains (if any).
  *
  * - \b default_tolerances Default trajectory tolerances. This option is only used when \p rt_goal_handle is also
- * specified. It contains the default tolernaces to check when executing an action goal. If the action goal specifies
+ * specified. It contains the default tolerances to check when executing an action goal. If the action goal specifies
  * tolerances (totally or partially), these values will take precedence over the defaults.
  *
  * - \b other_time_base When initializing a new trajectory, it might be the case that we desire the result expressed in

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -458,7 +458,8 @@ updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePt
   static int total_count = 0;
   total_latency += latency;
   total_count++;
-  std::cout << "Msg Latency: " << latency << " Average: " << total_latency / total_count << std::endl;
+  const double average = total_latency / total_count;
+  ROS_INFO_STREAM_THROTTLE_NAMED(1, name_, "Msg Latency: " << latency << " Average: " << average);
 #endif
     // ----------------------------------------------------
 


### PR DESCRIPTION
This has the fix created by @otamachan as discussed in https://github.com/ros-controls/ros_controllers/issues/143 where he says:

> I looked at the joint_trajectory_controller code and I found that the start time of the first trajectory segment is calculated using the previous period. This might cause that the start time of the first trajectory is later than the next sample time when the previous period is longer(even 1us) than the current period because of the jitter. And this leads to the above error.

I ran his fix overnight with continuous trajectory interruption and the error did not occur again.

I've also removed a code block that was intended to be removed in indigo, and I added a section for optionally measuring message latency in actionlib using compiler flags.
