### PR TITLE
dont print warning about dropped first point

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -341,6 +341,16 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
       options.setErrorString(error_string);
       return Trajectory();
     }
+    else if ( // If the first point is at time zero and no start time is set in the header, skip it silently
+              msg.points.begin()->time_from_start.isZero() &&
+              msg.header.stamp.isZero() &&
+              std::distance(msg.points.begin(), msg_it) == 1
+              )
+    {
+      ROS_DEBUG_STREAM("Dropping first trajectory point at time=0. " <<
+                       "First valid point will be reached at time_from_start " <<
+                       std::fixed << std::setprecision(3) << msg_it->time_from_start.toSec() << "s.");
+    }
     else
     {
       ros::Duration next_point_dur = msg_start_time + msg_it->time_from_start - time;


### PR DESCRIPTION
Same as #366 for melodic. I've only tested this on kinetic; please consider to double-check it.

Closes #291