### PR TITLE
Publish executed velocity if publish_cmd

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -74,6 +74,14 @@ if (CATKIN_ENABLE_TESTING)
     test/diff_drive_odom_frame.test
     test/diff_drive_odom_frame_test.cpp)
   target_link_libraries(diff_drive_odom_frame_test ${catkin_LIBRARIES})
+  add_rostest_gtest(diff_drive_default_cmd_vel_out_test
+    test/diff_drive_default_cmd_vel_out.test
+    test/diff_drive_default_cmd_vel_out_test.cpp)
+  target_link_libraries(diff_drive_default_cmd_vel_out_test ${catkin_LIBRARIES})
+  add_rostest_gtest(diff_drive_pub_cmd_vel_out_test
+    test/diff_drive_pub_cmd_vel_out.test
+    test/diff_drive_pub_cmd_vel_out_test.cpp)
+  target_link_libraries(diff_drive_pub_cmd_vel_out_test ${catkin_LIBRARIES})
   add_rostest(test/diff_drive_open_loop.test)
   add_rostest(test/skid_steer_controller.test)
   add_rostest(test/skid_steer_no_wheels.test)

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -40,6 +40,7 @@
 #include <hardware_interface/joint_command_interface.h>
 #include <pluginlib/class_list_macros.h>
 
+#include <geometry_msgs/TwistStamped.h>
 #include <nav_msgs/Odometry.h>
 #include <tf/tfMessage.h>
 
@@ -120,6 +121,9 @@ namespace diff_drive_controller{
     Commands command_struct_;
     ros::Subscriber sub_command_;
 
+    /// Publish executed commands
+    boost::shared_ptr<realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped> > cmd_vel_pub_;
+
     /// Odometry related:
     boost::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::Odometry> > odom_pub_;
     boost::shared_ptr<realtime_tools::RealtimePublisher<tf::tfMessage> > tf_odom_pub_;
@@ -158,6 +162,9 @@ namespace diff_drive_controller{
     Commands last0_cmd_;
     SpeedLimiter limiter_lin_;
     SpeedLimiter limiter_ang_;
+
+    /// Publish limited velocity:
+    bool publish_cmd_;
 
   private:
     /**

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -245,7 +245,10 @@ namespace diff_drive_controller{
 
     setOdomPubFields(root_nh, controller_nh);
 
-    cmd_vel_pub_.reset(new realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped>(controller_nh, "cmd_vel_out", 100));
+    if (publish_cmd_)
+    {
+      cmd_vel_pub_.reset(new realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped>(controller_nh, "cmd_vel_out", 100));
+    }
 
     // Get the joint object to use in the realtime loop
     for (int i = 0; i < wheel_joints_size_; ++i)
@@ -344,7 +347,7 @@ namespace diff_drive_controller{
     last0_cmd_ = curr_cmd;
 
     // Publish limited velocity:
-    if (publish_cmd_ && cmd_vel_pub_->trylock())
+    if (publish_cmd_ && cmd_vel_pub_ && cmd_vel_pub_->trylock())
     {
       cmd_vel_pub_->msg_.header.stamp = time;
       cmd_vel_pub_->msg_.twist.linear.x = curr_cmd.lin;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -120,6 +120,7 @@ namespace diff_drive_controller{
     , odom_frame_id_("odom")
     , enable_odom_tf_(true)
     , wheel_joints_size_(0)
+    , publish_cmd_(false)
   {
   }
 
@@ -217,6 +218,9 @@ namespace diff_drive_controller{
     controller_nh.param("angular/z/max_jerk"               , limiter_ang_.max_jerk               ,  limiter_ang_.max_jerk              );
     controller_nh.param("angular/z/min_jerk"               , limiter_ang_.min_jerk               , -limiter_ang_.max_jerk              );
 
+    // Publish limited velocity:
+    controller_nh.param("publish_cmd", publish_cmd_, publish_cmd_);
+
     // If either parameter is not available, we need to look up the value in the URDF
     bool lookup_wheel_separation = !controller_nh.getParam("wheel_separation", wheel_separation_);
     bool lookup_wheel_radius = !controller_nh.getParam("wheel_radius", wheel_radius_);
@@ -240,6 +244,8 @@ namespace diff_drive_controller{
                           << ", wheel radius " << wr);
 
     setOdomPubFields(root_nh, controller_nh);
+
+    cmd_vel_pub_.reset(new realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped>(controller_nh, "cmd_vel_out", 100));
 
     // Get the joint object to use in the realtime loop
     for (int i = 0; i < wheel_joints_size_; ++i)
@@ -336,6 +342,15 @@ namespace diff_drive_controller{
 
     last1_cmd_ = last0_cmd_;
     last0_cmd_ = curr_cmd;
+
+    // Publish limited velocity:
+    if (publish_cmd_ && cmd_vel_pub_->trylock())
+    {
+      cmd_vel_pub_->msg_.header.stamp = time;
+      cmd_vel_pub_->msg_.twist.linear.x = curr_cmd.lin;
+      cmd_vel_pub_->msg_.twist.angular.z = curr_cmd.ang;
+      cmd_vel_pub_->unlockAndPublish();
+    }
 
     // Apply multipliers:
     const double ws = wheel_separation_multiplier_ * wheel_separation_;

--- a/diff_drive_controller/test/diff_drive_default_cmd_vel_out.test
+++ b/diff_drive_controller/test/diff_drive_default_cmd_vel_out.test
@@ -1,0 +1,20 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- default value -->
+  <!-- <rosparam>
+    diffbot_controller:
+      publish_cmd: False
+  </rosparam> -->
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_default_cmd_vel_out_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_default_cmd_vel_out_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+    <remap from="cmd_vel_out" to="diffbot_controller/cmd_vel_out" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diff_drive_default_cmd_vel_out_test.cpp
+++ b/diff_drive_controller/test/diff_drive_default_cmd_vel_out_test.cpp
@@ -1,0 +1,68 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2017, PAL Robotics.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Jeremie Deray
+
+#include "test_common.h"
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testDefaultCmdVelOutTopic)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+
+  EXPECT_FALSE(isPublishingCmdVelOut());
+
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  EXPECT_FALSE(isPublishingCmdVelOut());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_default_cmd_vel_out_topic_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/diff_drive_pub_cmd_vel_out.test
+++ b/diff_drive_controller/test/diff_drive_pub_cmd_vel_out.test
@@ -1,0 +1,19 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <rosparam>
+    diffbot_controller:
+      publish_cmd: True
+  </rosparam>
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_pub_cmd_vel_out_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_pub_cmd_vel_out_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+    <remap from="cmd_vel_out" to="diffbot_controller/cmd_vel_out" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diff_drive_pub_cmd_vel_out_test.cpp
+++ b/diff_drive_controller/test/diff_drive_pub_cmd_vel_out_test.cpp
@@ -1,0 +1,73 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2017, PAL Robotics.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Jeremie Deray
+
+#include "test_common.h"
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testCmdVelOutTopic)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+
+  EXPECT_TRUE(isPublishingCmdVelOut());
+
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  EXPECT_TRUE(isPublishingCmdVelOut());
+
+  // get a twist message
+  geometry_msgs::TwistStamped odom_msg = getLastCmdVelOut();
+
+  EXPECT_GT(fabs(odom_msg.twist.linear.x), 0);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_pub_cmd_vel_out_topic_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}


### PR DESCRIPTION
Optionally publish the velocity command to be executed (`geometry_msgs/TwistStamped`).

Disabled by default.