### PR TITLE
Fix doubled-find_package()

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -3,22 +3,14 @@ project(ackermann_steering_controller)
 
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
-  controller_manager
   diff_drive_controller
-  gazebo_ros
-  geometry_msgs
   hardware_interface
   nav_msgs
   pluginlib
   realtime_tools
   roscpp
-  rostest
-  rosunit
-  std_msgs
-  std_srvs
   tf
   urdf
-  xacro
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)
@@ -56,6 +48,27 @@ install(FILES ackermann_steering_controller_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS
+    controller_interface
+    controller_manager
+    diff_drive_controller
+    gazebo_ros
+    geometry_msgs
+    hardware_interface
+    nav_msgs
+    pluginlib
+    realtime_tools
+    roscpp
+    rostest
+    rosunit
+    rviz
+    std_msgs
+    std_srvs
+    tf
+    urdf
+    xacro
+  )
+
   add_executable(${PROJECT_NAME}_ackermann_steering_bot test/common/src/ackermann_steering_bot.cpp)
   add_dependencies(tests ${PROJECT_NAME}_ackermann_steering_bot)
 

--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -3,14 +3,22 @@ project(ackermann_steering_controller)
 
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
+  controller_manager
   diff_drive_controller
+  gazebo_ros
+  geometry_msgs
   hardware_interface
   nav_msgs
   pluginlib
   realtime_tools
   roscpp
+  rostest
+  rosunit
+  std_msgs
+  std_srvs
   tf
   urdf
+  xacro
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)
@@ -48,17 +56,6 @@ install(FILES ackermann_steering_controller_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS
-    controller_manager
-    geometry_msgs
-    rostest
-    rosunit
-    std_msgs
-    std_srvs
-    gazebo_ros
-    xacro
-  )
-
   add_executable(${PROJECT_NAME}_ackermann_steering_bot test/common/src/ackermann_steering_bot.cpp)
   add_dependencies(tests ${PROJECT_NAME}_ackermann_steering_bot)
 

--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -49,25 +49,22 @@ install(FILES ackermann_steering_controller_plugins.xml
 
 if (CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS
-    controller_interface
     controller_manager
-    diff_drive_controller
     gazebo_ros
     geometry_msgs
     hardware_interface
     nav_msgs
-    pluginlib
     realtime_tools
     roscpp
-    rostest
     rosunit
-    rviz
     std_msgs
     std_srvs
     tf
     urdf
     xacro
   )
+
+  find_package(rostest REQUIRED)
 
   add_executable(${PROJECT_NAME}_ackermann_steering_bot test/common/src/ackermann_steering_bot.cpp)
   add_dependencies(tests ${PROJECT_NAME}_ackermann_steering_bot)

--- a/ackermann_steering_controller/README.md
+++ b/ackermann_steering_controller/README.md
@@ -1,4 +1,4 @@
-## Ackermann Steerubg Controller ##
+## Ackermann Steering Controller ##
 
 Controller for a ackermann steering drive mobile base. 
 

--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -34,6 +34,7 @@
   <test_depend>geometry_msgs</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
+  <test_depend>rviz</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>xacro</test_depend>

--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -2,7 +2,7 @@
 <package format="2">
   <name>ackermann_steering_controller</name>
   <version>0.13.5</version>
-  <description>Controller for a steer drive mobile base.</description>
+  <description>Controller for a ackermann steering drive mobile base.</description>
   <maintainer email="p595201m@mail.kyutech.jp">Masaru Morita</maintainer>
 
   <license>BSD</license>
@@ -32,8 +32,8 @@
   <test_depend>controller_manager</test_depend>
   <test_depend>gazebo_ros</test_depend>
   <test_depend>geometry_msgs</test_depend>
-  <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>xacro</test_depend>

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -2,23 +2,48 @@ cmake_minimum_required(VERSION 2.8.3)
 project(diff_drive_controller)
 
 find_package(catkin REQUIRED COMPONENTS
-    controller_interface
-    dynamic_reconfigure
-    nav_msgs
-    realtime_tools
-    tf
-    urdf
+  controller_interface
+  controller_manager
+  dynamic_reconfigure
+  gazebo_ros
+  geometry_msgs
+  hardware_interface
+  nav_msgs
+  pluginlib
+  realtime_tools
+  roscpp
+  rosgraph_msgs
+  rostest
+  rosunit
+  std_msgs
+  std_srvs
+  tf
+  urdf
+  xacro
 )
+
+find_package(Boost REQUIRED COMPONENTS system thread)
 
 generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    controller_interface
+    dynamic_reconfigure
+    hardware_interface
+    nav_msgs
+    realtime_tools
+    roscpp
+    tf
+  DEPENDS Boost
 )
 
 include_directories(
   include
+  ${Boost_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
 )
 
 include_directories(SYSTEM
@@ -26,23 +51,24 @@ include_directories(SYSTEM
 )
 
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
 install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
+)
 
 install(FILES diff_drive_controller_plugins.xml
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS controller_manager rosgraph_msgs rostest std_srvs tf)
   include_directories(include ${catkin_INCLUDE_DIRS})
 
   add_executable(diffbot test/diffbot.cpp)

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -62,18 +62,14 @@ install(FILES diff_drive_controller_plugins.xml
 
 if (CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS
-    controller_interface
     controller_manager
-    dynamic_reconfigure
     gazebo_ros
     geometry_msgs
     hardware_interface
     nav_msgs
-    pluginlib
     realtime_tools
     roscpp
     rosgraph_msgs
-    rostest
     rosunit
     std_msgs
     std_srvs
@@ -81,6 +77,8 @@ if (CATKIN_ENABLE_TESTING)
     urdf
     xacro
   )
+
+  find_package(rostest REQUIRED)
 
   include_directories(include ${catkin_INCLUDE_DIRS})
 

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -3,23 +3,15 @@ project(diff_drive_controller)
 
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
-  controller_manager
   dynamic_reconfigure
-  gazebo_ros
   geometry_msgs
   hardware_interface
   nav_msgs
   pluginlib
   realtime_tools
   roscpp
-  rosgraph_msgs
-  rostest
-  rosunit
-  std_msgs
-  std_srvs
   tf
   urdf
-  xacro
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)
@@ -69,6 +61,27 @@ install(FILES diff_drive_controller_plugins.xml
 )
 
 if (CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS
+    controller_interface
+    controller_manager
+    dynamic_reconfigure
+    gazebo_ros
+    geometry_msgs
+    hardware_interface
+    nav_msgs
+    pluginlib
+    realtime_tools
+    roscpp
+    rosgraph_msgs
+    rostest
+    rosunit
+    std_msgs
+    std_srvs
+    tf
+    urdf
+    xacro
+  )
+
   include_directories(include ${catkin_INCLUDE_DIRS})
 
   add_executable(diffbot test/diffbot.cpp)

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -15,16 +15,27 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>boost</depend>
   <depend>controller_interface</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>
   <depend>realtime_tools</depend>
+  <depend>roscpp</depend>
   <depend>tf</depend>
-  <depend>urdf</depend>
+
+  <build_depend>pluginlib</build_depend>
+  <build_depend>urdf</build_depend>
+
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>urdf</exec_depend>
 
   <test_depend>controller_manager</test_depend>
+  <test_depend>gazebo_ros</test_depend>
   <test_depend>rosgraph_msgs</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
+  <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>xacro</test_depend>
 

--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -53,25 +53,23 @@ install(FILES four_wheel_steering_controller_plugins.xml
 
 if(CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS
-    controller_interface
     controller_manager
     four_wheel_steering_msgs
     gazebo_ros
     geometry_msgs
     hardware_interface
     nav_msgs
-    pluginlib
     realtime_tools
     roscpp
     rosgraph_msgs
-    rostest
     rosunit
     std_msgs
     std_srvs
     tf
-    urdf_geometry_parser
     xacro
   )
+
+  find_package(rostest REQUIRED)
 
   add_executable(four_wheel_steering test/src/four_wheel_steering.cpp)
   target_link_libraries(four_wheel_steering ${catkin_LIBRARIES})

--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -3,41 +3,63 @@ project(four_wheel_steering_controller)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-set(${PROJECT_NAME}_CATKIN_DEPS
-    controller_interface
-    nav_msgs
-    four_wheel_steering_msgs
-    realtime_tools
-    tf
-    urdf_geometry_parser)
+find_package(catkin REQUIRED COMPONENTS
+  controller_interface
+  controller_manager
+  four_wheel_steering_msgs
+  gazebo_ros
+  geometry_msgs
+  hardware_interface
+  nav_msgs
+  pluginlib
+  realtime_tools
+  roscpp
+  rosgraph_msgs
+  rostest
+  rosunit
+  std_msgs
+  std_srvs
+  tf
+  urdf_geometry_parser
+  xacro
+)
 
-find_package(catkin REQUIRED COMPONENTS ${${PROJECT_NAME}_CATKIN_DEPS})
+find_package(Boost REQUIRED COMPONENTS system thread)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS ${${PROJECT_NAME}_CATKIN_DEPS}
+  CATKIN_DEPENDS
+    controller_interface
+    four_wheel_steering_msgs
+    hardware_interface
+    nav_msgs
+    realtime_tools
+    roscpp
+    tf
+  DEPENDS Boost
 )
 
 include_directories(
-  include ${catkin_INCLUDE_DIRS}
+  include
+  ${Boost_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} src/four_wheel_steering_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-  )
+)
 
 install(FILES four_wheel_steering_controller_plugins.xml
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS rosgraph_msgs rostest std_srvs controller_manager tf)
-
   add_executable(four_wheel_steering test/src/four_wheel_steering.cpp)
   target_link_libraries(four_wheel_steering ${catkin_LIBRARIES})
 

--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -5,23 +5,15 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
-  controller_manager
   four_wheel_steering_msgs
-  gazebo_ros
   geometry_msgs
   hardware_interface
   nav_msgs
   pluginlib
   realtime_tools
   roscpp
-  rosgraph_msgs
-  rostest
-  rosunit
-  std_msgs
-  std_srvs
   tf
   urdf_geometry_parser
-  xacro
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)
@@ -60,6 +52,27 @@ install(FILES four_wheel_steering_controller_plugins.xml
 )
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS
+    controller_interface
+    controller_manager
+    four_wheel_steering_msgs
+    gazebo_ros
+    geometry_msgs
+    hardware_interface
+    nav_msgs
+    pluginlib
+    realtime_tools
+    roscpp
+    rosgraph_msgs
+    rostest
+    rosunit
+    std_msgs
+    std_srvs
+    tf
+    urdf_geometry_parser
+    xacro
+  )
+
   add_executable(four_wheel_steering test/src/four_wheel_steering.cpp)
   target_link_libraries(four_wheel_steering ${catkin_LIBRARIES})
 

--- a/four_wheel_steering_controller/package.xml
+++ b/four_wheel_steering_controller/package.xml
@@ -13,17 +13,29 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>boost</depend>
   <depend>controller_interface</depend>
-  <depend>nav_msgs</depend>
   <depend>four_wheel_steering_msgs</depend>
+  <depend>hardware_interface</depend>
+  <depend>nav_msgs</depend>
   <depend>realtime_tools</depend>
+  <depend>roscpp</depend>
   <depend>tf</depend>
-  <depend>urdf_geometry_parser</depend>
 
+  <build_depend>pluginlib</build_depend>
+  <build_depend>urdf_geometry_parser</build_depend>
+
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>urdf_geometry_parser</exec_depend>
+
+  <test_depend>controller_manager</test_depend>
+  <test_depend>gazebo_ros</test_depend>
   <test_depend>rosgraph_msgs</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
+  <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>
-  <test_depend>controller_manager</test_depend>
+  <test_depend>xacro</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/four_wheel_steering_controller_plugins.xml"/>

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -57,25 +57,22 @@ if(CATKIN_ENABLE_TESTING)
   find_package(catkin
     REQUIRED COMPONENTS
       actionlib
-      angles
-      cmake_modules
-      control_toolbox
       control_msgs
       controller_interface
       controller_manager
       hardware_interface
-      pluginlib
       realtime_tools
       roscpp
-      rostest
       rosunit
-      rqt_plot
+      std_msgs
       trajectory_msgs
       urdf
       xacro
   )
 
-  include_directories(include ${catkin_INCLUDE_DIRS})
+  find_package(rostest REQUIRED)
+
+  include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
   catkin_add_gtest(quintic_spline_segment_test test/quintic_spline_segment_test.cpp)
   target_link_libraries(quintic_spline_segment_test ${catkin_LIBRARIES})
@@ -110,23 +107,23 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest_gtest(joint_trajectory_controller_test
                     test/joint_trajectory_controller.test
                     test/joint_trajectory_controller_test.cpp)
-  target_link_libraries(joint_trajectory_controller_test ${catkin_LIBRARIES})
+  target_link_libraries(joint_trajectory_controller_test ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
   add_rostest_gtest(joint_trajectory_controller_stopramp_test
                     test/joint_trajectory_controller_stopramp.test
                     test/joint_trajectory_controller_test.cpp)
-  target_link_libraries(joint_trajectory_controller_stopramp_test ${catkin_LIBRARIES})
+  target_link_libraries(joint_trajectory_controller_stopramp_test ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
   add_rostest_gtest(joint_trajectory_controller_vel_test
                     test/joint_trajectory_controller_vel.test
                     test/joint_trajectory_controller_test.cpp)
-  target_link_libraries(joint_trajectory_controller_vel_test ${catkin_LIBRARIES})
+  target_link_libraries(joint_trajectory_controller_vel_test ${Boost_LIBRARIES} ${catkin_LIBRARIES})
   target_compile_definitions(joint_trajectory_controller_vel_test PRIVATE TEST_VELOCITY_FF=1)
 
   add_rostest_gtest(joint_trajectory_controller_wrapping_test
                     test/joint_trajectory_controller_wrapping.test
                     test/joint_trajectory_controller_wrapping_test.cpp)
-  target_link_libraries(joint_trajectory_controller_wrapping_test ${catkin_LIBRARIES})
+  target_link_libraries(joint_trajectory_controller_wrapping_test ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 endif()
 

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -10,17 +10,12 @@ find_package(catkin
     control_toolbox
     control_msgs
     controller_interface
-    controller_manager
     hardware_interface
     pluginlib
     realtime_tools
     roscpp
-    rostest
-    rosunit
-    rqt_plot
     trajectory_msgs
     urdf
-    xacro
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)
@@ -59,6 +54,27 @@ add_library(${PROJECT_NAME} src/joint_trajectory_controller.cpp
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(catkin
+    REQUIRED COMPONENTS
+      actionlib
+      angles
+      cmake_modules
+      control_toolbox
+      control_msgs
+      controller_interface
+      controller_manager
+      hardware_interface
+      pluginlib
+      realtime_tools
+      roscpp
+      rostest
+      rosunit
+      rqt_plot
+      trajectory_msgs
+      urdf
+      xacro
+  )
+
   include_directories(include ${catkin_INCLUDE_DIRS})
 
   catkin_add_gtest(quintic_spline_segment_test test/quintic_spline_segment_test.cpp)

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -7,31 +7,39 @@ find_package(catkin
     actionlib
     angles
     cmake_modules
-    roscpp
-    urdf
     control_toolbox
-    controller_interface
-    hardware_interface
-    realtime_tools
     control_msgs
+    controller_interface
+    controller_manager
+    hardware_interface
+    pluginlib
+    realtime_tools
+    roscpp
+    rostest
+    rosunit
+    rqt_plot
     trajectory_msgs
+    urdf
+    xacro
 )
+
+find_package(Boost REQUIRED COMPONENTS system thread)
 
 # Declare catkin package
 catkin_package(
-  CATKIN_DEPENDS
-  actionlib
-  angles
-  roscpp
-  urdf
-  control_toolbox
-  controller_interface
-  hardware_interface
-  realtime_tools
-  control_msgs
-  trajectory_msgs
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    actionlib
+    angles
+    control_toolbox
+    control_msgs
+    controller_interface
+    hardware_interface
+    realtime_tools
+    roscpp
+    trajectory_msgs
+  DEPENDS Boost
 )
 
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
@@ -48,17 +56,9 @@ add_library(${PROJECT_NAME} src/joint_trajectory_controller.cpp
                             include/trajectory_interface/quintic_spline_segment.h
                             include/trajectory_interface/pos_vel_acc_state.h)
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin
-    REQUIRED COMPONENTS
-      actionlib
-      controller_manager
-      xacro
-  )
-
-  find_package(rostest REQUIRED)
   include_directories(include ${catkin_INCLUDE_DIRS})
 
   catkin_add_gtest(quintic_spline_segment_test test/quintic_spline_segment_test.cpp)

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -40,6 +40,7 @@
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>rqt_plot</test_depend>
+  <test_depend>std_msgs</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -36,10 +36,10 @@
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>urdf</exec_depend>
 
+  <test_depend>controller_manager</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>rqt_plot</test_depend>
-  <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -21,6 +21,7 @@
 
   <depend>actionlib</depend>
   <depend>angles</depend>
+  <depend>boost</depend>
   <depend>control_msgs</depend>
   <depend>control_toolbox</depend>
   <depend>controller_interface</depend>
@@ -28,9 +29,16 @@
   <depend>realtime_tools</depend>
   <depend>roscpp</depend>
   <depend>trajectory_msgs</depend>
-  <depend>urdf</depend>
+
+  <build_depend>pluginlib</build_depend>
+  <build_depend>urdf</build_depend>
+
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>urdf</exec_depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>rosunit</test_depend>
+  <test_depend>rqt_plot</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
 

--- a/ros_controllers/package.xml
+++ b/ros_controllers/package.xml
@@ -23,6 +23,7 @@
   <exec_depend>effort_controllers</exec_depend>
   <exec_depend>force_torque_sensor_controller</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
+  <exec_depend>four_wheel_steering_controller</exec_depend>
   <exec_depend>gripper_action_controller</exec_depend>
   <exec_depend>imu_sensor_controller</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>


### PR DESCRIPTION
Fixed https://github.com/ros-controls/ros_controllers/issues/378

for controllers as follows

- joint_trajectory_controller
- diff_drive_controller
- four_wheel_steering_controller
- ackermann_steering_controller
