### PR TITLE
Reset commands to zero for stopping controller

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -190,7 +190,15 @@ public:
     }
   }
 
-  void stopping(const ros::Time& /*time*/) {}
+  void stopping(const ros::Time& /*time*/) {
+    if (!joint_handles_ptr_) {return;}
+
+    // zero commands
+    for (unsigned int i = 0; i < pids_.size(); ++i)
+    {
+      (*joint_handles_ptr_)[i].setCommand(0.0);
+    }
+  }
 
   void updateCommand(const ros::Time&     /*time*/,
                      const ros::Duration& period,

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -157,8 +157,16 @@ starting(const ros::Time& time)
 
 template <class SegmentImpl, class HardwareInterface>
 inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
-stopping(const ros::Time& /*time*/)
+stopping(const ros::Time& time)
 {
+  // Update time data
+  TimeData time_data;
+  time_data.time   = time;
+  time_data.uptime = ros::Time(0.0);
+  time_data_.initRT(time_data);
+
+  // Hardware interface adapter
+  hw_iface_adapter_.stopping(time_data.uptime);
   preemptActiveGoal();
 }
 


### PR DESCRIPTION
I have implemented a hardware interface for a Kinova Jaco and am currently using a controller of type velocity_controllers/JointTrajectoryController.

I have witnessed the following problem:
If I command the arm and kill the controller in the middle of the arm motion the last sent velocity command continues to be sent to the arm until the controller is reloaded.

It makes more sense to me that the controller manager should ensure there is a zero command sent when the controller is stopped.

This PR attempts to implement stopping behavior for the joint_trajectory controller which publishes zero commands on stop.

I am a noobie to ros_control so I very well could have some user error going on here. Feel free to take a look at the attached hardware interface, launch file and config file for my controller implementation.

[kinova_ros_control.zip](https://github.com/ros-controls/ros_controllers/files/2939531/kinova_ros_control.zip)
