### PR TITLE
Enable forwarding of the acceleration values from the trajectory

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -384,7 +384,7 @@ update(const ros::Time& time, const ros::Duration& period)
     }
     desired_state_.position[i] = desired_joint_state_.position[0];
     desired_state_.velocity[i] = desired_joint_state_.velocity[0];
-    desired_state_.acceleration[i] = 0.0;
+    desired_state_.acceleration[i] = desired_joint_state_.acceleration[0]; ;
 
     state_joint_error_.position[0] = angles::shortest_angular_distance(current_state_.position[i],desired_joint_state_.position[0]);
     state_joint_error_.velocity[0] = desired_joint_state_.velocity[0] - current_state_.velocity[i];


### PR DESCRIPTION
The joint_trajectory_controller implementation does currently not support the forwarding of the acceleration values of the trajectory, although this information is available. This simple fix enables using the acceleration data from the trajectory for use with the PosVelAccJointHandle.