### PR TITLE
[DiffDrive] Per wheel multiplier

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -62,6 +62,7 @@ if (CATKIN_ENABLE_TESTING)
     test/diff_drive_timeout_test.cpp)
   target_link_libraries(diff_drive_timeout_test ${catkin_LIBRARIES})
   add_rostest(test/diff_drive_multipliers.test)
+  add_rostest(test/diff_drive_left_right_multipliers.test)
   add_rostest_gtest(diff_drive_fail_test
     test/diff_drive_wrong.test
     test/diff_drive_fail_test.cpp)

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -137,7 +137,8 @@ namespace diff_drive_controller{
 
     /// Wheel separation and radius calibration multipliers:
     double wheel_separation_multiplier_;
-    double wheel_radius_multiplier_;
+    double left_wheel_radius_multiplier_;
+    double right_wheel_radius_multiplier_;
 
     /// Timeout to consider cmd_vel commands old:
     double cmd_vel_timeout_;

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -141,7 +141,7 @@ namespace diff_drive_controller
 
     /**
      * \brief Sets the wheel parameters: radius and separation
-     * \param wheel_separation   Seperation between left and right wheels [m]
+     * \param wheel_separation   Separation between left and right wheels [m]
      * \param left_wheel_radius  Left wheel radius [m]
      * \param right_wheel_radius Right wheel radius [m]
      */

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -141,9 +141,9 @@ namespace diff_drive_controller
 
     /**
      * \brief Sets the wheel parameters: radius and separation
-     * \param wheel_separation Seperation between left and right wheels [m]
-     * \param wheel_radius     Left wheel radius [m]
-     * \param wheel_radius     Right wheel radius [m]
+     * \param wheel_separation   Seperation between left and right wheels [m]
+     * \param left_wheel_radius  Left wheel radius [m]
+     * \param right_wheel_radius Right wheel radius [m]
      */
     void setWheelParams(double wheel_separation, double left_wheel_radius, double right_wheel_radius);
 

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -142,9 +142,10 @@ namespace diff_drive_controller
     /**
      * \brief Sets the wheel parameters: radius and separation
      * \param wheel_separation Seperation between left and right wheels [m]
-     * \param wheel_radius     Wheel radius [m]
+     * \param wheel_radius     Left wheel radius [m]
+     * \param wheel_radius     Right wheel radius [m]
      */
-    void setWheelParams(double wheel_separation, double wheel_radius);
+    void setWheelParams(double wheel_separation, double left_wheel_radius, double right_wheel_radius);
 
     /**
      * \brief Velocity rolling window size setter
@@ -191,7 +192,8 @@ namespace diff_drive_controller
 
     /// Wheel kinematic parameters [m]:
     double wheel_separation_;
-    double wheel_radius_;
+    double left_wheel_radius_;
+    double right_wheel_radius_;
 
     /// Previou wheel position/state [rad]:
     double left_wheel_old_pos_;

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -55,7 +55,8 @@ namespace diff_drive_controller
   , linear_(0.0)
   , angular_(0.0)
   , wheel_separation_(0.0)
-  , wheel_radius_(0.0)
+  , left_wheel_radius_(0.0)
+  , right_wheel_radius_(0.0)
   , left_wheel_old_pos_(0.0)
   , right_wheel_old_pos_(0.0)
   , velocity_rolling_window_size_(velocity_rolling_window_size)
@@ -75,8 +76,8 @@ namespace diff_drive_controller
   bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)
   {
     /// Get current wheel joint positions:
-    const double left_wheel_cur_pos  = left_pos  * wheel_radius_;
-    const double right_wheel_cur_pos = right_pos * wheel_radius_;
+    const double left_wheel_cur_pos  = left_pos  * left_wheel_radius_;
+    const double right_wheel_cur_pos = right_pos * right_wheel_radius_;
 
     /// Estimate velocity of wheels using old and current position:
     const double left_wheel_est_vel  = left_wheel_cur_pos  - left_wheel_old_pos_;
@@ -122,10 +123,11 @@ namespace diff_drive_controller
     integrate_fun_(linear * dt, angular * dt);
   }
 
-  void Odometry::setWheelParams(double wheel_separation, double wheel_radius)
+  void Odometry::setWheelParams(double wheel_separation, double left_wheel_radius, double right_wheel_radius)
   {
-    wheel_separation_ = wheel_separation;
-    wheel_radius_     = wheel_radius;
+    wheel_separation_   = wheel_separation;
+    left_wheel_radius_  = left_wheel_radius;
+    right_wheel_radius_ = right_wheel_radius;
   }
 
   void Odometry::setVelocityRollingWindowSize(size_t velocity_rolling_window_size)

--- a/diff_drive_controller/test/diff_drive_left_right_multipliers.test
+++ b/diff_drive_controller/test/diff_drive_left_right_multipliers.test
@@ -1,0 +1,16 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Load diff drive parameter multipliers -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_left_right_multipliers.yaml" />
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_test"
+        time-limit="80.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diffbot_left_right_multipliers.yaml
+++ b/diff_drive_controller/test/diffbot_left_right_multipliers.yaml
@@ -1,0 +1,4 @@
+diffbot_controller:
+  wheel_separation_multiplier: 2.3
+  left_wheel_radius_multiplier: 1.4
+  right_wheel_radius_multiplier: 1.4


### PR DESCRIPTION
This PR allows to parametrize one calibration multiplier per wheel (left / right).  
The default behavior remains unchanged (looking for `wheel_radius_multiplier` if exists).  
The `diff_drive_multipliers.test` is duplicated to `diff_drive_left_right_multipliers.test` in order to test this.