### PR TITLE
Add test that sends trajectory entirely in past

### DIFF
--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -776,7 +776,7 @@ TEST_F(JointTrajectoryControllerTest, ignoreOldTopicTraj)
   }
 }
 
-TEST_F(JointTrajectoryControllerTest, ignoreOldActionTraj)
+TEST_F(JointTrajectoryControllerTest, ignorePreemptOfOldActionTraj)
 {
   ASSERT_TRUE(initState());
   ASSERT_TRUE(action_client->waitForServer(long_timeout));
@@ -806,6 +806,17 @@ TEST_F(JointTrajectoryControllerTest, ignoreOldActionTraj)
     EXPECT_NEAR(traj.points.back().velocities[i],    state->desired.velocities[i],    EPS);
     EXPECT_NEAR(traj.points.back().accelerations[i], state->desired.accelerations[i], EPS);
   }
+}
+
+TEST_F(JointTrajectoryControllerTest, ignoreSingleOldActionTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Send trajectory
+  traj_home_goal.trajectory.header.stamp = ros::Time::now() - ros::Duration(10000);
+  action_client->sendGoal(traj_home_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::REJECTED,  short_timeout));
 }
 
 TEST_F(JointTrajectoryControllerTest, ignorePartiallyOldActionTraj)


### PR DESCRIPTION
This recreates the crash raised in #233 as a new test.
