### PR TITLE
[WIP - DiffDrive] Publish joint trajectory controller state 

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -3,6 +3,7 @@ project(diff_drive_controller)
 
 find_package(catkin REQUIRED COMPONENTS
     controller_interface
+    control_msgs
     nav_msgs
     realtime_tools
     tf

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -83,6 +83,14 @@ if (CATKIN_ENABLE_TESTING)
     test/diff_drive_pub_cmd_vel_out.test
     test/diff_drive_pub_cmd_vel_out_test.cpp)
   target_link_libraries(diff_drive_pub_cmd_vel_out_test ${catkin_LIBRARIES})
+  add_rostest_gtest(diff_drive_default_joint_trajectory_controller_state_test
+    test/diff_drive_default_joint_trajectory_controller_state.test
+    test/diff_drive_default_joint_trajectory_controller_state_test.cpp)
+  target_link_libraries(diff_drive_default_joint_trajectory_controller_state_test ${catkin_LIBRARIES})
+  add_rostest_gtest(diff_drive_publish_joint_trajectory_controller_state_test
+    test/diff_drive_publish_joint_trajectory_controller_state.test
+    test/diff_drive_publish_joint_trajectory_controller_state_test.cpp)
+  target_link_libraries(diff_drive_publish_joint_trajectory_controller_state_test ${catkin_LIBRARIES})
   add_rostest_gtest(diff_drive_default_odom_frame_test
     test/diff_drive_default_odom_frame.test
     test/diff_drive_default_odom_frame_test.cpp)

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -43,6 +43,7 @@
 #include <geometry_msgs/TwistStamped.h>
 #include <nav_msgs/Odometry.h>
 #include <tf/tfMessage.h>
+#include <control_msgs/JointTrajectoryControllerState.h>
 
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_publisher.h>
@@ -108,6 +109,17 @@ namespace diff_drive_controller{
     std::vector<hardware_interface::JointHandle> left_wheel_joints_;
     std::vector<hardware_interface::JointHandle> right_wheel_joints_;
 
+    // Previous time
+    ros::Time time_previous_;
+
+    /// Previous velocities from the encoders:
+    std::vector<double> vel_left_previous_;
+    std::vector<double> vel_right_previous_;
+
+    /// Previous velocities from the encoders:
+    double vel_left_desired_previous_;
+    double vel_right_desired_previous_;
+
     /// Velocity command related:
     struct Commands
     {
@@ -128,6 +140,9 @@ namespace diff_drive_controller{
     boost::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::Odometry> > odom_pub_;
     boost::shared_ptr<realtime_tools::RealtimePublisher<tf::tfMessage> > tf_odom_pub_;
     Odometry odometry_;
+
+    /// Joint Trajectory Controller State
+    boost::shared_ptr<realtime_tools::RealtimePublisher<control_msgs::JointTrajectoryControllerState> > joint_trajectory_controller_state_pub_;
 
     /// Wheel separation, wrt the midpoint of the wheel width:
     double wheel_separation_;
@@ -165,6 +180,9 @@ namespace diff_drive_controller{
 
     /// Publish limited velocity:
     bool publish_cmd_;
+
+    /// Publish wheel data:
+    bool publish_joint_trajectory_controller_state_;
 
   private:
     /**

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>controller_interface</depend>
+  <depend>control_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>realtime_tools</depend>
   <depend>tf</depend>

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -163,6 +163,7 @@ namespace diff_drive_controller{
     , enable_odom_tf_(true)
     , wheel_joints_size_(0)
     , publish_cmd_(false)
+    , publish_joint_trajectory_controller_state_(false)
   {
   }
 
@@ -263,6 +264,9 @@ namespace diff_drive_controller{
     // Publish limited velocity:
     controller_nh.param("publish_cmd", publish_cmd_, publish_cmd_);
 
+    // Publish wheel data:
+    controller_nh.param("publish_joint_trajectory_controller_state", publish_joint_trajectory_controller_state_, publish_joint_trajectory_controller_state_);
+
     // If either parameter is not available, we need to look up the value in the URDF
     bool lookup_wheel_separation = !controller_nh.getParam("wheel_separation", wheel_separation_);
     bool lookup_wheel_radius = !controller_nh.getParam("wheel_radius", wheel_radius_);
@@ -290,6 +294,40 @@ namespace diff_drive_controller{
     if (publish_cmd_)
     {
       cmd_vel_pub_.reset(new realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped>(controller_nh, "cmd_vel_out", 100));
+    }
+
+    // Wheel data:
+    if (publish_joint_trajectory_controller_state_)
+    {
+      joint_trajectory_controller_state_pub_ = boost::make_shared<realtime_tools::RealtimePublisher<control_msgs::JointTrajectoryControllerState> >(controller_nh, "joint_trajectory_controller_state", 100);
+
+      const size_t num_wheels = wheel_joints_size_ * 2;
+
+      joint_trajectory_controller_state_pub_->msg_.joint_names.resize(num_wheels);
+
+      joint_trajectory_controller_state_pub_->msg_.desired.positions.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.desired.velocities.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.desired.accelerations.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.desired.effort.resize(num_wheels);
+
+      joint_trajectory_controller_state_pub_->msg_.actual.positions.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.actual.velocities.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.actual.accelerations.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.actual.effort.resize(num_wheels);
+
+      joint_trajectory_controller_state_pub_->msg_.error.positions.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.error.velocities.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.error.accelerations.resize(num_wheels);
+      joint_trajectory_controller_state_pub_->msg_.error.effort.resize(num_wheels);
+
+      for (size_t i = 0; i < wheel_joints_size_; ++i)
+      {
+        joint_trajectory_controller_state_pub_->msg_.joint_names[i] = left_wheel_names[i];
+        joint_trajectory_controller_state_pub_->msg_.joint_names[i + wheel_joints_size_] = right_wheel_names[i];
+      }
+
+      vel_left_previous_.resize(wheel_joints_size_, 0.0);
+      vel_right_previous_.resize(wheel_joints_size_, 0.0);
     }
 
     // Get the joint object to use in the realtime loop
@@ -382,6 +420,11 @@ namespace diff_drive_controller{
     // Limit velocities and accelerations:
     const double cmd_dt(period.toSec());
 
+    // Compute desired wheels velocities,
+    // that is before applying limits:
+    const double vel_left_desired  = (curr_cmd.lin - curr_cmd.ang * ws / 2.0)/wr;
+    const double vel_right_desired = (curr_cmd.lin + curr_cmd.ang * ws / 2.0)/wr;
+
     limiter_lin_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, cmd_dt);
     limiter_ang_.limit(curr_cmd.ang, last0_cmd_.ang, last1_cmd_.ang, cmd_dt);
 
@@ -411,6 +454,71 @@ namespace diff_drive_controller{
       left_wheel_joints_[i].setCommand(vel_left);
       right_wheel_joints_[i].setCommand(vel_right);
     }
+
+    // Publish wheel data:
+    if (publish_joint_trajectory_controller_state_ && joint_trajectory_controller_state_pub_->trylock())
+    {
+      joint_trajectory_controller_state_pub_->msg_.header.stamp = time;
+
+      for (size_t i = 0; i < wheel_joints_size_; ++i)
+      {
+        const double control_duration = (time - time_previous_).toSec();
+
+        const double left_wheel_acc = (left_wheel_joints_[i].getVelocity() - vel_left_previous_[i]) / control_duration;
+        const double right_wheel_acc = (right_wheel_joints_[i].getVelocity() - vel_right_previous_[i]) / control_duration;
+
+        // Actual
+        joint_trajectory_controller_state_pub_->msg_.actual.positions[i]     = left_wheel_joints_[i].getPosition();
+        joint_trajectory_controller_state_pub_->msg_.actual.velocities[i]    = left_wheel_joints_[i].getVelocity();
+        joint_trajectory_controller_state_pub_->msg_.actual.accelerations[i] = left_wheel_acc;
+        joint_trajectory_controller_state_pub_->msg_.actual.effort[i]        = left_wheel_joints_[i].getEffort();
+
+        joint_trajectory_controller_state_pub_->msg_.actual.positions[i + wheel_joints_size_]     = right_wheel_joints_[i].getPosition();
+        joint_trajectory_controller_state_pub_->msg_.actual.velocities[i + wheel_joints_size_]    = right_wheel_joints_[i].getVelocity();
+        joint_trajectory_controller_state_pub_->msg_.actual.accelerations[i + wheel_joints_size_] = right_wheel_acc;
+        joint_trajectory_controller_state_pub_->msg_.actual.effort[i+ wheel_joints_size_]         = right_wheel_joints_[i].getEffort();
+
+        // Desired
+        joint_trajectory_controller_state_pub_->msg_.desired.positions[i]    += vel_left_desired * cmd_dt;
+        joint_trajectory_controller_state_pub_->msg_.desired.velocities[i]    = vel_left_desired;
+        joint_trajectory_controller_state_pub_->msg_.desired.accelerations[i] = (vel_left_desired - vel_left_desired_previous_) * cmd_dt;
+        joint_trajectory_controller_state_pub_->msg_.desired.effort[i]        = std::numeric_limits<double>::quiet_NaN();
+
+        joint_trajectory_controller_state_pub_->msg_.desired.positions[i + wheel_joints_size_]    += vel_right_desired * cmd_dt;
+        joint_trajectory_controller_state_pub_->msg_.desired.velocities[i + wheel_joints_size_]    = vel_right_desired;
+        joint_trajectory_controller_state_pub_->msg_.desired.accelerations[i + wheel_joints_size_] = (vel_right_desired - vel_right_desired_previous_) * cmd_dt;
+        joint_trajectory_controller_state_pub_->msg_.desired.effort[i+ wheel_joints_size_]         = std::numeric_limits<double>::quiet_NaN();
+
+        // Error
+        joint_trajectory_controller_state_pub_->msg_.error.positions[i]     = joint_trajectory_controller_state_pub_->msg_.desired.positions[i] -
+                                                                              joint_trajectory_controller_state_pub_->msg_.actual.positions[i];
+        joint_trajectory_controller_state_pub_->msg_.error.velocities[i]    = joint_trajectory_controller_state_pub_->msg_.desired.velocities[i] -
+                                                                              joint_trajectory_controller_state_pub_->msg_.actual.velocities[i];
+        joint_trajectory_controller_state_pub_->msg_.error.accelerations[i] = joint_trajectory_controller_state_pub_->msg_.desired.accelerations[i] -
+                                                                              joint_trajectory_controller_state_pub_->msg_.actual.accelerations[i];
+        joint_trajectory_controller_state_pub_->msg_.error.effort[i]        = joint_trajectory_controller_state_pub_->msg_.desired.effort[i] -
+                                                                              joint_trajectory_controller_state_pub_->msg_.actual.effort[i];
+
+        joint_trajectory_controller_state_pub_->msg_.error.positions[i + wheel_joints_size_]     = joint_trajectory_controller_state_pub_->msg_.desired.positions[i + wheel_joints_size_] -
+                                                                                                   joint_trajectory_controller_state_pub_->msg_.actual.positions[i + wheel_joints_size_];
+        joint_trajectory_controller_state_pub_->msg_.error.velocities[i + wheel_joints_size_]    = joint_trajectory_controller_state_pub_->msg_.desired.velocities[i + wheel_joints_size_] -
+                                                                                                   joint_trajectory_controller_state_pub_->msg_.actual.velocities[i + wheel_joints_size_];
+        joint_trajectory_controller_state_pub_->msg_.error.accelerations[i + wheel_joints_size_] = joint_trajectory_controller_state_pub_->msg_.desired.accelerations[i + wheel_joints_size_] -
+                                                                                                   joint_trajectory_controller_state_pub_->msg_.actual.accelerations[i + wheel_joints_size_];
+        joint_trajectory_controller_state_pub_->msg_.error.effort[i+ wheel_joints_size_]         = joint_trajectory_controller_state_pub_->msg_.desired.effort[i + wheel_joints_size_] -
+                                                                                                   joint_trajectory_controller_state_pub_->msg_.actual.effort[i + wheel_joints_size_];
+
+        // Save previous velocities to compute acceleration
+        vel_left_previous_[i] = left_wheel_joints_[i].getVelocity();
+        vel_right_previous_[i] = right_wheel_joints_[i].getVelocity();
+        vel_left_desired_previous_ = vel_left_desired;
+        vel_right_desired_previous_ = vel_right_desired;
+      }
+
+      joint_trajectory_controller_state_pub_->unlockAndPublish();
+    }
+
+    time_previous_ = time;
   }
 
   void DiffDriveController::starting(const ros::Time& time)
@@ -419,6 +527,7 @@ namespace diff_drive_controller{
 
     // Register starting time used to keep fixed rate
     last_state_publish_time_ = time;
+    time_previous_ = time;
 
     odometry_.init(time);
   }

--- a/diff_drive_controller/test/diff_drive_default_joint_trajectory_controller_state.test
+++ b/diff_drive_controller/test/diff_drive_default_joint_trajectory_controller_state.test
@@ -1,0 +1,20 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- default value -->
+  <!-- <rosparam>
+    diffbot_controller:
+      publish_joint_trajectory_controller_state: False
+  </rosparam> -->
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_default_joint_trajectory_controller_state_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_default_joint_trajectory_controller_state_test"
+        time-limit="30.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+    <remap from="joint_trajectory_controller_state" to="diffbot_controller/joint_trajectory_controller_state" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diff_drive_default_joint_trajectory_controller_state_test.cpp
+++ b/diff_drive_controller/test/diff_drive_default_joint_trajectory_controller_state_test.cpp
@@ -1,0 +1,68 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2018, PAL Robotics.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Jeremie Deray
+
+#include "test_common.h"
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testDefaultJointTrajectoryControllerStateTopic)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+
+  EXPECT_FALSE(isPublishingJointTrajectoryControllerState());
+
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  EXPECT_FALSE(isPublishingJointTrajectoryControllerState());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_default_joint_traj_controller_state_topic_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/diff_drive_publish_joint_trajectory_controller_state.test
+++ b/diff_drive_controller/test/diff_drive_publish_joint_trajectory_controller_state.test
@@ -1,0 +1,20 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- default value -->
+   <rosparam>
+    diffbot_controller:
+      publish_joint_trajectory_controller_state: True
+  </rosparam>
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_publish_joint_trajectory_controller_state_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_publish_joint_trajectory_controller_state_test"
+        time-limit="30.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+    <remap from="joint_trajectory_controller_state" to="diffbot_controller/joint_trajectory_controller_state" />
+  </test>
+</launch>

--- a/diff_drive_controller/test/diff_drive_publish_joint_trajectory_controller_state_test.cpp
+++ b/diff_drive_controller/test/diff_drive_publish_joint_trajectory_controller_state_test.cpp
@@ -1,0 +1,68 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2018, PAL Robotics.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+/// \author Jeremie Deray
+
+#include "test_common.h"
+
+// TEST CASES
+TEST_F(DiffDriveControllerTest, testPublishJointTrajectoryControllerStateTopic)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+
+  EXPECT_TRUE(isPublishingJointTrajectoryControllerState());
+
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  cmd_vel.linear.x = 0.1;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  EXPECT_TRUE(isPublishingJointTrajectoryControllerState());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "diff_drive_publish_joint_traj_controller_state_topic_test");
+
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -35,6 +35,7 @@
 
 #include <geometry_msgs/TwistStamped.h>
 #include <nav_msgs/Odometry.h>
+#include <control_msgs/JointTrajectoryControllerState.h>
 #include <tf/tf.h>
 
 #include <std_srvs/Empty.h>
@@ -55,6 +56,7 @@ public:
   : cmd_pub(nh.advertise<geometry_msgs::Twist>("cmd_vel", 100))
   , odom_sub(nh.subscribe("odom", 100, &DiffDriveControllerTest::odomCallback, this))
   , vel_out_sub(nh.subscribe("cmd_vel_out", 100, &DiffDriveControllerTest::cmdVelOutCallback, this))
+  , joint_traj_controller_state_sub(nh.subscribe("joint_trajectory_controller_state", 100, &DiffDriveControllerTest::jointTrajectoryControllerStateCallback, this))
   , start_srv(nh.serviceClient<std_srvs::Empty>("start"))
   , stop_srv(nh.serviceClient<std_srvs::Empty>("stop"))
   {
@@ -63,13 +65,16 @@ public:
   ~DiffDriveControllerTest()
   {
     odom_sub.shutdown();
+    joint_traj_controller_state_sub.shutdown();
   }
 
   nav_msgs::Odometry getLastOdom(){ return last_odom; }
   geometry_msgs::TwistStamped getLastCmdVelOut(){ return last_cmd_vel_out; }
+  control_msgs::JointTrajectoryControllerState getLastJointTrajectoryControllerState(){ return last_joint_traj_controller_state; }
   void publish(geometry_msgs::Twist cmd_vel){ cmd_pub.publish(cmd_vel); }
   bool isControllerAlive(){ return (odom_sub.getNumPublishers() > 0) && (cmd_pub.getNumSubscribers() > 0); }
   bool isPublishingCmdVelOut(){ return (vel_out_sub.getNumPublishers() > 0); }
+  bool isPublishingJointTrajectoryControllerState(){ return (joint_traj_controller_state_sub.getNumPublishers() > 0); }
 
   void start(){ std_srvs::Empty srv; start_srv.call(srv); }
   void stop(){ std_srvs::Empty srv; stop_srv.call(srv); }
@@ -81,6 +86,8 @@ private:
   ros::Subscriber vel_out_sub;
   nav_msgs::Odometry last_odom;
   geometry_msgs::TwistStamped last_cmd_vel_out;
+  ros::Subscriber joint_traj_controller_state_sub;
+  control_msgs::JointTrajectoryControllerState last_joint_traj_controller_state;
 
   ros::ServiceClient start_srv;
   ros::ServiceClient stop_srv;
@@ -92,6 +99,15 @@ private:
                      << ", lin_est: " << odom.twist.twist.linear.x
                      << ", ang_est: " << odom.twist.twist.angular.z);
     last_odom = odom;
+  }
+
+  void jointTrajectoryControllerStateCallback(const control_msgs::JointTrajectoryControllerState& joint_traj_controller_state)
+  {
+    ROS_INFO_STREAM("Joint trajectory controller state callback.");
+    ROS_DEBUG_STREAM("Joint trajectory controller state callback received:\n" <<
+                     joint_traj_controller_state);
+
+    last_joint_traj_controller_state = joint_traj_controller_state;
   }
 
   void cmdVelOutCallback(const geometry_msgs::TwistStamped& cmd_vel_out)


### PR DESCRIPTION
Allows to publish the 'wheel data' as reported by the `hardware_interface::JointHandle` functions `getVelocity() / getPosition()`.