### PR TITLE
TrajectoryController: Use desired state to calculate hold trajectory

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -96,6 +96,11 @@ if(CATKIN_ENABLE_TESTING)
                     test/joint_trajectory_controller_test.cpp)
   target_link_libraries(joint_trajectory_controller_test ${catkin_LIBRARIES})
 
+  add_rostest_gtest(joint_trajectory_controller_stopramp_test
+                    test/joint_trajectory_controller_stopramp.test
+                    test/joint_trajectory_controller_test.cpp)
+  target_link_libraries(joint_trajectory_controller_stopramp_test ${catkin_LIBRARIES})
+
   add_rostest_gtest(joint_trajectory_controller_vel_test
                     test/joint_trajectory_controller_vel.test
                     test/joint_trajectory_controller_test.cpp)

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -208,7 +208,7 @@ private:
   ros::Duration state_publisher_period_;
   ros::Duration action_monitor_period_;
 
-  typename Segment::Time stop_trajectory_duration_;
+  typename Segment::Time stop_trajectory_duration_;  ///< Duration for stop ramp. If zero, the controller stops at the actual position.
   boost::dynamic_bitset<> successful_joint_traj_;
   bool allow_partial_joints_goal_;
 
@@ -240,8 +240,9 @@ private:
   /**
    * \brief Hold the current position.
    *
-   * Substitutes the current trajectory with a single-segment one going from the current position and velocity to the
-   * current position and zero velocity.
+   * Substitutes the current trajectory with a single-segment one going from the current position and velocity to
+   * zero velocity.
+   * \see parameter stop_trajectory_duration
    * \note This method is realtime-safe.
    */
   void setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh=RealtimeGoalHandlePtr());

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -748,6 +748,7 @@ setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh)
   typename Segment::State hold_start_state_ = typename Segment::State(1);
   typename Segment::State hold_end_state_ = typename Segment::State(1);
   const unsigned int n_joints = joints_.size();
+  const typename Segment::Time start_time  = time.toSec();
 
   if(stop_trajectory_duration_ == 0.0)
   {
@@ -757,8 +758,8 @@ setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh)
       hold_start_state_.position[0]     =  joints_[i].getPosition();
       hold_start_state_.velocity[0]     =  0.0;
       hold_start_state_.acceleration[0] =  0.0;
-      (*hold_trajectory_ptr_)[i].front().init(time.toSec(),  hold_start_state_,
-                                                           time.toSec(), hold_start_state_);
+      (*hold_trajectory_ptr_)[i].front().init(start_time,  hold_start_state_,
+                                              start_time, hold_start_state_);
       // Set goal handle for the segment
       (*hold_trajectory_ptr_)[i].front().setGoalHandle(gh);
     }
@@ -771,7 +772,6 @@ setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh)
     // - Create segment that goes from current state to above zero velocity state, in the desired time
     // NOTE: The symmetry assumption from the second point above might not hold for all possible segment types
 
-    const typename Segment::Time start_time  = time.toSec();
     const typename Segment::Time end_time    = time.toSec() + stop_trajectory_duration_;
     const typename Segment::Time end_time_2x = time.toSec() + 2.0 * stop_trajectory_duration_;
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -743,47 +743,64 @@ template <class SegmentImpl, class HardwareInterface>
 void JointTrajectoryController<SegmentImpl, HardwareInterface>::
 setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh)
 {
-  // Settle position in a fixed time. We do the following:
-  // - Create segment that goes from current (pos,vel) to (pos,-vel) in 2x the desired stop time
-  // - Assuming segment symmetry, sample segment at its midpoint (desired stop time). It should have zero velocity
-  // - Create segment that goes from current state to above zero velocity state, in the desired time
-  // NOTE: The symmetry assumption from the second point above might not hold for all possible segment types
-
   assert(joint_names_.size() == hold_trajectory_ptr_->size());
 
   typename Segment::State hold_start_state_ = typename Segment::State(1);
   typename Segment::State hold_end_state_ = typename Segment::State(1);
-
-  const typename Segment::Time start_time  = time.toSec();
-  const typename Segment::Time end_time    = time.toSec() + stop_trajectory_duration_;
-  const typename Segment::Time end_time_2x = time.toSec() + 2.0 * stop_trajectory_duration_;
-
-  // Create segment that goes from current (pos,vel) to (pos,-vel)
   const unsigned int n_joints = joints_.size();
-  for (unsigned int i = 0; i < n_joints; ++i)
+
+  if(stop_trajectory_duration_ == 0.0)
   {
-    // If there is a time delay in the system it is better to use calculate the hold trajectory starting from the
-    // desired position. Otherwise there would be a jerk in the motion.
-    hold_start_state_.position[0]     =  desired_state_.position[i];
-    hold_start_state_.velocity[0]     =  desired_state_.velocity[i];
-    hold_start_state_.acceleration[0] =  0.0;
+    // stop at current actual position
+    for (unsigned int i = 0; i < n_joints; ++i)
+    {
+      hold_start_state_.position[0]     =  joints_[i].getPosition();
+      hold_start_state_.velocity[0]     =  0.0;
+      hold_start_state_.acceleration[0] =  0.0;
+      (*hold_trajectory_ptr_)[i].front().init(time.toSec(),  hold_start_state_,
+                                                           time.toSec(), hold_start_state_);
+      // Set goal handle for the segment
+      (*hold_trajectory_ptr_)[i].front().setGoalHandle(gh);
+    }
+  }
+  else
+  {
+    // Settle position in a fixed time. We do the following:
+    // - Create segment that goes from current (pos,vel) to (pos,-vel) in 2x the desired stop time
+    // - Assuming segment symmetry, sample segment at its midpoint (desired stop time). It should have zero velocity
+    // - Create segment that goes from current state to above zero velocity state, in the desired time
+    // NOTE: The symmetry assumption from the second point above might not hold for all possible segment types
 
-    hold_end_state_.position[0]       =  desired_state_.position[i];
-    hold_end_state_.velocity[0]       = -desired_state_.velocity[i];
-    hold_end_state_.acceleration[0]   =  0.0;
+    const typename Segment::Time start_time  = time.toSec();
+    const typename Segment::Time end_time    = time.toSec() + stop_trajectory_duration_;
+    const typename Segment::Time end_time_2x = time.toSec() + 2.0 * stop_trajectory_duration_;
 
-    (*hold_trajectory_ptr_)[i].front().init(start_time,  hold_start_state_,
-                                                             end_time_2x, hold_end_state_);
+    // Create segment that goes from current (pos,vel) to (pos,-vel)
+    for (unsigned int i = 0; i < n_joints; ++i)
+    {
+      // If there is a time delay in the system it is better to calculate the hold trajectory starting from the
+      // desired position. Otherwise there would be a jerk in the motion.
+      hold_start_state_.position[0]     =  desired_state_.position[i];
+      hold_start_state_.velocity[0]     =  desired_state_.velocity[i];
+      hold_start_state_.acceleration[0] =  0.0;
 
-    // Sample segment at its midpoint, that should have zero velocity
-    (*hold_trajectory_ptr_)[i].front().sample(end_time, hold_end_state_);
+      hold_end_state_.position[0]       =  desired_state_.position[i];
+      hold_end_state_.velocity[0]       = -desired_state_.velocity[i];
+      hold_end_state_.acceleration[0]   =  0.0;
 
-    // Now create segment that goes from current state to one with zero end velocity
-    (*hold_trajectory_ptr_)[i].front().init(start_time, hold_start_state_,
-                                                             end_time,   hold_end_state_);
+      (*hold_trajectory_ptr_)[i].front().init(start_time,  hold_start_state_,
+                                                               end_time_2x, hold_end_state_);
 
-    // Set goal handle for the segment
-    (*hold_trajectory_ptr_)[i].front().setGoalHandle(gh);
+      // Sample segment at its midpoint, that should have zero velocity
+      (*hold_trajectory_ptr_)[i].front().sample(end_time, hold_end_state_);
+
+      // Now create segment that goes from current state to one with zero end velocity
+      (*hold_trajectory_ptr_)[i].front().init(start_time, hold_start_state_,
+                                                               end_time,   hold_end_state_);
+
+      // Set goal handle for the segment
+      (*hold_trajectory_ptr_)[i].front().setGoalHandle(gh);
+    }
   }
   curr_trajectory_box_.set(hold_trajectory_ptr_);
 }

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -35,5 +35,5 @@
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="95.0"/>
+        time-limit="85.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -35,5 +35,5 @@
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
-        time-limit="85.0"/>
+        time-limit="95.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_stopramp.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_stopramp.test
@@ -35,5 +35,5 @@
   <test test-name="joint_trajectory_controller_stopramp_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_stopramp_test"
-        time-limit="95.0"/>
+        time-limit="85.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_stopramp.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_stopramp.test
@@ -11,7 +11,7 @@
       type="rrbot"/>
 
   <!-- Load controller config -->
-  <rosparam command="load" file="$(find joint_trajectory_controller)/test/rrbot_vel_controllers.yaml" />
+  <rosparam command="load" file="$(find joint_trajectory_controller)/test/rrbot_controllers_stopramp.yaml" />
 
   <!-- Spawn controller -->
   <node name="controller_spawner"
@@ -32,8 +32,8 @@
   </group>
 
   <!-- Controller test -->
-  <test test-name="joint_trajectory_controller_vel_test"
+  <test test-name="joint_trajectory_controller_stopramp_test"
         pkg="joint_trajectory_controller"
-        type="joint_trajectory_controller_vel_test"
-        time-limit="120.0"/>
+        type="joint_trajectory_controller_stopramp_test"
+        time-limit="95.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -762,7 +762,6 @@ TEST_F(JointTrajectoryControllerTest, emptyTopicCancelsActionTraj)
   trajectory_msgs::JointTrajectory traj_empty;
   traj_pub.publish(traj_empty);
   ASSERT_TRUE(waitForState(action_client,  SimpleClientGoalState::PREEMPTED, short_timeout));
-  ros::Duration(2.0).sleep(); // Stopping takes some time
 
   // Check that we're not on the start state
   StateConstPtr state1 = getState();
@@ -812,7 +811,7 @@ TEST_F(JointTrajectoryControllerTest, emptyTopicCancelsActionTrajWithDelay)
     ActionGoal empty_goal;
     empty_goal.trajectory.joint_names = joint_names;
     action_client->sendGoal(empty_goal);
-    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, long_timeout));
+    ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, short_timeout));
 
     // Velocity should be continuous so all axes >= 0
     std::vector<double> minVelocity = getMinActualVelocity();
@@ -868,7 +867,7 @@ TEST_F(JointTrajectoryControllerTest, emptyTopicCancelsActionTrajWithDelayStopZe
   ActionGoal empty_goal;
   empty_goal.trajectory.joint_names = joint_names;
   action_client->sendGoal(empty_goal);
-  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, long_timeout));
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, short_timeout));
 
   StateConstPtr state1 = getState();
 
@@ -921,7 +920,7 @@ TEST_F(JointTrajectoryControllerTest, emptyActionCancelsTopicTraj)
   empty_goal.trajectory.joint_names = traj.joint_names;
   action_client->sendGoal(empty_goal);
   ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
-  ros::Duration(2.0).sleep(); // Stopping takes some time
+  ASSERT_TRUE(waitForState(action_client, SimpleClientGoalState::SUCCEEDED, short_timeout));
 
   // Check that we're not on the start state
   StateConstPtr state1 = getState();
@@ -965,7 +964,7 @@ TEST_F(JointTrajectoryControllerTest, emptyActionCancelsActionTraj)
   action_client2->sendGoal(empty_goal);
   ASSERT_TRUE(waitForState(action_client,  SimpleClientGoalState::PREEMPTED, short_timeout));
   ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::ACTIVE, short_timeout));
-  ros::Duration(2.0).sleep(); // Stopping takes some time
+  ASSERT_TRUE(waitForState(action_client2, SimpleClientGoalState::SUCCEEDED, short_timeout));
 
   // Check that we're not on the start state
   StateConstPtr state1 = getState();

--- a/joint_trajectory_controller/test/rrbot_controllers.yaml
+++ b/joint_trajectory_controller/test/rrbot_controllers.yaml
@@ -12,3 +12,5 @@ rrbot_controller:
     joint2:
       goal:       0.01
       trajectory: 0.05
+  stop_trajectory_duration: 0.1
+  state_publish_rate: 100

--- a/joint_trajectory_controller/test/rrbot_controllers_stopramp.yaml
+++ b/joint_trajectory_controller/test/rrbot_controllers_stopramp.yaml
@@ -12,5 +12,5 @@ rrbot_controller:
     joint2:
       goal:       0.01
       trajectory: 0.05
-  stop_trajectory_duration: 0.0
+  stop_trajectory_duration: 0.1
   state_publish_rate: 100


### PR DESCRIPTION
The current state is used for calculating the hold-trajectory, that results in a jump in the desired position. The time delay originating from the canopen communication leads to a desired position that is already in the past.

Below the effect can be clearly seen by comparing the trajectories (plotted from the CAN traces).

![kinetic-vs-fix_06](https://user-images.githubusercontent.com/29709121/30276474-416d022e-9705-11e7-8df4-6ae3ffe192ab.png)

It can be clearly seen that the desired trajectory switches the sign of the velocity. This results in a jerk of the respective drive. If the speed is high and/or the stop_time is reduced this effect increases.
I would also argue that this behavior causes mechanical stress in the robot.
 
Any opinions?

_Noticed with Schunk [LWA4p](https://github.com/ipa320/schunk_modular_robotics/tree/indigo_dev/schunk_description/urdf/lwa4p)_

