### PR TITLE
fix license string

### DIFF
--- a/rqt_joint_trajectory_controller/package.xml
+++ b/rqt_joint_trajectory_controller/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
 
   <author email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodriguez Tsouroukdissian</author>
-  <license>Modified BSD</license>
+  <license>BSD</license>
   <url type="website">http://wiki.ros.org/rqt_joint_trajectory_controller</url>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
Fix license string in package xml, fixes ros-controls/ros_control#326 

```find ros_control* -name package.xml -print0 | xargs -0 grep BSD``` only shows ```<license>BSD</license>``` now

Second pull request in ros_controllers incoming.