### PR TITLE
export odom params if not on server

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -234,6 +234,24 @@ namespace diff_drive_controller{
       return false;
     }
 
+    // Export parameters to param server if not available
+    if (lookup_wheel_separation)
+    {
+      controller_nh.setParam("wheel_separation", wheel_separation_);
+    }
+    if (lookup_wheel_radius)
+    {
+      controller_nh.setParam("wheel_radius", wheel_radius_);
+    }
+    if (!controller_nh.hasParam("wheel_separation_multiplier"))
+    {
+      controller_nh.setParam("wheel_separation_multiplier", wheel_separation_multiplier_);
+    }
+    if (!controller_nh.hasParam("wheel_radius_multiplier"))
+    {
+      controller_nh.setParam("wheel_radius_multiplier", wheel_radius_multiplier_);
+    }
+
     // Regardless of how we got the separation and radius, use them
     // to set the odometry parameters
     const double ws = wheel_separation_multiplier_ * wheel_separation_;


### PR DESCRIPTION
Simply export the odometry parameters (wheel separation, radius and respective multipliers), if they are not already on the param server.
@bmagyar @efernandez Gentle ping for an easy one.