### PR TITLE
Indigo devel

### DIFF
--- a/joint_trajectory_controller/CHANGELOG.rst
+++ b/joint_trajectory_controller/CHANGELOG.rst
@@ -2,11 +2,11 @@
 Changelog for package joint_trajectory_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.9.3 (2016-02-12)
-------------------
+0.10.0 (2015-11-20)
+-------------------
 * Add joint limits spec to rrbot test robot
 * Address -Wunused-parameter warnings
-* reset to semantic zero in HardwareInterfaceAdapter for PositionJointInterface
+* Reset to semantic zero in HardwareInterfaceAdapter for PositionJointInterface
 * Contributors: Adolfo Rodriguez Tsouroukdissian, ipa-fxm
 
 0.9.2 (2015-05-04)

--- a/joint_trajectory_controller/README.md
+++ b/joint_trajectory_controller/README.md
@@ -4,4 +4,3 @@ Controller for executing joint-space trajectories on a group of joints.
 
 Detailed user documentation can be found in the controller's [ROS wiki page](http://wiki.ros.org/joint_trajectory_controller).
 
-

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -41,12 +41,13 @@ namespace internal
 template <class Enclosure, class Member>
 inline boost::shared_ptr<Member> share_member(boost::shared_ptr<Enclosure> enclosure, Member &member)
 {
-  actionlib::EnclosureDeleter<Enclosure> d(enclosure);
+  actionlib::EnclosureDeleter<Enclosure>
+ d(enclosure);
   boost::shared_ptr<Member> p(&member, d);
   return p;
 }
 
-std::vector<std::string> getStrings(const ros::NodeHandle& nh, const std::string& param_name)
+static inline std::vector<std::string> getStrings(const ros::NodeHandle& nh, const std::string& param_name)
 {
   using namespace XmlRpc;
   XmlRpcValue xml_array;
@@ -76,7 +77,7 @@ std::vector<std::string> getStrings(const ros::NodeHandle& nh, const std::string
   return out;
 }
 
-boost::shared_ptr<urdf::Model> getUrdf(const ros::NodeHandle& nh, const std::string& param_name)
+static inline boost::shared_ptr<urdf::Model> getUrdf(const ros::NodeHandle& nh, const std::string& param_name)
 {
   boost::shared_ptr<urdf::Model> urdf(new urdf::Model);
 
@@ -101,7 +102,7 @@ boost::shared_ptr<urdf::Model> getUrdf(const ros::NodeHandle& nh, const std::str
 }
 
 typedef boost::shared_ptr<const urdf::Joint> UrdfJointConstPtr;
-std::vector<UrdfJointConstPtr> getUrdfJoints(const urdf::Model& urdf, const std::vector<std::string>& joint_names)
+static inline std::vector<UrdfJointConstPtr> getUrdfJoints(const urdf::Model& urdf, const std::vector<std::string>& joint_names)
 {
   std::vector<UrdfJointConstPtr> out;
   for (unsigned int i = 0; i < joint_names.size(); ++i)
@@ -120,7 +121,7 @@ std::vector<UrdfJointConstPtr> getUrdfJoints(const urdf::Model& urdf, const std:
   return out;
 }
 
-std::string getLeafNamespace(const ros::NodeHandle& nh)
+static inline std::string getLeafNamespace(const ros::NodeHandle& nh)
 {
   const std::string complete_ns = nh.getNamespace();
   std::size_t id   = complete_ns.find_last_of("/");

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>joint_trajectory_controller</name>
   <description> Controller for executing joint-space trajectories on a group of joints. </description>
-  <version>0.9.3</version>
+  <version>0.10.0</version>
 
   <maintainer email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodriguez Tsouroukdissian</maintainer>
 

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -1,7 +1,7 @@
 <package>
   <name>joint_trajectory_controller</name>
   <description> Controller for executing joint-space trajectories on a group of joints. </description>
-  <version>0.10.0</version>
+  <version>0.9.3</version>
 
   <maintainer email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodriguez Tsouroukdissian</maintainer>
 


### PR DESCRIPTION
joint_trajectory_controller: 
Added "static inline" in front of functions defined in joint_trajectory_controller_impl.h
It caused the link edition to fail because of multiple definitions of those functions.
