### PR TITLE
Set hold trajectory goal handle when empty trajectory action is received.

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -244,7 +244,7 @@ private:
    * current position and zero velocity.
    * \note This method is realtime-safe.
    */
-  void setHoldPosition(const ros::Time& time);
+  void setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh=RealtimeGoalHandlePtr());
 
 };
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -508,7 +508,7 @@ updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePt
   // Hold current position if trajectory is empty
   if (msg->points.empty())
   {
-    setHoldPosition(time_data->uptime);
+    setHoldPosition(time_data->uptime, gh);
     ROS_DEBUG_NAMED(name_, "Empty trajectory command, stopping.");
     return true;
   }
@@ -724,7 +724,7 @@ publishState(const ros::Time& time)
 
 template <class SegmentImpl, class HardwareInterface>
 void JointTrajectoryController<SegmentImpl, HardwareInterface>::
-setHoldPosition(const ros::Time& time)
+setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh)
 {
   // Settle position in a fixed time. We do the following:
   // - Create segment that goes from current (pos,vel) to (pos,-vel) in 2x the desired stop time
@@ -762,6 +762,9 @@ setHoldPosition(const ros::Time& time)
     // Now create segment that goes from current state to one with zero end velocity
     (*hold_trajectory_ptr_)[i].front().init(start_time, hold_start_state_,
                                                              end_time,   hold_end_state_);
+
+    // Set goal handle for the segment
+    (*hold_trajectory_ptr_)[i].front().setGoalHandle(gh);
   }
   curr_trajectory_box_.set(hold_trajectory_ptr_);
 }

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -35,5 +35,5 @@
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="80.0"/>
+        time-limit="85.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -731,6 +731,95 @@ TEST_F(JointTrajectoryControllerTest, emptyTopicCancelsActionTraj)
   }
 }
 
+TEST_F(JointTrajectoryControllerTest, emptyActionCancelsTopicTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Go to home configuration, we need known initial conditions
+  traj_home_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_home_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, long_timeout));
+
+  // Start state
+  StateConstPtr start_state = getState();
+
+  // Send trajectory
+  traj.header.stamp = ros::Time(0); // Start immediately
+  traj_pub.publish(traj);
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send an empty trajectory goal that preempts the previous one and stops the robot where it is
+  ActionGoal empty_goal;
+  empty_goal.trajectory.joint_names = traj.joint_names;
+  action_client->sendGoal(empty_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+  ros::Duration(2.0).sleep(); // Stopping takes some time
+
+  // Check that we're not on the start state
+  StateConstPtr state1 = getState();
+  EXPECT_LT(traj.points.front().positions[0] * 0.9,
+            std::abs(start_state->desired.positions[0] - state1->desired.positions[0]));
+
+  // Check that we're not moving
+  ros::Duration(0.5).sleep(); // Wait
+  StateConstPtr state2 = getState();
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    EXPECT_NEAR(state1->desired.positions[i],     state2->desired.positions[i],     EPS);
+    EXPECT_NEAR(state1->desired.velocities[i],    state2->desired.velocities[i],    EPS);
+    EXPECT_NEAR(state1->desired.accelerations[i], state2->desired.accelerations[i], EPS);
+  }
+}
+
+TEST_F(JointTrajectoryControllerTest, emptyActionCancelsActionTraj)
+{
+  ASSERT_TRUE(initState());
+  ASSERT_TRUE(action_client->waitForServer(long_timeout));
+
+  // Go to home configuration, we need known initial conditions
+  traj_home_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_home_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, long_timeout));
+
+  // Start state
+  StateConstPtr start_state = getState();
+
+  // Send trajectory
+  traj_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
+  action_client->sendGoal(traj_goal);
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+  ros::Duration wait_duration = traj.points.front().time_from_start;
+  wait_duration.sleep(); // Wait until ~first waypoint
+
+  // Send an empty trajectory goal that preempts the previous one and stops the robot where it is
+  ActionGoal empty_goal;
+  empty_goal.trajectory.joint_names = traj.joint_names;
+  action_client2->sendGoal(empty_goal);
+  ASSERT_TRUE(waitForState(action_client,  SimpleClientGoalState::PREEMPTED, short_timeout));
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::ACTIVE, short_timeout));
+  ros::Duration(2.0).sleep(); // Stopping takes some time
+
+  // Check that we're not on the start state
+  StateConstPtr state1 = getState();
+  EXPECT_LT(traj.points.front().positions[0] * 0.9,
+            std::abs(start_state->desired.positions[0] - state1->desired.positions[0]));
+
+  // Check that we're not moving
+  ros::Duration(0.5).sleep(); // Wait
+  StateConstPtr state2 = getState();
+  for (unsigned int i = 0; i < n_joints; ++i)
+  {
+    EXPECT_NEAR(state1->desired.positions[i],     state2->desired.positions[i],     EPS);
+    EXPECT_NEAR(state1->desired.velocities[i],    state2->desired.velocities[i],    EPS);
+    EXPECT_NEAR(state1->desired.accelerations[i], state2->desired.accelerations[i], EPS);
+  }
+
+  // Check that new action succeeds after being accepted
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::SUCCEEDED, short_timeout));
+}
+
 TEST_F(JointTrajectoryControllerTest, cancelActionGoal)
 {
   ASSERT_TRUE(action_client->waitForServer(long_timeout));

--- a/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
@@ -35,5 +35,5 @@
   <test test-name="joint_trajectory_controller_vel_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="80.0"/>
+        time-limit="85.0"/>
 </launch>


### PR DESCRIPTION
Previously, an empty trajectory received through the action interface would set hold trajectory and accept the action goal, but the action would never be terminated, leaving clients hanging.

In #247 it was suggested to amend this by skipping the empty trajectory altogether and rejecting the action, while keeping the expected behavior (stop the running trajectory) for empty trajectories received through the topic interface. However, @ipa-mdl [suggested](https://github.com/ros-controls/ros_controllers/pull/247#issuecomment-298638630) that this created a discrepancy in the behaviors of the topic and action interfaces.

This PR tries to address this concern by implementing the same behavior in both interfaces, and fixing the hanging client issue by setting the goal handle associated to the hold trajectory to that of the empty trajectory goal.