### PR TITLE
Add antiwindup to get/setGains methods of jointPosition and jointVelocity controllers

### DIFF
--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -138,7 +138,7 @@ public:
   /**
    * \brief Get the PID parameters
    */
-  void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+  void getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup);
 
   /**
    * \brief Print debug info to console
@@ -148,7 +148,7 @@ public:
   /**
    * \brief Get the PID parameters
    */
-  void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min);
+  void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min, const bool &antiwindup = false);
 
   /**
    * \brief Get the name of the joint this controller uses

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -138,6 +138,11 @@ public:
   /**
    * \brief Get the PID parameters
    */
+  void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+
+  /**
+   * \brief Get the PID parameters
+   */
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup);
 
   /**

--- a/effort_controllers/include/effort_controllers/joint_velocity_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_velocity_controller.h
@@ -123,7 +123,7 @@ public:
   /**
    * \brief Get the PID parameters
    */
-  void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+  void getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup);
 
   /**
    * \brief Print debug info to console
@@ -133,7 +133,7 @@ public:
   /**
    * \brief Get the PID parameters
    */
-  void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min);
+  void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min, const bool &antiwindup = false);
 
   /**
    * \brief Get the name of the joint this controller uses

--- a/effort_controllers/include/effort_controllers/joint_velocity_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_velocity_controller.h
@@ -123,6 +123,11 @@ public:
   /**
    * \brief Get the PID parameters
    */
+  void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+
+  /**
+   * \brief Get the PID parameters
+   */
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup);
 
   /**

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -58,7 +58,7 @@ bool JointPositionController::init(hardware_interface::EffortJointInterface *rob
 {
   // Get joint name from parameter server
   std::string joint_name;
-  if (!n.getParam("joint", joint_name)) 
+  if (!n.getParam("joint", joint_name))
   {
     ROS_ERROR("No joint given (namespace: %s)", n.getNamespace().c_str());
     return false;
@@ -95,14 +95,14 @@ bool JointPositionController::init(hardware_interface::EffortJointInterface *rob
   return true;
 }
 
-void JointPositionController::setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min)
+void JointPositionController::setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min, const bool &antiwindup)
 {
-  pid_controller_.setGains(p,i,d,i_max,i_min);
+  pid_controller_.setGains(p,i,d,i_max,i_min,antiwindup);
 }
 
-void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
+void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup)
 {
-  pid_controller_.getGains(p,i,d,i_max,i_min);
+  pid_controller_.getGains(p,i,d,i_max,i_min,antiwindup);
 }
 
 void JointPositionController::printDebug()
@@ -224,11 +224,14 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
       controller_state_publisher_->msg_.command = commanded_effort;
 
       double dummy;
+      bool antiwindup;
       getGains(controller_state_publisher_->msg_.p,
         controller_state_publisher_->msg_.i,
         controller_state_publisher_->msg_.d,
         controller_state_publisher_->msg_.i_clamp,
-        dummy);
+        dummy,
+        antiwindup);
+      controller_state_publisher_->msg_.antiwindup = static_cast<char>(antiwindup);
       controller_state_publisher_->unlockAndPublish();
     }
   }

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -105,6 +105,12 @@ void JointPositionController::getGains(double &p, double &i, double &d, double &
   pid_controller_.getGains(p,i,d,i_max,i_min,antiwindup);
 }
 
+void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
+{
+  bool dummy;
+  pid_controller_.getGains(p,i,d,i_max,i_min,dummy);
+}
+
 void JointPositionController::printDebug()
 {
   pid_controller_.printValues();

--- a/effort_controllers/src/joint_velocity_controller.cpp
+++ b/effort_controllers/src/joint_velocity_controller.cpp
@@ -86,16 +86,14 @@ bool JointVelocityController::init(hardware_interface::EffortJointInterface *rob
   return true;
 }
 
-
-void JointVelocityController::setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min)
+void JointVelocityController::setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min, const bool &antiwindup)
 {
-  pid_controller_.setGains(p,i,d,i_max,i_min);
-
+  pid_controller_.setGains(p,i,d,i_max,i_min,antiwindup);
 }
 
-void JointVelocityController::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
+void JointVelocityController::getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup)
 {
-  pid_controller_.getGains(p,i,d,i_max,i_min);
+  pid_controller_.getGains(p,i,d,i_max,i_min,antiwindup);
 }
 
 void JointVelocityController::printDebug()
@@ -149,11 +147,14 @@ void JointVelocityController::update(const ros::Time& time, const ros::Duration&
       controller_state_publisher_->msg_.command = commanded_effort;
 
       double dummy;
+      bool antiwindup;
       getGains(controller_state_publisher_->msg_.p,
-               controller_state_publisher_->msg_.i,
-               controller_state_publisher_->msg_.d,
-               controller_state_publisher_->msg_.i_clamp,
-               dummy);
+        controller_state_publisher_->msg_.i,
+        controller_state_publisher_->msg_.d,
+        controller_state_publisher_->msg_.i_clamp,
+        dummy,
+        antiwindup);
+      controller_state_publisher_->msg_.antiwindup = static_cast<char>(antiwindup);
       controller_state_publisher_->unlockAndPublish();
     }
   }

--- a/effort_controllers/src/joint_velocity_controller.cpp
+++ b/effort_controllers/src/joint_velocity_controller.cpp
@@ -96,6 +96,12 @@ void JointVelocityController::getGains(double &p, double &i, double &d, double &
   pid_controller_.getGains(p,i,d,i_max,i_min,antiwindup);
 }
 
+void JointVelocityController::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
+{
+  bool dummy;
+  pid_controller_.getGains(p,i,d,i_max,i_min,dummy);
+}
+
 void JointVelocityController::printDebug()
 {
   pid_controller_.printValues();

--- a/velocity_controllers/include/velocity_controllers/joint_position_controller.h
+++ b/velocity_controllers/include/velocity_controllers/joint_position_controller.h
@@ -145,7 +145,7 @@ public:
   /**
    * \brief Get the PID parameters
    */
-  void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+  void getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup);
 
   /**
    * \brief Print debug info to console
@@ -155,7 +155,7 @@ public:
   /**
    * \brief Get the PID parameters
    */
-  void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min);
+  void setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min, const bool &antiwindup = false);
 
   /**
    * \brief Get the name of the joint this controller uses

--- a/velocity_controllers/include/velocity_controllers/joint_position_controller.h
+++ b/velocity_controllers/include/velocity_controllers/joint_position_controller.h
@@ -145,6 +145,11 @@ public:
   /**
    * \brief Get the PID parameters
    */
+  void getGains(double &p, double &i, double &d, double &i_max, double &i_min);
+
+  /**
+   * \brief Get the PID parameters
+   */
   void getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup);
 
   /**

--- a/velocity_controllers/src/joint_position_controller.cpp
+++ b/velocity_controllers/src/joint_position_controller.cpp
@@ -96,14 +96,14 @@ bool JointPositionController::init(hardware_interface::VelocityJointInterface *r
   return true;
 }
 
-void JointPositionController::setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min)
+void JointPositionController::setGains(const double &p, const double &i, const double &d, const double &i_max, const double &i_min, const bool &antiwindup)
 {
-  pid_controller_.setGains(p,i,d,i_max,i_min);
+  pid_controller_.setGains(p,i,d,i_max,i_min,antiwindup);
 }
 
-void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
+void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup)
 {
-  pid_controller_.getGains(p,i,d,i_max,i_min);
+  pid_controller_.getGains(p,i,d,i_max,i_min,antiwindup);
 }
 
 void JointPositionController::printDebug()
@@ -225,11 +225,14 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
       controller_state_publisher_->msg_.command = commanded_velocity;
 
       double dummy;
+      bool antiwindup;
       getGains(controller_state_publisher_->msg_.p,
         controller_state_publisher_->msg_.i,
         controller_state_publisher_->msg_.d,
         controller_state_publisher_->msg_.i_clamp,
-        dummy);
+        dummy,
+        antiwindup);
+      controller_state_publisher_->msg_.antiwindup = static_cast<char>(antiwindup);
       controller_state_publisher_->unlockAndPublish();
     }
   }

--- a/velocity_controllers/src/joint_position_controller.cpp
+++ b/velocity_controllers/src/joint_position_controller.cpp
@@ -101,6 +101,12 @@ void JointPositionController::setGains(const double &p, const double &i, const d
   pid_controller_.setGains(p,i,d,i_max,i_min,antiwindup);
 }
 
+void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min)
+{
+  bool dummy;
+  pid_controller_.getGains(p,i,d,i_max,i_min,dummy);
+}
+
 void JointPositionController::getGains(double &p, double &i, double &d, double &i_max, double &i_min, bool &antiwindup)
 {
   pid_controller_.getGains(p,i,d,i_max,i_min,antiwindup);


### PR DESCRIPTION
See also: https://github.com/ros-controls/control_toolbox/pull/38
