### PR TITLE
fix xacro macro warning

### DIFF
--- a/diff_drive_controller/test/square_wheel.xacro
+++ b/diff_drive_controller/test/square_wheel.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <macro name="square_wheel" params="name parent radius *origin">
+  <xacro:macro name="square_wheel" params="name parent radius *origin">
     <link name="${name}_link">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0"/>
@@ -25,7 +25,7 @@
     <joint name="${name}_joint" type="continuous">
       <parent link="${parent}_link"/>
       <child link="${name}_link"/>
-      <insert_block name="origin"/>
+      <xacro:insert_block name="origin"/>
       <axis xyz="0 0 1"/>
     </joint>
 
@@ -40,5 +40,5 @@
     <gazebo reference="${name}_link">
       <material>Gazebo/Red</material>
     </gazebo>
-  </macro>
+  </xacro:macro>
 </robot>


### PR DESCRIPTION
The machine told me 
```sh
deprecated: xacro tags should be prepended with 'xacro' xml namespace.
Use the following script to fix incorrect usage:
        find . -iname "*.xacro" | xargs sed -i 's#<\([/]\?\)\(if\|unless\|include\|arg\|property\|macro\|insert_block\)#<\1xacro:\2#g'
```

So I did.