### PR TITLE
[DiffDrive] Test fixing

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -34,7 +34,7 @@ install(FILES diff_drive_controller_plugins.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS controller_manager rostest std_srvs tf)
+  find_package(catkin REQUIRED COMPONENTS controller_manager rosgraph_msgs rostest std_srvs tf)
   include_directories(include ${catkin_INCLUDE_DIRS})
 
   add_executable(diffbot test/diffbot.cpp)

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -21,9 +21,10 @@
   <depend>tf</depend>
   <depend>urdf</depend>
 
+  <test_depend>controller_manager</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>std_srvs</test_depend>
-  <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/diff_drive_controller/test/diff_drive_common.launch
+++ b/diff_drive_controller/test/diff_drive_common.launch
@@ -1,4 +1,7 @@
 <launch>
+  <!-- Use simulation time -->
+  <rosparam param="use_sim_time">True</rosparam>
+
   <!-- Load diffbot model -->
   <param name="robot_description"
          command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro' --inorder" />

--- a/diff_drive_controller/test/diff_drive_default_cmd_vel_out_test.cpp
+++ b/diff_drive_controller/test/diff_drive_default_cmd_vel_out_test.cpp
@@ -33,10 +33,11 @@
 TEST_F(DiffDriveControllerTest, testDefaultCmdVelOutTopic)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+  // msgs are published in the same loop
+  // thus if odom is published cmd_vel_out
+  // should be as well (if enabled)
+  waitForOdomMsgs();
 
   EXPECT_FALSE(isPublishingCmdVelOut());
 

--- a/diff_drive_controller/test/diff_drive_default_odom_frame_test.cpp
+++ b/diff_drive_controller/test/diff_drive_default_odom_frame_test.cpp
@@ -34,10 +34,8 @@
 TEST_F(DiffDriveControllerTest, testOdomFrame)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+
   // set up tf listener
   tf::TransformListener listener;
   ros::Duration(2.0).sleep();
@@ -48,10 +46,8 @@ TEST_F(DiffDriveControllerTest, testOdomFrame)
 TEST_F(DiffDriveControllerTest, testOdomTopic)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+  waitForOdomMsgs();
 
   // get an odom message
   nav_msgs::Odometry odom_msg = getLastOdom();

--- a/diff_drive_controller/test/diff_drive_fail_test.cpp
+++ b/diff_drive_controller/test/diff_drive_fail_test.cpp
@@ -34,11 +34,14 @@ TEST_F(DiffDriveControllerTest, testWrongJointName)
 {
   // the controller should never be alive
   int secs = 0;
-  while(!isControllerAlive() && secs < 5)
+  while(!isControllerAlive() && ros::ok() && secs < 5)
   {
     ros::Duration(1.0).sleep();
     secs++;
   }
+  if (!ros::ok())
+    FAIL() << "Something went wrong while executing test.";
+
   // give up and assume controller load failure after 5 seconds
   EXPECT_GE(secs, 5);
 }

--- a/diff_drive_controller/test/diff_drive_multiple_cmd_vel_publishers_test.cpp
+++ b/diff_drive_controller/test/diff_drive_multiple_cmd_vel_publishers_test.cpp
@@ -33,11 +33,9 @@
 TEST_F(DiffDriveControllerTest, breakWithMultiplePublishers)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
- 
+  waitForController();
+  waitForOdomMsgs();
+
   nav_msgs::Odometry old_odom = getLastOdom();
   //TODO: we should be programatically publish from 2 different nodes
   // not the current hacky solution with the launch files

--- a/diff_drive_controller/test/diff_drive_odom_frame_test.cpp
+++ b/diff_drive_controller/test/diff_drive_odom_frame_test.cpp
@@ -34,10 +34,8 @@
 TEST_F(DiffDriveControllerTest, testNoOdomFrame)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+
   // set up tf listener
   tf::TransformListener listener;
   ros::Duration(2.0).sleep();
@@ -48,10 +46,8 @@ TEST_F(DiffDriveControllerTest, testNoOdomFrame)
 TEST_F(DiffDriveControllerTest, testNewOdomFrame)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+
   // set up tf listener
   tf::TransformListener listener;
   ros::Duration(2.0).sleep();
@@ -62,10 +58,10 @@ TEST_F(DiffDriveControllerTest, testNewOdomFrame)
 TEST_F(DiffDriveControllerTest, testOdomTopic)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+
+  // wait until we received first odom msg
+  waitForOdomMsgs();
 
   // get an odom message
   nav_msgs::Odometry odom_msg = getLastOdom();

--- a/diff_drive_controller/test/diff_drive_pub_cmd_vel_out_test.cpp
+++ b/diff_drive_controller/test/diff_drive_pub_cmd_vel_out_test.cpp
@@ -33,10 +33,11 @@
 TEST_F(DiffDriveControllerTest, testCmdVelOutTopic)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+  // msgs are published in the same loop
+  // thus if odom is published cmd_vel_out
+  // should be as well (if enabled)
+  waitForOdomMsgs();
 
   EXPECT_TRUE(isPublishingCmdVelOut());
 

--- a/diff_drive_controller/test/diffbot.cpp
+++ b/diff_drive_controller/test/diffbot.cpp
@@ -29,6 +29,7 @@
 
 // ROS
 #include <ros/ros.h>
+#include <rosgraph_msgs/Clock.h>
 
 // ros_control
 #include <controller_manager/controller_manager.h>
@@ -40,19 +41,54 @@ int main(int argc, char **argv)
   ros::init(argc, argv, "diffbot");
   ros::NodeHandle nh;
 
+  // This should be set in launch files
+  // as well
+  nh.setParam("/use_sim_time", true);
+
   Diffbot<> robot;
   ROS_WARN_STREAM("period: " << robot.getPeriod().toSec());
   controller_manager::ControllerManager cm(&robot, nh);
 
-  ros::Rate rate(1.0 / robot.getPeriod().toSec());
+  ros::Publisher clock_publisher = nh.advertise<rosgraph_msgs::Clock>("/clock", 1);
+
   ros::AsyncSpinner spinner(1);
   spinner.start();
+
+  boost::chrono::system_clock::time_point begin = boost::chrono::system_clock::now();
+  boost::chrono::system_clock::time_point end   = boost::chrono::system_clock::now();
+
+  ros::Time internal_time(0);
+  const ros::Duration dt = robot.getPeriod();
+  double elapsed_secs = 0;
+
   while(ros::ok())
   {
+    begin = boost::chrono::system_clock::now();
+
     robot.read();
-    cm.update(robot.getTime(), robot.getPeriod());
+    cm.update(internal_time, dt);
+
     robot.write();
-    rate.sleep();
+
+    end = boost::chrono::system_clock::now();
+
+    elapsed_secs = boost::chrono::duration_cast<boost::chrono::duration<double> >((end - begin)).count();
+
+    if (dt.toSec() - elapsed_secs < 0.0)
+    {
+      ROS_WARN_STREAM_THROTTLE(
+            0.1, "Control cycle is taking to much time, elapsed: " << elapsed_secs);
+    }
+    else
+    {
+      ROS_DEBUG_STREAM_THROTTLE(1.0, "Control cycle is, elapsed: " << elapsed_secs);
+      usleep((dt.toSec() - elapsed_secs) * 1e6);
+    }
+
+    rosgraph_msgs::Clock clock;
+    clock.clock = ros::Time(internal_time);
+    clock_publisher.publish(clock);
+    internal_time += dt;
   }
   spinner.stop();
 


### PR DESCRIPTION
Fixing diff_drive_odom_frame_test.

In some cases the test `testOdomTopic` might be calling `getLastOdom()` before any odom message is received. It thus evaluate a default constructed msg.

I also turned the `while` loop that wait for the controller to be up into a function. It also ensure that `ros::ok()` otherwise launching manually a test without the controller get stuck in an infinite loop...