### PR TITLE
fix warning about hiding overloaded method

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -69,6 +69,7 @@ namespace diff_drive_controller{
   public:
     DiffDriveController();
 
+    using controller_interface::Controller<hardware_interface::VelocityJointInterface>::init;
     /**
      * \brief Initialize controller
      * \param hw            Velocity joint interface for the wheels

--- a/diff_drive_controller/test/diffbot.h
+++ b/diff_drive_controller/test/diffbot.h
@@ -80,6 +80,7 @@ public:
   ros::Time getTime() const {return ros::Time::now();}
   ros::Duration getPeriod() const {return ros::Duration(0.01);}
 
+  using hardware_interface::RobotHW::read;
   void read()
   {
     std::ostringstream os;
@@ -92,6 +93,7 @@ public:
     ROS_INFO_STREAM("Commands for joints: " << os.str());
   }
 
+  using hardware_interface::RobotHW::write;
   void write()
   {
     if (running_)

--- a/effort_controllers/include/effort_controllers/joint_group_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_group_position_controller.h
@@ -71,6 +71,7 @@ public:
   JointGroupPositionController();
   ~JointGroupPositionController();
 
+  using controller_interface::Controller<hardware_interface::EffortJointInterface>::init;
   bool init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle &n);
   void update(const ros::Time& /*time*/, const ros::Duration& /*period*/);
 

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -92,6 +92,7 @@ public:
   JointPositionController();
   ~JointPositionController();
 
+  using controller_interface::Controller<hardware_interface::EffortJointInterface>::init;
   /** \brief The init function is called to initialize the controller from a
    * non-realtime thread with a pointer to the hardware interface, itself,
    * instead of a pointer to a RobotHW.

--- a/effort_controllers/include/effort_controllers/joint_velocity_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_velocity_controller.h
@@ -79,6 +79,7 @@ public:
   JointVelocityController();
   ~JointVelocityController();
 
+  using controller_interface::Controller<hardware_interface::EffortJointInterface>::init;
   bool init(hardware_interface::EffortJointInterface *robot, const std::string &joint_name, const control_toolbox::Pid &pid);
 
   /** \brief The init function is called to initialize the controller from a

--- a/force_torque_sensor_controller/include/force_torque_sensor_controller/force_torque_sensor_controller.h
+++ b/force_torque_sensor_controller/include/force_torque_sensor_controller/force_torque_sensor_controller.h
@@ -47,6 +47,7 @@ class ForceTorqueSensorController: public controller_interface::Controller<hardw
 public:
   ForceTorqueSensorController(){}
 
+  using controller_interface::Controller<hardware_interface::ForceTorqueSensorInterface>::init;
   virtual bool init(hardware_interface::ForceTorqueSensorInterface* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh);
   virtual void starting(const ros::Time& time);
   virtual void update(const ros::Time& time, const ros::Duration& /*period*/);

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.h
@@ -72,6 +72,7 @@ public:
   ForwardCommandController() {}
   ~ForwardCommandController() {sub_command_.shutdown();}
 
+  using controller_interface::Controller<T>::init;
   bool init(T* hw, ros::NodeHandle &n)
   {
     std::string joint_name;

--- a/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
@@ -76,6 +76,7 @@ public:
   ForwardJointGroupCommandController() {}
   ~ForwardJointGroupCommandController() {sub_command_.shutdown();}
 
+  using controller_interface::Controller<T>::init;
   bool init(T* hw, ros::NodeHandle &n)
   {
     // List of controlled joints

--- a/four_wheel_steering_controller/include/four_wheel_steering_controller/four_wheel_steering_controller.h
+++ b/four_wheel_steering_controller/include/four_wheel_steering_controller/four_wheel_steering_controller.h
@@ -64,6 +64,8 @@ namespace four_wheel_steering_controller{
   public:
     FourWheelSteeringController();
 
+    using controller_interface::MultiInterfaceController<hardware_interface::VelocityJointInterface,
+                                                         hardware_interface::PositionJointInterface>::init;
     /**
      * \brief Initialize controller
      * \param robot_hw      Velocity and position joint interface for the wheels

--- a/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
+++ b/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
@@ -168,10 +168,12 @@ namespace four_wheel_steering_controller{
 
     urdf_geometry_parser::UrdfGeometryParser uvk(root_nh, base_frame_id_);
     if(lookup_track)
+    {
       if(!uvk.getDistanceBetweenJoints(front_wheel_names[0], front_wheel_names[1], track_))
         return false;
       else
         controller_nh.setParam("track",track_);
+    }
 
     if(!uvk.getDistanceBetweenJoints(front_steering_names[0], front_wheel_names[0], wheel_steering_y_offset_))
       return false;
@@ -179,16 +181,20 @@ namespace four_wheel_steering_controller{
       controller_nh.setParam("wheel_steering_y_offset",wheel_steering_y_offset_);
 
     if(lookup_wheel_radius)
+    {
       if(!uvk.getJointRadius(front_wheel_names[0], wheel_radius_))
         return false;
       else
         controller_nh.setParam("wheel_radius",wheel_radius_);
+    }
 
     if(lookup_wheel_base)
+    {
       if(!uvk.getDistanceBetweenJoints(front_wheel_names[0], rear_wheel_names[0], wheel_base_))
         return false;
       else
         controller_nh.setParam("wheel_base",wheel_base_);
+    }
 
     // Regardless of how we got the separation and radius, use them
     // to set the odometry parameters

--- a/four_wheel_steering_controller/test/src/four_wheel_steering.h
+++ b/four_wheel_steering_controller/test/src/four_wheel_steering.h
@@ -59,6 +59,7 @@ public:
   ros::Time getTime() const {return ros::Time::now();}
   ros::Duration getPeriod() const {return ros::Duration(0.01);}
 
+  using hardware_interface::RobotHW::read;
   void read()
   {
     std::ostringstream os;
@@ -79,6 +80,7 @@ public:
     ROS_DEBUG_STREAM("Commands for steering joints: " << os.str());
   }
 
+  using hardware_interface::RobotHW::write;
   void write()
   {
     if (running_)

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
@@ -87,6 +87,7 @@ public:
   
   GripperActionController();
   
+  using controller_interface::Controller<HardwareInterface>::init;
   /** \name Non Real-Time Safe Functions
    *\{*/
   bool init(HardwareInterface* hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);

--- a/imu_sensor_controller/include/imu_sensor_controller/imu_sensor_controller.h
+++ b/imu_sensor_controller/include/imu_sensor_controller/imu_sensor_controller.h
@@ -47,6 +47,7 @@ class ImuSensorController: public controller_interface::Controller<hardware_inte
 public:
   ImuSensorController(){}
 
+  using controller_interface::Controller<hardware_interface::ImuSensorInterface>::init;
   virtual bool init(hardware_interface::ImuSensorInterface* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh);
   virtual void starting(const ros::Time& time);
   virtual void update(const ros::Time& time, const ros::Duration& /*period*/);

--- a/joint_state_controller/include/joint_state_controller/joint_state_controller.h
+++ b/joint_state_controller/include/joint_state_controller/joint_state_controller.h
@@ -81,6 +81,7 @@ class JointStateController: public controller_interface::Controller<hardware_int
 public:
   JointStateController() : publish_rate_(0.0) {}
 
+  using controller_interface::Controller<hardware_interface::JointStateInterface>::init;
   virtual bool init(hardware_interface::JointStateInterface* hw,
                     ros::NodeHandle&                         root_nh,
                     ros::NodeHandle&                         controller_nh);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -130,6 +130,7 @@ public:
 
   JointTrajectoryController();
 
+  using controller_interface::Controller<HardwareInterface>::init;
   /** \name Non Real-Time Safe Functions
    *\{*/
   bool init(HardwareInterface* hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);

--- a/joint_trajectory_controller/test/rrbot.cpp
+++ b/joint_trajectory_controller/test/rrbot.cpp
@@ -96,8 +96,10 @@ public:
   ros::Time getTime() const {return ros::Time::now();}
   ros::Duration getPeriod() const {return ros::Duration(0.01);}
 
+  using hardware_interface::RobotHW::read;
   void read() {}
 
+  using hardware_interface::RobotHW::write;
   void write()
   {
     const double smoothing = *(smoothing_.readFromRT());

--- a/joint_trajectory_controller/test/rrbot_wrapping.cpp
+++ b/joint_trajectory_controller/test/rrbot_wrapping.cpp
@@ -78,8 +78,10 @@ public:
   ros::Time getTime() const {return ros::Time::now();}
   ros::Duration getPeriod() const {return ros::Duration(0.01);}
 
+  using hardware_interface::RobotHW::read;
   void read() {}
 
+  using hardware_interface::RobotHW::write;
   void write()
   {
     const double smoothing = *(smoothing_.readFromRT());

--- a/velocity_controllers/include/velocity_controllers/joint_position_controller.h
+++ b/velocity_controllers/include/velocity_controllers/joint_position_controller.h
@@ -99,6 +99,7 @@ public:
   JointPositionController();
   ~JointPositionController();
 
+  using controller_interface::Controller<hardware_interface::VelocityJointInterface>::init;
   /** \brief The init function is called to initialize the controller from a
    * non-realtime thread with a pointer to the hardware interface, itself,
    * instead of a pointer to a RobotHW.


### PR DESCRIPTION
This PR fixes a warning of this form:
~~~
/opt/ros/kinetic/include/controller_interface/controller.h: At global scope:
/opt/ros/kinetic/include/controller_interface/controller.h:71:16: warning: ‘bool controller_interface::Controller<T>::init(T*, ros::NodeHandle&) [with T = hardware_interface::ForceTorqueSensorInterface]’ was hidden [-Woverloaded-virtual]
   virtual bool init(T* /*hw*/, ros::NodeHandle& /*controller_nh*/) {return true;};
                ^
In file included from src/ros_controllers/force_torque_sensor_controller/src/force_torque_sensor_controller.cpp:32:0:
src/ros_controllers/force_torque_sensor_controller/include/force_torque_sensor_controller/force_torque_sensor_controller.h:50:16: warning:   by ‘virtual bool force_torque_sensor_controller::ForceTorqueSensorController::init(hardware_interface::ForceTorqueSensorInterface*, ros::NodeHandle&, ros::NodeHandle&)’ [-Woverloaded-virtual]
   virtual bool init(hardware_interface::ForceTorqueSensorInterface* hw, ros::NodeHandle &root_nh, ros::NodeHandle& controller_nh);
~~~