### PR TITLE
dont print warning about dropped first point

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -314,6 +314,16 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
                       "s in the past.");
       return Trajectory();
     }
+    else if ( // If the first point is at time zero and no start time is set in the header, skip it silently
+              msg.points.begin()->time_from_start == ros::Duration(0.) &&
+              msg.header.stamp == ros::Time(0) &&
+              std::distance(msg.points.begin(), msg_it) == 1
+              )
+    {
+      ROS_DEBUG_STREAM("Dropping first trajectory point at time=0. " <<
+                       "First valid point will be reached at time_from_start " <<
+                       std::fixed << std::setprecision(3) << msg_it->time_from_start.toSec() << "s.");
+    }
     else
     {
       ros::Duration next_point_dur = msg_start_time + msg_it->time_from_start - time;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -315,8 +315,8 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       return Trajectory();
     }
     else if ( // If the first point is at time zero and no start time is set in the header, skip it silently
-              msg.points.begin()->time_from_start == ros::Duration(0.) &&
-              msg.header.stamp == ros::Time(0) &&
+              msg.points.begin()->time_from_start.isZero() &&
+              msg.header.stamp.isZero() &&
               std::distance(msg.points.begin(), msg_it) == 1
               )
     {


### PR DESCRIPTION
Since this is expected behaviour, if no start time is given in header of the message.

The warning about dropped points isn's useful, if the first point just contains
the expected start point. Dropping it is expected behaviour, thus degrading this
to a debug output message.

A subsequent feature could be to check the current position against the
parametrized tolerance of this point.

Closes #291