### PR TITLE
Fix odometry twist computation

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(catkin REQUIRED COMPONENTS
     urdf
 )
 
+find_package(sophus REQUIRED)
+
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
@@ -16,6 +18,7 @@ catkin_package(
 
 include_directories(
   include ${catkin_INCLUDE_DIRS}
+  include ${sophus_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -43,6 +43,7 @@
 #define ODOMETRY_H_
 
 #include <ros/time.h>
+#include <sophus/se2.hpp>
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/rolling_mean.hpp>
@@ -62,6 +63,9 @@ namespace diff_drive_controller
 
     /// Integration function, used to integrate the odometry:
     typedef boost::function<void(double, double)> IntegrationFunction;
+
+    /// SO(2) and SE(2) Lie Groups:
+    typedef Sophus::SE2d SE2;
 
     /**
      * \brief Constructor
@@ -91,8 +95,19 @@ namespace diff_drive_controller
      * \param linear  Linear velocity [m/s]
      * \param angular Angular velocity [rad/s]
      * \param time    Current time
+     * \return true if the odometry is actually updated
      */
-    void updateOpenLoop(double linear, double angular, const ros::Time &time);
+    bool updateOpenLoop(double linear, double angular, const ros::Time &time);
+
+    /**
+     * \brief Update the odometry twist with the previous and current odometry
+     * pose
+     * \param p0   Previous odometry pose
+     * \param p1   Current  odometry pose
+     * \param time Current time
+     * \return true if the odometry twist is actually updated
+     */
+    bool updateTwist(const SE2& p0, const SE2& p1, const ros::Time& time);
 
     /**
      * \brief heading getter
@@ -122,21 +137,30 @@ namespace diff_drive_controller
     }
 
     /**
-     * \brief linear velocity getter
-     * \return linear velocity [m/s]
+     * \brief x velocity getter
+     * \return x velocity [m/s]
      */
-    double getLinear() const
+    double getVx() const
     {
-      return linear_;
+      return v_x_;
     }
 
     /**
-     * \brief angular velocity getter
-     * \return angular velocity [rad/s]
+     * \brief y velocity getter
+     * \return y velocity [m/s]
      */
-    double getAngular() const
+    double getVy() const
     {
-      return angular_;
+      return v_y_;
+    }
+
+    /**
+     * \brief yaw velocity getter
+     * \return yaw velocity [rad/s]
+     */
+    double getVyaw() const
+    {
+      return v_yaw_;
     }
 
     /**
@@ -186,8 +210,9 @@ namespace diff_drive_controller
     double heading_;  // [rad]
 
     /// Current velocity:
-    double linear_;  //   [m/s]
-    double angular_; // [rad/s]
+    double v_x_;   //   [m/s]
+    double v_y_;   //   [m/s]
+    double v_yaw_; // [rad/s]
 
     /// Wheel kinematic parameters [m]:
     double wheel_separation_;
@@ -199,8 +224,9 @@ namespace diff_drive_controller
 
     /// Rolling mean accumulators for the linar and angular velocities:
     size_t velocity_rolling_window_size_;
-    RollingMeanAcc linear_acc_;
-    RollingMeanAcc angular_acc_;
+    RollingMeanAcc v_x_acc_;
+    RollingMeanAcc v_y_acc_;
+    RollingMeanAcc v_yaw_acc_;
 
     /// Integration funcion, used to integrate the odometry:
     IntegrationFunction integrate_fun_;

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -15,6 +15,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>sophus</build_depend>
+
   <depend>controller_interface</depend>
   <depend>nav_msgs</depend>
   <depend>realtime_tools</depend>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -350,8 +350,9 @@ namespace diff_drive_controller{
         odom_pub_->msg_.pose.pose.position.x = odometry_.getX();
         odom_pub_->msg_.pose.pose.position.y = odometry_.getY();
         odom_pub_->msg_.pose.pose.orientation = orientation;
-        odom_pub_->msg_.twist.twist.linear.x  = odometry_.getLinear();
-        odom_pub_->msg_.twist.twist.angular.z = odometry_.getAngular();
+        odom_pub_->msg_.twist.twist.linear.x  = odometry_.getVx();
+        odom_pub_->msg_.twist.twist.linear.y  = odometry_.getVy();
+        odom_pub_->msg_.twist.twist.angular.z = odometry_.getVyaw();
         odom_pub_->unlockAndPublish();
       }
 
@@ -618,7 +619,6 @@ namespace diff_drive_controller{
         (0)  (0)  (0)  (static_cast<double>(pose_cov_list[3])) (0)  (0)
         (0)  (0)  (0)  (0)  (static_cast<double>(pose_cov_list[4])) (0)
         (0)  (0)  (0)  (0)  (0)  (static_cast<double>(pose_cov_list[5]));
-    odom_pub_->msg_.twist.twist.linear.y  = 0;
     odom_pub_->msg_.twist.twist.linear.z  = 0;
     odom_pub_->msg_.twist.twist.angular.x = 0;
     odom_pub_->msg_.twist.twist.angular.y = 0;


### PR DESCRIPTION
The twist is computed as the relative transformation in SE(2) between
the previous and current odometry pose, divided by the time step dt.

This is the first PR of a big list trying to bring the CPR fork changes upstream: https://github.com/clearpathrobotics/ros_controllers/commits/indigo-devel?after=35323e012116cee02e9c2e25f5f31be14d44298b+139 (from June 8, 2015)

This first PR is the same as https://github.com/clearpathrobotics/ros_controllers/pull/2 with a few conflicts resolved.