### PR TITLE
correctly parse joint trajectory options

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -242,9 +242,9 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
   const bool has_current_trajectory = options.current_trajectory && !options.current_trajectory->empty();
   const bool has_joint_names        = options.joint_names        && !options.joint_names->empty();
   const bool has_angle_wraparound   = options.angle_wraparound   && !options.angle_wraparound->empty();
-  const bool has_rt_goal_handle     = options.rt_goal_handle;
-  const bool has_other_time_base    = options.other_time_base;
-  const bool has_default_tolerances = options.default_tolerances;
+  const bool has_rt_goal_handle     = options.rt_goal_handle != nullptr;
+  const bool has_other_time_base    = options.other_time_base != nullptr;
+  const bool has_default_tolerances = options.default_tolerances != nullptr;
 
   if (!has_current_trajectory && has_angle_wraparound)
   {


### PR DESCRIPTION
when compiling on my osx machine with clang (x86_64-apple-darwin16.7.0) this actually didn't compile. This fix was necessary.