### PR TITLE
Skip trajectories with an empty set of points.

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -159,12 +159,16 @@ template <class SegmentImpl, class HardwareInterface>
 inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
 trajectoryCommandCB(const JointTrajectoryConstPtr& msg)
 {
-  const bool update_ok = updateTrajectoryCommand(msg, RealtimeGoalHandlePtr());
-  if (update_ok || (msg && msg->points.empty()))
+  if (msg && msg->points.empty())
   {
     ROS_DEBUG_NAMED(name_, "Empty trajectory command, stopping.");
     setHoldPosition(time_data_.readFromRT()->uptime);
     preemptActiveGoal();
+  }
+  else
+  {  
+    const bool update_ok = updateTrajectoryCommand(msg, RealtimeGoalHandlePtr());
+    if (update_ok) {preemptActiveGoal();}
   }
 }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -508,9 +508,8 @@ updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePt
   // Hold current position if trajectory is empty
   if (msg->points.empty())
   {
-    setHoldPosition(time_data->uptime);
-    ROS_DEBUG_NAMED(name_, "Empty trajectory command, stopping.");
-    return true;
+    ROS_WARN_NAMED(name_, "Empty trajectory command, skipping.");
+    return false;
   }
 
   // Trajectory initialization options
@@ -687,7 +686,7 @@ queryStateService(control_msgs::QueryTrajectoryState::Request&  req,
     response_point.velocity[i]     = state.velocity[0];
     response_point.acceleration[i] = state.acceleration[0];
   }
-  
+
   // Populate response
   resp.name         = joint_names_;
   resp.position     = response_point.position;


### PR DESCRIPTION
Upon receiving a trajectory goal with an empty set of points, `updateTrajectoryCommand` will detect it and set a hold trajectory, but [return `true`](https://github.com/ros-controls/ros_controllers/blob/99d55fc2a6a24612e5cbe2bcd8145d78e4cddbfd/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L513) nevertheless, causing `goalCB` to accept it. However the controller then fails to succeed or abort, since [this check](https://github.com/ros-controls/ros_controllers/blob/99d55fc2a6a24612e5cbe2bcd8145d78e4cddbfd/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L389) always fails (the segment has no associated goal handle, being part of the hold trajectory) and any client waiting for a result will be stuck.

It's my impression that avoiding to set the hold trajectory and just returning false is the right thing to do (just like a [few lines before](https://github.com/ros-controls/ros_controllers/blob/99d55fc2a6a24612e5cbe2bcd8145d78e4cddbfd/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L489)), but I'm not quite sure of the potential side-effects.

What do you think?