### PR TITLE
Add action_ns parameter to specify action name

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -300,8 +300,12 @@ bool JointTrajectoryController<SegmentImpl, HardwareInterface>::init(HardwareInt
   // ROS API: Published topics
   state_publisher_.reset(new StatePublisher(controller_nh_, "state", 1));
 
+  // Get action_ns parameter
+  std::string action_ns;
+  controller_nh_.param<std::string>("action_ns", action_ns, "follow_joint_trajectory");
+
   // ROS API: Action interface
-  action_server_.reset(new ActionServer(controller_nh_, "follow_joint_trajectory",
+  action_server_.reset(new ActionServer(controller_nh_, action_ns,
                                         boost::bind(&JointTrajectoryController::goalCB,   this, _1),
                                         boost::bind(&JointTrajectoryController::cancelCB, this, _1),
                                         false));


### PR DESCRIPTION
This PR add a parameter "action_ns" into joint_trajectory_controller to specify the action name.

The action name of joint_trajectory_controller is fixed to "follow_joint_trajectory". And as far as I tried, it cannot be remapped. Some robots (in my case Nextage Open, but some other robots also) have its own controller and different action name like "follow_joint_trajectory_action".  Usually this is not problem because MoveIt! can specify action name by "action_ns" in controller_list.

However, I want to make [fake_joint_controller](https://github.com/tork-a/fake_joint) to emulate these controller. For this purpose, I need to change the action name of the controller. 

Default of this parameter is "follow_joint_trajectory", so it has no effect for existing users.