### PR TITLE
Hold joint position if tolerances were violated

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -417,6 +417,10 @@ update(const ros::Time& time, const ros::Duration& period)
             ROS_ERROR_STREAM_NAMED(name_,"Path tolerances failed for joint: " << joint_names_[i]);
             checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance, true);
           }
+
+          // If we violate path tolerance then hold current position
+          setHoldPosition(time_data.uptime, rt_active_goal_);
+
           rt_segment_goal->preallocated_result_->error_code =
           control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
           rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -457,6 +457,9 @@ update(const ros::Time& time, const ros::Duration& period)
             checkStateTolerancePerJoint(state_joint_error_, tolerances.goal_state_tolerance, true);
           }
 
+          // If we violate goal tolerances then hold current position
+          setHoldPosition(time_data.uptime, rt_active_goal_);
+
           rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED;
           rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
           rt_active_goal_.reset();


### PR DESCRIPTION
Currently, the joint_trajectory_controller keeps executing a trajectory even after the goal was aborted due to a tolerance violation. In my opinion, this is a bad idea for multiple reasons:
* It is unsafe to keep moving, since the robot deviated from the path. The chance of a collision is high.
* The current behavior is unexpected.
* Even if you wanted to, you could not stop the execution anymore, because an aborted goal can't be preempted again. 

This behavior was mentioned in issue #48, but never fixed.

This PR addresses this issue by calling `setHoldPosition()` before aborting the goal.

I think, the current tests should be sufficient. However, I was unable to execute them since I got a lot of unrelated errors.