### PR TITLE
WIP: Add effort sampling support

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(${PROJECT_NAME} src/joint_trajectory_controller.cpp
                             include/joint_trajectory_controller/tolerances.h
                             include/trajectory_interface/trajectory_interface.h
                             include/trajectory_interface/quintic_spline_segment.h
-                            include/trajectory_interface/pos_vel_acc_state.h)
+                            include/trajectory_interface/pos_vel_acc_eff_state.h)
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -125,7 +125,10 @@ public:
   {
     // Forward desired position to command
     const unsigned int n_joints = joint_handles_ptr_->size();
-    for (unsigned int i = 0; i < n_joints; ++i) {(*joint_handles_ptr_)[i].setCommand(desired_state.position[i]);}
+    for (unsigned int i = 0; i < n_joints; ++i)
+    {
+        (*joint_handles_ptr_)[i].setCommand(desired_state.position[i]);
+    }
   }
 
 private:

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -384,6 +384,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       // Get the first time and state that will be executed from the new trajectory
       trajectory_msgs::JointTrajectoryPoint point_per_joint;
       if (!it->positions.empty())     {point_per_joint.positions.resize(1, it->positions[msg_joint_it]);}
+      if (!it->effort.empty())     {point_per_joint.effort.resize(1, it->effort[msg_joint_it]);}
       if (!it->velocities.empty())    {point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);}
       if (!it->accelerations.empty()) {point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);}
       point_per_joint.time_from_start = it->time_from_start;
@@ -438,6 +439,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       if (!isValid(*it, it->positions.size()))
             throw(std::invalid_argument("Size mismatch in trajectory point position, velocity or acceleration data."));
       if (!it->positions.empty())     {it_point_per_joint.positions.resize(1, it->positions[msg_joint_it]);}
+      if (!it->effort.empty())     {it_point_per_joint.effort.resize(1, it->effort[msg_joint_it]);}
       if (!it->velocities.empty())    {it_point_per_joint.velocities.resize(1, it->velocities[msg_joint_it]);}
       if (!it->accelerations.empty()) {it_point_per_joint.accelerations.resize(1, it->accelerations[msg_joint_it]);}
       it_point_per_joint.time_from_start = it->time_from_start;
@@ -445,6 +447,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       if (!isValid(*next_it, next_it->positions.size()))
             throw(std::invalid_argument("Size mismatch in trajectory point position, velocity or acceleration data."));
       if (!next_it->positions.empty()) {next_it_point_per_joint.positions.resize(1, next_it->positions[msg_joint_it]);}
+      if (!next_it->effort.empty()) {next_it_point_per_joint.effort.resize(1, next_it->effort[msg_joint_it]);}
       if (!next_it->velocities.empty()) {next_it_point_per_joint.velocities.resize(1, next_it->velocities[msg_joint_it]);}
       if (!next_it->accelerations.empty()) {next_it_point_per_joint.accelerations.resize(1, next_it->accelerations[msg_joint_it]);}
       next_it_point_per_joint.time_from_start = next_it->time_from_start;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_msg_utils.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_msg_utils.h
@@ -85,6 +85,9 @@ inline bool isValid(const trajectory_msgs::JointTrajectoryPoint& point, const un
   if (!point.positions.empty()     && point.positions.size()     != joint_dim) {return false;}
   if (!point.velocities.empty()    && point.velocities.size()    != joint_dim) {return false;}
   if (!point.accelerations.empty() && point.accelerations.size() != joint_dim) {return false;}
+
+  if (!point.positions.empty() && !point.effort.empty() && point.effort.size() != joint_dim) {return false;}
+
   return true;
 }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -118,6 +118,7 @@ public:
       if (!point.positions.empty())     {this->position.resize(joint_dim);}
       if (!point.velocities.empty())    {this->velocity.resize(joint_dim);}
       if (!point.accelerations.empty()) {this->acceleration.resize(joint_dim);}
+      if (!point.effort.empty()) {this->effort.resize(joint_dim);}
 
       for (unsigned int i = 0; i < joint_dim; ++i)
       {
@@ -125,6 +126,7 @@ public:
         const Scalar offset = position_offset.empty() ? 0.0 : position_offset[i];
 
         if (!point.positions.empty())     {this->position[i]     = point.positions[i] + offset;}
+        if (!point.effort.empty())        {this->effort[i]     = point.effort[i];}
         if (!point.velocities.empty())    {this->velocity[i]     = point.velocities[i];}
         if (!point.accelerations.empty()) {this->acceleration[i] = point.accelerations[i];}
       }

--- a/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_eff_state.h
+++ b/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_eff_state.h
@@ -29,8 +29,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRAJECTORY_INTERFACE_POS_VEL_ACC_STATE_H
-#define TRAJECTORY_INTERFACE_POS_VEL_ACC_STATE_H
+#ifndef TRAJECTORY_INTERFACE_POS_VEL_ACC_EFF_STATE_H
+#define TRAJECTORY_INTERFACE_POS_VEL_ACC_EFF_STATE_H
 
 #include <vector>
 
@@ -41,11 +41,11 @@ namespace trajectory_interface
  * \brief Multi-dof trajectory state containing position, velocity and acceleration data.
  */
 template <class ScalarType>
-struct PosVelAccState
+struct PosVelAccEffState
 {
   typedef ScalarType Scalar;
 
-  PosVelAccState() {}
+  PosVelAccEffState() {}
 
    /**
     * \brief Resource-preallocating constructor.
@@ -61,15 +61,17 @@ struct PosVelAccState
     * zero_pos.position.resize(2);
     * \endcode
     */
-  PosVelAccState(const typename std::vector<Scalar>::size_type size)
+  PosVelAccEffState(const typename std::vector<Scalar>::size_type size)
     : position(    std::vector<Scalar>(size, static_cast<Scalar>(0))),
       velocity(    std::vector<Scalar>(size, static_cast<Scalar>(0))),
-      acceleration(std::vector<Scalar>(size, static_cast<Scalar>(0)))
+      acceleration(std::vector<Scalar>(size, static_cast<Scalar>(0))),
+      effort(std::vector<Scalar>(size, static_cast<Scalar>(0)))
   {}
 
   std::vector<Scalar> position;
   std::vector<Scalar> velocity;
   std::vector<Scalar> acceleration;
+  std::vector<Scalar> effort;
 };
 
 } // namespace

--- a/joint_trajectory_controller/test/tolerances_test.cpp
+++ b/joint_trajectory_controller/test/tolerances_test.cpp
@@ -29,11 +29,11 @@
 
 #include <gtest/gtest.h>
 #include <ros/ros.h>
-#include <trajectory_interface/pos_vel_acc_state.h>
+#include <trajectory_interface/pos_vel_acc_eff_state.h>
 #include <joint_trajectory_controller/tolerances.h>
 
 using namespace joint_trajectory_controller;
-typedef trajectory_interface::PosVelAccState<double> State;
+typedef trajectory_interface::PosVelAccEffState<double> State;
 typedef StateTolerances<double> StateTols;
 
 TEST(TolerancesTest, CheckStateTolerance)


### PR DESCRIPTION
This branch adds support for sampling effort values specified on JointTrajectoryMsgs. 
The controller does a linear interpolation of the effort values which any interface can
use via the enhanced pos_vel_acc_eff state used by QuinticSplineSegment.