### PR TITLE
Increase jtc test time limit to 120s (from 80s)

### DIFF
--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -31,5 +31,5 @@
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="80.0"/>
+        time-limit="120.0"/>
 </launch>


### PR DESCRIPTION
This addresses https://github.com/ros-controls/ros_controllers/issues/221 by adding `xvfb` to the Travis configuration `before_script` block, as explained in https://docs.travis-ci.com/user/gui-and-headless-browsers/

If the test still fails, I'll also increase the timeout.

FYI @bmagyar 
