### PR TITLE
Changes in import of Qt modules

### DIFF
--- a/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/double_editor.py
+++ b/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/double_editor.py
@@ -30,7 +30,7 @@ import rospkg
 
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import Signal
-from python_qt_binding.QtGui import QWidget
+from python_qt_binding.QtWidgets import QWidget
 
 
 class DoubleEditor(QWidget):

--- a/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -32,7 +32,7 @@ import rospkg
 from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import QTimer, Signal
-from python_qt_binding.QtGui import QWidget, QFormLayout
+from python_qt_binding.QtWidgets import QWidget, QFormLayout
 
 from control_msgs.msg import JointTrajectoryControllerState
 from controller_manager_msgs.utils\


### PR DESCRIPTION
RQt supports Qt5 in the Kinetic release (see the migration guide
http://wiki.ros.org/kinetic/Migration). In Qt5, QWidget and QFormLayout are
found in QtWidgets, see this ROS answer:
http://answers.ros.org/question/235126/import-issues-in-ros-kinetic-rqt/

Fixes #230 

I attach to the PR an Screenshot of it working on 16.04/Kinetic:
![rqt_jtc](https://dl.dropboxusercontent.com/u/16526900/Screenshot%20from%202016-08-03%2016-49-17.png)
