### PR TITLE
fix mistake in jerk limit

### DIFF
--- a/diff_drive_controller/src/speed_limiter.cpp
+++ b/diff_drive_controller/src/speed_limiter.cpp
@@ -121,7 +121,7 @@ namespace diff_drive_controller
       const double dv  = v  - v0;
       const double dv0 = v0 - v1;
 
-      const double dt2 = 2. * dt * dt;
+      const double dt2 = dt * dt;
 
       const double da_min = min_jerk * dt2;
       const double da_max = max_jerk * dt2;

--- a/diff_drive_controller/test/diffbot_limits.yaml
+++ b/diff_drive_controller/test/diffbot_limits.yaml
@@ -8,7 +8,7 @@ diffbot_controller:
       min_acceleration: -0.5
       max_acceleration: 1.0
       has_jerk_limits: true
-      max_jerk: 5.0
+      max_jerk: 10.0
   angular:
     z:
       has_velocity_limits: true
@@ -16,4 +16,4 @@ diffbot_controller:
       has_acceleration_limits: true
       max_acceleration: 2.0
       has_jerk_limits: true
-      max_jerk: 10.0
+      max_jerk: 20.0

--- a/four_wheel_steering_controller/src/speed_limiter.cpp
+++ b/four_wheel_steering_controller/src/speed_limiter.cpp
@@ -115,7 +115,7 @@ namespace four_wheel_steering_controller
       const double dv  = v  - v0;
       const double dv0 = v0 - v1;
 
-      const double dt2 = 2. * dt * dt;
+      const double dt2 = dt * dt;
 
       const double da_min = min_jerk * dt2;
       const double da_max = max_jerk * dt2;


### PR DESCRIPTION
The mistake is not only on melodic.

![image](https://user-images.githubusercontent.com/2566326/49586942-dfb39680-f962-11e8-9cd6-5aa2541d8de4.png)

There's not a factor 2 in the formulas.

