### PR TITLE
Fix xacro-related warnings

### DIFF
--- a/diff_drive_controller/test/diff_drive_bad_urdf.test
+++ b/diff_drive_controller/test/diff_drive_bad_urdf.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_bad.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_bad.xacro'" />
 
   <!-- Controller test -->
   <test test-name="diff_drive_fail_test"

--- a/diff_drive_controller/test/diff_drive_bad_urdf.test
+++ b/diff_drive_controller/test/diff_drive_bad_urdf.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_bad.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_bad.xacro' --inorder" />
 
   <!-- Controller test -->
   <test test-name="diff_drive_fail_test"

--- a/diff_drive_controller/test/diff_drive_common.launch
+++ b/diff_drive_controller/test/diff_drive_common.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load diffbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro' --inorder" />
 
   <!-- Start diffbot -->
   <node name="diffbot"

--- a/diff_drive_controller/test/diff_drive_common.launch
+++ b/diff_drive_controller/test/diff_drive_common.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load diffbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
 
   <!-- Start diffbot -->
   <node name="diffbot"

--- a/diff_drive_controller/test/diff_drive_radius_param.test
+++ b/diff_drive_controller/test/diff_drive_radius_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
 

--- a/diff_drive_controller/test/diff_drive_radius_param.test
+++ b/diff_drive_controller/test/diff_drive_radius_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro' --inorder" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
 

--- a/diff_drive_controller/test/diff_drive_radius_param_fail.test
+++ b/diff_drive_controller/test/diff_drive_radius_param_fail.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro' --inorder" />
   <!-- Don't provide the radius parameter, so the controller should break -->
   <!-- <param name="diffbot_controller/wheel_radius" value="0.11"/> -->
 

--- a/diff_drive_controller/test/diff_drive_radius_param_fail.test
+++ b/diff_drive_controller/test/diff_drive_radius_param_fail.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Don't provide the radius parameter, so the controller should break -->
   <!-- <param name="diffbot_controller/wheel_radius" value="0.11"/> -->
 

--- a/diff_drive_controller/test/diff_drive_separation_param.test
+++ b/diff_drive_controller/test/diff_drive_separation_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro' --inorder" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
   <!-- Provide the wheel separation -->

--- a/diff_drive_controller/test/diff_drive_separation_param.test
+++ b/diff_drive_controller/test/diff_drive_separation_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
   <!-- Provide the wheel separation -->

--- a/diff_drive_controller/test/skid_steer_common.launch
+++ b/diff_drive_controller/test/skid_steer_common.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load skidsteerbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"

--- a/diff_drive_controller/test/skid_steer_common.launch
+++ b/diff_drive_controller/test/skid_steer_common.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load skidsteerbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro' --inorder" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"

--- a/diff_drive_controller/test/sphere_wheel.xacro
+++ b/diff_drive_controller/test/sphere_wheel.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <macro name="sphere_wheel" params="name parent radius *origin">
+  <xacro:macro name="sphere_wheel" params="name parent radius *origin">
     <link name="${name}_link">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -24,7 +24,7 @@
     <joint name="${name}_joint" type="continuous">
       <parent link="${parent}_link"/>
       <child link="${name}_link"/>
-      <insert_block name="origin"/>
+      <xacro:insert_block name="origin"/>
       <axis xyz="0 0 1"/>
     </joint>
 
@@ -39,5 +39,5 @@
     <gazebo reference="${name}_link">
       <material>Gazebo/Red</material>
     </gazebo>
-  </macro>
+  </xacro:macro>
 </robot>

--- a/diff_drive_controller/test/view_diffbot.launch
+++ b/diff_drive_controller/test/view_diffbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro' --inorder" />
 
   <!-- Start diffbot -->
   <node name="diffbot"

--- a/diff_drive_controller/test/view_diffbot.launch
+++ b/diff_drive_controller/test/view_diffbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
 
   <!-- Start diffbot -->
   <node name="diffbot"

--- a/diff_drive_controller/test/view_skidsteerbot.launch
+++ b/diff_drive_controller/test/view_skidsteerbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro' --inorder" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"

--- a/diff_drive_controller/test/view_skidsteerbot.launch
+++ b/diff_drive_controller/test/view_skidsteerbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"

--- a/diff_drive_controller/test/wheel.xacro
+++ b/diff_drive_controller/test/wheel.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <macro name="wheel" params="name parent radius thickness *origin">
+  <xacro:macro name="wheel" params="name parent radius thickness *origin">
     <link name="${name}_link">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -24,7 +24,7 @@
     <joint name="${name}_joint" type="continuous">
       <parent link="${parent}_link"/>
       <child link="${name}_link"/>
-      <insert_block name="origin"/>
+      <xacro:insert_block name="origin"/>
       <axis xyz="0 0 1"/>
     </joint>
 
@@ -39,5 +39,5 @@
     <gazebo reference="${name}_link">
       <material>Gazebo/Red</material>
     </gazebo>
-  </macro>
+  </xacro:macro>
 </robot>

--- a/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load RRbot model -->
   <param name="robot_description"
-      command="$(find xacro)/xacro.py '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
+      command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
 
   <!-- Start RRbot -->
   <node name="rrbot"

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load RRbot model -->
   <param name="robot_description"
-      command="$(find xacro)/xacro.py '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
+      command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
 
   <!-- Start RRbot -->
   <node name="rrbot"

--- a/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load RRbot model -->
   <param name="robot_description"
-      command="$(find xacro)/xacro.py '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
+      command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
 
   <!-- Start RRbot -->
   <node name="rrbot"


### PR DESCRIPTION
- [x]  Replace calls to `xacro.py` with `xacro` in launch and test files.
- [x]  See if `xacro: Traditional processing is deprecated. Switch to --inorder processing!` should be addressed.
- [x]  Address the one below: 
```
Use the following script to fix incorrect usage:

        find . -iname "*.xacro" | xargs sed -i 's#<\([/]\?\)\(if\|unless\|include\|arg\|property\|macro\|insert_block\)#<\1xacro:\2#g'

when processing file: /root/ros/ws_ci_src/src/ci_src/diff_drive_controller/test/diffbot.xacro
```