### PR TITLE
Make the compiler happy in the test.

### DIFF
--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -189,10 +189,10 @@ protected:
 
     std::transform(controller_min_actual_velocity.begin(), controller_min_actual_velocity.end(),
                    state->actual.velocities.begin(), controller_min_actual_velocity.begin(),
-                   std::min<double>);
+                   [](double a, double b){return std::min(a, b);});
     std::transform(controller_max_actual_velocity.begin(), controller_max_actual_velocity.end(),
                    state->actual.velocities.begin(), controller_max_actual_velocity.begin(),
-                   std::max<double>);
+                   [](double a, double b){return std::max(a, b);});
   }
 
   StateConstPtr getState()


### PR DESCRIPTION
This should fix the error that is happening on Melodic: http://build.ros.org/view/Mdev/job/Mdev__ros_controllers__ubuntu_bionic_amd64/3/console

The test still fails for some reason, but at least it
compiles now.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>