### PR TITLE
Add urdf compatibility header

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -42,6 +42,8 @@
 
 #include <urdf_parser/urdf_parser.h>
 
+#include <urdf/urdfdom_compatibility.h>
+
 #include <boost/assign.hpp>
 
 #include <diff_drive_controller/diff_drive_controller.h>


### PR DESCRIPTION
Well...this is sort of a long shot but my tests with a Wily docker container revealed that a release of the current state with the new urdf headers would break on Wily the same way as it did with `gazebo_ros_packages`. 

https://github.com/ros-controls/ros_control/issues/258