### PR TITLE
Rebased #141: Add JointTrajectoryController specification for SplineJointInterface

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -330,7 +330,7 @@ class HardwareInterfaceAdapter<hardware_interface::PosVelJointInterface, State>
 public:
   HardwareInterfaceAdapter() : joint_handles_ptr_(0) {}
 
-  bool init(std::vector<hardware_interface::PosVelJointHandle>& joint_handles, ros::NodeHandle& controller_nh)
+  bool init(std::vector<hardware_interface::PosVelJointHandle>& joint_handles, ros::NodeHandle& /*controller_nh*/)
   {
     // Store pointer to joint handles
     joint_handles_ptr_ = &joint_handles;
@@ -338,8 +338,8 @@ public:
     return true;
   }
 
-  void starting(const ros::Time& time) {}
-  void stopping(const ros::Time& time) {}
+  void starting(const ros::Time& /*time*/) {}
+  void stopping(const ros::Time& /*time*/) {}
 
   void updateCommand(const ros::Time&     /*time*/,
                      const ros::Duration& /*period*/,
@@ -367,7 +367,7 @@ class HardwareInterfaceAdapter<hardware_interface::PosVelAccJointInterface, Stat
 public:
   HardwareInterfaceAdapter() : joint_handles_ptr_(0) {}
 
-  bool init(std::vector<hardware_interface::PosVelAccJointHandle>& joint_handles, ros::NodeHandle& controller_nh)
+  bool init(std::vector<hardware_interface::PosVelAccJointHandle>& joint_handles, ros::NodeHandle& /*controller_nh*/)
   {
     // Store pointer to joint handles
     joint_handles_ptr_ = &joint_handles;
@@ -375,8 +375,8 @@ public:
     return true;
   }
 
-  void starting(const ros::Time& time) {}
-  void stopping(const ros::Time& time) {}
+  void starting(const ros::Time& /*time*/) {}
+  void stopping(const ros::Time& /*time*/) {}
 
   void updateCommand(const ros::Time&     /*time*/,
                      const ros::Duration& /*period*/,

--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -41,6 +41,7 @@
 
 #include <control_toolbox/pid.h>
 #include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/posvelacc_command_interface.h>
 
 /**
  * \brief Helper class to simplify integrating the JointTrajectoryController with different hardware interfaces.
@@ -317,6 +318,44 @@ private:
   std::vector<PidPtr> pids_;
 
   std::vector<hardware_interface::JointHandle>* joint_handles_ptr_;
+};
+
+
+/**
+ * \brief Adapter for a spline-controlled hardware interface. Forwards desired positions as commands.
+ */
+template <class State>
+class HardwareInterfaceAdapter<hardware_interface::PosVelAccJointInterface, State>
+{
+public:
+  HardwareInterfaceAdapter() : joint_handles_ptr_(0) {}
+
+  bool init(std::vector<hardware_interface::PosVelAccJointHandle>& joint_handles, ros::NodeHandle& controller_nh)
+  {
+    // Store pointer to joint handles
+    joint_handles_ptr_ = &joint_handles;
+
+    return true;
+  }
+
+  void starting(const ros::Time& time) {}
+  void stopping(const ros::Time& time) {}
+
+  void updateCommand(const ros::Time&     /*time*/,
+                     const ros::Duration& /*period*/,
+                     const State&         desired_state,
+                     const State&         /*state_error*/)
+  {
+    // Forward desired position to command
+    const unsigned int n_joints = joint_handles_ptr_->size();
+    for (unsigned int i = 0; i < n_joints; ++i)
+    {
+      (*joint_handles_ptr_)[i].setCommand(desired_state.position[i], desired_state.velocity[i], desired_state.acceleration[i]);
+    }
+  }
+
+private:
+  std::vector<hardware_interface::PosVelAccJointHandle>* joint_handles_ptr_;
 };
 
 #endif // header guard

--- a/joint_trajectory_controller/ros_control_plugins.xml
+++ b/joint_trajectory_controller/ros_control_plugins.xml
@@ -27,6 +27,15 @@
     </description>
   </class>
 
+  <class name="pos_vel_controllers/JointTrajectoryController"
+         type="pos_vel_controllers::JointTrajectoryController"
+         base_class_type="controller_interface::ControllerBase">
+    <description>
+      The JointTrajectoryController executes joint-space trajectories on a set of joints.
+      This variant represents trajectory segments as quintic splines and sends commands to an pos_vel interface.
+    </description>
+  </class>
+
   <class name="pos_vel_acc_controllers/JointTrajectoryController"
          type="pos_vel_acc_controllers::JointTrajectoryController"
          base_class_type="controller_interface::ControllerBase">

--- a/joint_trajectory_controller/ros_control_plugins.xml
+++ b/joint_trajectory_controller/ros_control_plugins.xml
@@ -27,4 +27,13 @@
     </description>
   </class>
 
+  <class name="pos_vel_acc_controllers/JointTrajectoryController"
+         type="pos_vel_acc_controllers::JointTrajectoryController"
+         base_class_type="controller_interface::ControllerBase">
+    <description>
+      The JointTrajectoryController executes joint-space trajectories on a set of joints.
+      This variant represents trajectory segments as quintic splines and sends commands to an spline interface.
+    </description>
+  </class>
+
 </library>

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -66,6 +66,17 @@ namespace effort_controllers
           JointTrajectoryController;
 }
 
+namespace pos_vel_controllers
+{
+  /**
+   * \brief Joint trajectory controller that represents trajectory segments as <b>quintic splines</b> and sends
+   * commands to an \b pos_vel interface.
+   */
+  typedef joint_trajectory_controller::JointTrajectoryController<trajectory_interface::QuinticSplineSegment<double>,
+                                                                 hardware_interface::PosVelJointInterface>
+          JointTrajectoryController;
+}
+
 namespace pos_vel_acc_controllers
 {
   /**
@@ -80,4 +91,5 @@ namespace pos_vel_acc_controllers
 PLUGINLIB_EXPORT_CLASS(position_controllers::JointTrajectoryController, controller_interface::ControllerBase)
 PLUGINLIB_EXPORT_CLASS(velocity_controllers::JointTrajectoryController, controller_interface::ControllerBase)
 PLUGINLIB_EXPORT_CLASS(effort_controllers::JointTrajectoryController,   controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(pos_vel_controllers::JointTrajectoryController,   controller_interface::ControllerBase)
 PLUGINLIB_EXPORT_CLASS(pos_vel_acc_controllers::JointTrajectoryController,   controller_interface::ControllerBase)

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -66,6 +66,18 @@ namespace effort_controllers
           JointTrajectoryController;
 }
 
+namespace pos_vel_acc_controllers
+{
+  /**
+   * \brief Joint trajectory controller that represents trajectory segments as <b>quintic splines</b> and sends
+   * commands to an \b effort interface.
+   */
+  typedef joint_trajectory_controller::JointTrajectoryController<trajectory_interface::QuinticSplineSegment<double>,
+                                                                 hardware_interface::PosVelAccJointInterface>
+          JointTrajectoryController;
+}
+
 PLUGINLIB_EXPORT_CLASS(position_controllers::JointTrajectoryController, controller_interface::ControllerBase)
 PLUGINLIB_EXPORT_CLASS(velocity_controllers::JointTrajectoryController, controller_interface::ControllerBase)
 PLUGINLIB_EXPORT_CLASS(effort_controllers::JointTrajectoryController,   controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(pos_vel_acc_controllers::JointTrajectoryController,   controller_interface::ControllerBase)

--- a/joint_trajectory_controller/src/joint_trajectory_controller.cpp
+++ b/joint_trajectory_controller/src/joint_trajectory_controller.cpp
@@ -81,7 +81,7 @@ namespace pos_vel_acc_controllers
 {
   /**
    * \brief Joint trajectory controller that represents trajectory segments as <b>quintic splines</b> and sends
-   * commands to an \b effort interface.
+   * commands to a \b pos_vel_acc interface.
    */
   typedef joint_trajectory_controller::JointTrajectoryController<trajectory_interface::QuinticSplineSegment<double>,
                                                                  hardware_interface::PosVelAccJointInterface>


### PR DESCRIPTION
Rebased #141 onto `kinetic-devel` and added a posvel joint trajectory controller that forwards the position and velocity states to the joint handle for completeness.

From testing on my dynamixels, I don't think it behaves quite as the expectation is. In the directly forwarded implementation, the commanded position sent to the joint handle changes as a trajectory leg is executed. This is the desired behavior when we're only controlling position (or velocity/effort since we are emulating position control) because we want the action to take a fixed amount of time.

However I think the behavior that is expected when describing a 'position with velocity' joint trajectory controller as in #254 is that the commanded position doesn't need to sweep towards the goal position because the velocity that the joint is moving towards the goal position can be commanded directly instead. As such both commanded position and commanded velocity of the joint could remain constant over the course of the entire leg of the trajectory (This is especially useful in low frequency hardware interfaces where the discreet position sweep is very visible).

Existing behavior of a posvel joint handle as it moves towards a trajectory point
```
[ INFO] [1503626104.561299523]: Position target: 1.472098 Velocity target: 1.600000 
[ INFO] [1503626104.577326303]: Position target: 1.504085 Velocity target: 1.600000 
[ INFO] [1503626104.593215307]: Position target: 1.536259 Velocity target: 1.600000 
[ INFO] [1503626104.625216529]: Position target: 1.568098 Velocity target: 1.600000 
[ INFO] [1503626104.641279416]: Position target: 1.600000 Velocity target: 0.000000
```

'Desired' behavior
```
[ INFO] [1503626104.561299523]: Position target: 1.600000 Velocity target: 1.600000 
[ INFO] [1503626104.577326303]: Position target: 1.600000 Velocity target: 1.600000 
[ INFO] [1503626104.593215307]: Position target: 1.600000 Velocity target: 1.600000 
[ INFO] [1503626104.625216529]: Position target: 1.600000 Velocity target: 1.600000 
[ INFO] [1503626104.641279416]: Position target: 1.600000 Velocity target: 0.000000
```

I'd love to get some thoughts on what should be the desired behavior and implementation suggestions, since at first glance `hardware_interface_adapter` doesn't expose the goal state for a trajectory leg, just the current moment in time.