### PR TITLE
fix test

### DIFF
--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -70,7 +70,16 @@ public:
   geometry_msgs::TwistStamped getLastCmdVelOut(){ return last_cmd_vel_out; }
   void publish(geometry_msgs::Twist cmd_vel){ cmd_pub.publish(cmd_vel); }
   bool isControllerAlive()const{ return (odom_sub.getNumPublishers() > 0) && (cmd_pub.getNumSubscribers() > 0); }
-  bool isPublishingCmdVelOut()const{ return (vel_out_sub.getNumPublishers() > 0); }
+  bool isPublishingCmdVelOut(const ros::Duration &timeout=ros::Duration(1)) const
+  {
+    ros::Time start = ros::Time::now();
+    int get_num_publishers = vel_out_sub.getNumPublishers();
+    while ( (get_num_publishers == 0) && (ros::Time::now() < start + timeout) ) {
+      ros::Duration(0.1).sleep();
+      get_num_publishers = vel_out_sub.getNumPublishers();
+    }
+    return (get_num_publishers > 0);
+  }
   bool hasReceivedFirstOdom()const{ return received_first_odom; }
 
   void start(){ std_srvs::Empty srv; start_srv.call(srv); }

--- a/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_partial_trajectory_controller.test
@@ -1,5 +1,6 @@
 <launch>
   <arg name="display_plots" default="false"/>
+  <arg name="gtest_filter" default="*"/>
 
   <!-- Load RRbot model -->
   <param name="robot_description"
@@ -35,5 +36,6 @@
   <test test-name="joint_partial_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_partial_trajectory_controller_test"
+        args='--gtest_filter="$(arg gtest_filter)"'
         time-limit="80.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller.test
@@ -1,5 +1,6 @@
 <launch>
   <arg name="display_plots" default="false"/>
+  <arg name="gtest_filter" default="*"/>
 
   <!-- Load RRbot model -->
   <param name="robot_description"
@@ -35,5 +36,6 @@
   <test test-name="joint_trajectory_controller_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_test"
+        args='--gtest_filter="$(arg gtest_filter)"'
         time-limit="85.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_stopramp.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_stopramp.test
@@ -1,5 +1,6 @@
 <launch>
   <arg name="display_plots" default="false"/>
+  <arg name="gtest_filter" default="*"/>
 
   <!-- Load RRbot model -->
   <param name="robot_description"
@@ -35,5 +36,6 @@
   <test test-name="joint_trajectory_controller_stopramp_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_stopramp_test"
+        args='--gtest_filter="$(arg gtest_filter)"'
         time-limit="85.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -1195,7 +1195,7 @@ TEST_F(JointTrajectoryControllerTest, jointVelocityFeedForward)
   // Send trajectory
   traj_goal.trajectory.header.stamp = ros::Time(0); // Start immediately
   action_client->sendGoal(traj_goal);
-  EXPECT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, short_timeout));
+  EXPECT_TRUE(waitForState(action_client, SimpleClientGoalState::ACTIVE, long_timeout));
 
   // Wait until done
   EXPECT_TRUE(waitForState(action_client, SimpleClientGoalState::ABORTED, long_timeout));

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -288,6 +288,7 @@ protected:
     start_controller.request.strictness = start_controller.request.STRICT;
     if(!switch_controller_service.call(start_controller)) return false;
     if(!start_controller.response.ok) return false;
+    return true;
   }
 };
 

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -810,6 +810,8 @@ TEST_F(JointTrajectoryControllerTest, emptyTopicCancelsActionTraj)
   trajectory_msgs::JointTrajectory traj_empty;
   traj_pub.publish(traj_empty);
   ASSERT_TRUE(waitForState(action_client,  SimpleClientGoalState::PREEMPTED, short_timeout));
+  // make sure that stateCB received the newer topics than when we confirmed with waitForState function
+  waitForNextState(short_timeout);
 
   // Check that we're not on the start state
   StateConstPtr state1 = getState();

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -1073,6 +1073,8 @@ TEST_F(JointTrajectoryControllerTest, ignoreOldTopicTraj)
   wait_duration = traj.points.back().time_from_start - traj.points.front().time_from_start + ros::Duration(0.5);
   wait_duration.sleep(); // Wait until first trajectory is done
 
+  // make sure that stateCB received the newer topics than when we confirmed with waitForState function
+  waitForNextState(short_timeout);
   // Check that we're at the original trajectory end (NOT back home)
   StateConstPtr state = getState();
   for (unsigned int i = 0; i < n_joints; ++i)

--- a/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_vel.test
@@ -1,5 +1,6 @@
 <launch>
   <arg name="display_plots" default="false"/>
+  <arg name="gtest_filter" default="*"/>
 
   <!-- Load RRbot model -->
   <param name="robot_description"
@@ -35,5 +36,6 @@
   <test test-name="joint_trajectory_controller_vel_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_vel_test"
+        args='--gtest_filter="$(arg gtest_filter)"'
         time-limit="120.0"/>
 </launch>

--- a/joint_trajectory_controller/test/joint_trajectory_controller_wrapping.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_wrapping.test
@@ -1,5 +1,7 @@
 <launch>
   <arg name="display_plots" default="false"/>
+  <arg name="gtest_filter" default="*"/>
+
   <!-- Load RRbot model -->
   <param name="robot_description"
       command="$(find xacro)/xacro.py '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
@@ -34,5 +36,6 @@
   <test test-name="joint_trajectory_controller_wrapping_test"
         pkg="joint_trajectory_controller"
         type="joint_trajectory_controller_wrapping_test"
+        args='--gtest_filter="$(arg gtest_filter)"'
         time-limit="80.0"/>
 </launch>


### PR DESCRIPTION
As discussed in https://github.com/ros-controls/ros_controllers/pull/327#issuecomment-383351311, the test code in `ros_control` is sometimes unstable. I have found several reason and hope this solves some of the test issues (I know, this is not a perfect, joint_trajectory_controller_vel_test still sometimes failing)

1. diff_drive_controller: isPublishngCmdVelOut somtimes retunes before it actually catch `cmd_vel`, in this PR, i added the code to check getNumPublisheres until timeouts.

2. joint_trajectory_controller_stopramp.test: waits `waitForStates` but it dones not gurantee if new stateCB is called aster the states is actually changed. I have added waitForNextStates function that wait for 1 more messages.