### PR TITLE
Report errors using error_string in FollowJointTrajectory action result

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -106,7 +106,8 @@ struct InitJointTrajectoryOptions
       rt_goal_handle(),
       default_tolerances(0),
       other_time_base(0),
-      allow_partial_joints_goal(false)
+      allow_partial_joints_goal(false),
+      error_string(0)
   {}
 
   Trajectory*                current_trajectory;
@@ -116,6 +117,7 @@ struct InitJointTrajectoryOptions
   SegmentTolerances<Scalar>* default_tolerances;
   ros::Time*                 other_time_base;
   bool                       allow_partial_joints_goal;
+  std::string*               error_string;
 };
 
 template <class Trajectory>
@@ -166,6 +168,9 @@ bool isNotEmpty(typename Trajectory::value_type trajPerJoint)
  * The typical usecase for this variable is when the \p current_trajectory option is specified, and contains data in
  * a different time base (eg. monotonically increasing) than \p msg (eg. system-clock synchronized).
  *
+ * - \b error_string Error message. If specified, an error message will be written to this string in case of failure to
+ * initialize the output trajectory from \p msg.
+ *
  * \return Trajectory container.
  *
  * \tparam Trajectory Trajectory type. Should be a \e sequence container \e sorted by segment start time.
@@ -205,17 +210,25 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   ROS_DEBUG_STREAM("Figuring out new trajectory starting at time "
                    << std::fixed << std::setprecision(3) << msg_start_time.toSec());
 
+  std::string error_string;
+
   // Empty trajectory
   if (msg.points.empty())
   {
-    ROS_DEBUG("Trajectory message contains empty trajectory. Nothing to convert.");
+    error_string = "Trajectory message contains empty trajectory. Nothing to convert.";
+    ROS_DEBUG_STREAM(error_string);
+    if (options.error_string)
+      *options.error_string = error_string;
     return Trajectory();
   }
 
   // Non strictly-monotonic waypoints
   if (!isTimeStrictlyIncreasing(msg))
   {
-    ROS_ERROR("Trajectory message contains waypoints that are not strictly increasing in time.");
+    error_string = "Trajectory message contains waypoints that are not strictly increasing in time.";
+    ROS_ERROR_STREAM(error_string);
+    if (options.error_string)
+      *options.error_string = error_string;
     return Trajectory();
   }
 
@@ -258,8 +271,11 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     const unsigned int n_angle_wraparound = options.angle_wraparound->size();
     if (n_angle_wraparound != joint_names.size())
     {
-      ROS_ERROR("Cannot create trajectory from message. "
-                "Vector specifying whether joints wrap around has an invalid size.");
+      error_string = "Cannot create trajectory from message. "
+                "Vector specifying whether joints wrap around has an invalid size.";
+      ROS_ERROR_STREAM(error_string);
+      if (options.error_string)
+        *options.error_string = error_string;
       return Trajectory();
     }
   }
@@ -269,7 +285,10 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   {
     if (msg.joint_names.size() != joint_names.size())
     {
-      ROS_ERROR("Cannot create trajectory from message. It does not contain the expected joints.");
+      error_string = "Cannot create trajectory from message. It does not contain the expected joints.";
+      ROS_ERROR_STREAM(error_string);
+      if (options.error_string)
+        *options.error_string = error_string;
       return Trajectory();
     }
   }
@@ -280,7 +299,10 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
 
   if (mapping_vector.empty())
   {
-    ROS_ERROR("Cannot create trajectory from message. It does not contain the expected joints.");
+    error_string = "Cannot create trajectory from message. It does not contain the expected joints.";
+    ROS_ERROR_STREAM(error_string);
+    if (options.error_string)
+      *options.error_string = error_string;
     return Trajectory();
   }
 
@@ -308,10 +330,13 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     if (msg_it == msg.points.end())
     {
       ros::Duration last_point_dur = time - (msg_start_time + (--msg_it)->time_from_start);
-      ROS_WARN_STREAM("Dropping all " << msg.points.size() <<
-                      " trajectory point(s), as they occur before the current time.\n" <<
-                      "Last point is " << std::fixed << std::setprecision(3) << last_point_dur.toSec() <<
-                      "s in the past.");
+      error_string = "Dropping all " + std::to_string(msg.points.size());
+      error_string += " trajectory point(s), as they occur before the current time.\n";
+      error_string += "Last point is " + std::to_string(last_point_dur.toSec());
+      error_string += "s in the past.";
+      ROS_WARN_STREAM(error_string);
+      if (options.error_string)
+        *options.error_string = error_string;
       return Trajectory();
     }
     else
@@ -408,7 +433,10 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
         TrajIter last  = findSegment(curr_joint_traj, last_curr_time); // Segment active when new trajectory starts
         if (first == curr_joint_traj.end() || last == curr_joint_traj.end())
         {
-          ROS_ERROR("Unexpected error: Could not find segments in current trajectory. Please contact the package maintainer.");
+          error_string = "Unexpected error: Could not find segments in current trajectory. Please contact the package maintainer.";
+          ROS_ERROR_STREAM(error_string);
+          if (options.error_string)
+            *options.error_string = error_string;
           return Trajectory();
         }
         result_traj_per_joint.insert(result_traj_per_joint.begin(), first, ++last); // Range [first,last) will still be executed

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -65,7 +65,7 @@ template <class T>
 inline std::vector<unsigned int> mapping(const T& t1, const T& t2)
 {
   typedef unsigned int SizeType;
-  
+
   // t1 must be a subset of t2
   if (t1.size() > t2.size()) {return std::vector<SizeType>();}
 
@@ -118,6 +118,14 @@ struct InitJointTrajectoryOptions
   ros::Time*                 other_time_base;
   bool                       allow_partial_joints_goal;
   std::string*               error_string;
+
+  void setErrorString(const std::string &msg) const
+  {
+    if(error_string)
+    {
+      *error_string = msg;
+    }
+  }
 };
 
 template <class Trajectory>
@@ -217,8 +225,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   {
     error_string = "Trajectory message contains empty trajectory. Nothing to convert.";
     ROS_DEBUG_STREAM(error_string);
-    if (options.error_string)
-      *options.error_string = error_string;
+    options.setErrorString(error_string);
     return Trajectory();
   }
 
@@ -227,8 +234,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   {
     error_string = "Trajectory message contains waypoints that are not strictly increasing in time.";
     ROS_ERROR_STREAM(error_string);
-    if (options.error_string)
-      *options.error_string = error_string;
+    options.setErrorString(error_string);
     return Trajectory();
   }
 
@@ -274,8 +280,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       error_string = "Cannot create trajectory from message. "
                 "Vector specifying whether joints wrap around has an invalid size.";
       ROS_ERROR_STREAM(error_string);
-      if (options.error_string)
-        *options.error_string = error_string;
+      options.setErrorString(error_string);
       return Trajectory();
     }
   }
@@ -287,8 +292,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
     {
       error_string = "Cannot create trajectory from message. It does not contain the expected joints.";
       ROS_ERROR_STREAM(error_string);
-      if (options.error_string)
-        *options.error_string = error_string;
+      options.setErrorString(error_string);
       return Trajectory();
     }
   }
@@ -301,8 +305,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   {
     error_string = "Cannot create trajectory from message. It does not contain the expected joints.";
     ROS_ERROR_STREAM(error_string);
-    if (options.error_string)
-      *options.error_string = error_string;
+    options.setErrorString(error_string);
     return Trajectory();
   }
 
@@ -335,8 +338,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       error_string += "Last point is " + std::to_string(last_point_dur.toSec());
       error_string += "s in the past.";
       ROS_WARN_STREAM(error_string);
-      if (options.error_string)
-        *options.error_string = error_string;
+      options.setErrorString(error_string);
       return Trajectory();
     }
     else
@@ -435,8 +437,7 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
         {
           error_string = "Unexpected error: Could not find segments in current trajectory. Please contact the package maintainer.";
           ROS_ERROR_STREAM(error_string);
-          if (options.error_string)
-            *options.error_string = error_string;
+          options.setErrorString(error_string);
           return Trajectory();
         }
         result_traj_per_joint.insert(result_traj_per_joint.begin(), first, ++last); // Range [first,last) will still be executed

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -222,7 +222,7 @@ protected:
   ros::Timer         goal_handle_timer_;
   ros::Time          last_state_publish_time_;
 
-  virtual bool updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePtr gh);
+  virtual bool updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePtr gh, std::string* error_string = 0);
   virtual void trajectoryCommandCB(const JointTrajectoryConstPtr& msg);
   virtual void goalCB(GoalHandle gh);
   virtual void cancelCB(GoalHandle gh);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -500,17 +500,24 @@ bool JointTrajectoryController<SegmentImpl, HardwareInterface>::
 updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePtr gh, std::string* error_string)
 {
   typedef InitJointTrajectoryOptions<Trajectory> Options;
+  std::string error_string_tmp;
 
   // Preconditions
   if (!this->isRunning())
   {
-    ROS_ERROR_NAMED(name_, "Can't accept new commands. Controller is not running.");
+    error_string_tmp = "Can't accept new commands. Controller is not running.";
+    ROS_ERROR_STREAM_NAMED(name_, error_string_tmp);
+    if (error_string)
+      *error_string = error_string_tmp;
     return false;
   }
 
   if (!msg)
   {
-    ROS_WARN_NAMED(name_, "Received null-pointer trajectory message, skipping.");
+    error_string_tmp = "Received null-pointer trajectory message, skipping.";
+    ROS_WARN_STREAM_NAMED(name_, error_string_tmp);
+    if (error_string)
+      *error_string = error_string_tmp;
     return false;
   }
 
@@ -562,11 +569,16 @@ updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePt
   catch(const std::invalid_argument& ex)
   {
     ROS_ERROR_STREAM_NAMED(name_, ex.what());
+    if (error_string)
+      *error_string = ex.what();
     return false;
   }
   catch(...)
   {
-    ROS_ERROR_NAMED(name_, "Unexpected exception caught when initializing trajectory from ROS message data.");
+    error_string_tmp = "Unexpected exception caught when initializing trajectory from ROS message data.";
+    ROS_ERROR_STREAM_NAMED(name_, error_string_tmp);
+    if (error_string)
+      *error_string = error_string_tmp;
     return false;
   }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -166,13 +166,8 @@ template <class SegmentImpl, class HardwareInterface>
 inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
 trajectoryCommandCB(const JointTrajectoryConstPtr& msg)
 {
-  std::string error_string;
-  const bool update_ok = updateTrajectoryCommand(msg, RealtimeGoalHandlePtr(), &error_string);
+  const bool update_ok = updateTrajectoryCommand(msg, RealtimeGoalHandlePtr());
   if (update_ok) {preemptActiveGoal();}
-  else
-  {
-    ROS_WARN_STREAM_NAMED(name_, "Failed to update trajectory: " << error_string);
-  }
 }
 
 template <class SegmentImpl, class HardwareInterface>
@@ -561,7 +556,6 @@ updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePt
     }
     else
     {
-      ROS_WARN_NAMED(name_, "Failed to initialize trajectory from message, skipping.");
       return false;
     }
   }


### PR DESCRIPTION
A couple of colleagues and me just spent a couple of hours troubleshooting a failing trajectory execution that was apparently caused by unsynchronized clocks causing trajectories being received by the controller with all points in the past.

It would have saved us a lot of time if some error message was displayed.