### PR TITLE
[diff_drive_controller] invert rotation direction

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -110,6 +110,10 @@ namespace diff_drive_controller{
     std::vector<hardware_interface::JointHandle> left_wheel_joints_;
     std::vector<hardware_interface::JointHandle> right_wheel_joints_;
 
+    // Whether the joint's speed must be inverted:
+    bool left_inverted;
+    bool right_inverted;
+
     /// Velocity command related:
     struct Commands
     {


### PR DESCRIPTION
We have a turtlebot-like robot base with two dynamixels actuating two wheels. Due to the geometry of the robot, we have to invert the rotation speed of one of the joint to achieve the desired result with the `diff_drive_controller`.

This can very easily be done in this controller with two extra parameters, as proposed here.