### PR TITLE
Remove rqt_plot test_depend

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -56,7 +56,6 @@ if(CATKIN_ENABLE_TESTING)
       actionlib
       controller_manager
       xacro
-      rqt_plot
   )
 
   find_package(rostest REQUIRED)

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -33,7 +33,6 @@
   <test_depend>rostest</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
-  <test_depend>rqt_plot</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/ros_control_plugins.xml"/>

--- a/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="display_plots" default="false"/>
+
   <!-- Load RRbot model -->
   <param name="robot_description"
       command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
@@ -16,16 +18,18 @@
         pkg="controller_manager" type="spawner" output="screen"
         args="rrbot_controller" />
 
-  <!-- Rxplot monitoring -->
-  <node name="rrbot_pos_monitor"
-        pkg="rqt_plot"
-        type="rqt_plot"
-        args="/rrbot_controller/state/desired/positions[0]:positions[1],/rrbot_controller/state/actual/positions[0]:positions[1]" />
+  <group if="$(arg display_plots)">
+    <!-- rqt_plot monitoring -->
+    <node name="rrbot_pos_monitor"
+          pkg="rqt_plot"
+          type="rqt_plot"
+          args="/rrbot_controller/state/desired/positions[0]:positions[1],/rrbot_controller/state/actual/positions[0]:positions[1]" />
 
-  <node name="rrbot_vel_monitor"
-        pkg="rqt_plot"
-        type="rqt_plot"
-        args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
+    <node name="rrbot_vel_monitor"
+          pkg="rqt_plot"
+          type="rqt_plot"
+          args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
+  </group>
 
   <!-- Controller test -->
   <test test-name="joint_partial_trajectory_controller_test"

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="display_plots" default="false"/>
+
   <!-- Load RRbot model -->
   <param name="robot_description"
       command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
@@ -16,16 +18,18 @@
         pkg="controller_manager" type="spawner" output="screen"
         args="rrbot_controller" />
 
-  <!-- Rxplot monitoring -->
-  <node name="rrbot_pos_monitor"
-        pkg="rqt_plot"
-        type="rqt_plot"
-        args="/rrbot_controller/state/desired/positions[0]:positions[1],/rrbot_controller/state/actual/positions[0]:positions[1]" />
+  <group if="$(arg display_plots)">
+    <!-- rqt_plot monitoring -->
+    <node name="rrbot_pos_monitor"
+          pkg="rqt_plot"
+          type="rqt_plot"
+          args="/rrbot_controller/state/desired/positions[0]:positions[1],/rrbot_controller/state/actual/positions[0]:positions[1]" />
 
-  <node name="rrbot_vel_monitor"
-        pkg="rqt_plot"
-        type="rqt_plot"
-        args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
+    <node name="rrbot_vel_monitor"
+          pkg="rqt_plot"
+          type="rqt_plot"
+          args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
+  </group>
 
   <!-- Controller test -->
   <test test-name="joint_trajectory_controller_test"

--- a/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="display_plots" default="false"/>
+
   <!-- Load RRbot model -->
   <param name="robot_description"
       command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
@@ -16,16 +18,18 @@
         pkg="controller_manager" type="spawner" output="screen"
         args="rrbot_controller" />
 
-  <!-- Rxplot monitoring -->
-  <node name="rrbot_pos_monitor"
-        pkg="rqt_plot"
-        type="rqt_plot"
-        args="/rrbot_controller/state/desired/positions[0]:positions[1],/rrbot_controller/state/actual/positions[0]:positions[1]" />
+  <group if="$(arg display_plots)">
+    <!-- rqt_plot monitoring -->
+    <node name="rrbot_pos_monitor"
+          pkg="rqt_plot"
+          type="rqt_plot"
+          args="/rrbot_controller/state/desired/positions[0]:positions[1],/rrbot_controller/state/actual/positions[0]:positions[1]" />
 
-  <node name="rrbot_vel_monitor"
-        pkg="rqt_plot"
-        type="rqt_plot"
-        args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
+    <node name="rrbot_vel_monitor"
+          pkg="rqt_plot"
+          type="rqt_plot"
+          args="/rrbot_controller/state/desired/velocities[0]:velocities[1],/rrbot_controller/state/actual/velocities[0]:velocities[1]" />
+  </group>
 
   <!-- Controller test -->
   <test test-name="joint_trajectory_controller_vel_test"


### PR DESCRIPTION
Let's see how this works out.

It feels silly to be blocked by `rqt_common_plugins` when we only use `rqt_plot` to visualise tests.