### PR TITLE
Increase jtc. test time limit to 120s

### DIFF
--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -31,5 +31,5 @@
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="80.0"/>
+        time-limit="120.0"/>
 </launch>


### PR DESCRIPTION
This cherry-picks https://github.com/ros-controls/ros_controllers/pull/222 into `kinetic-devel`.

@bmagyar for review
