### PR TITLE
update joint_trjectory controller with mimic joint support

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -222,6 +222,17 @@ protected:
   ros::Timer         goal_handle_timer_;
   ros::Time          last_state_publish_time_;
 
+  // Mimic Joints
+  std::vector<JointHandle>  mimic_joints_;             ///< Handles to mimic joints.
+  std::vector<std::string>  mimic_joint_names_;        ///< Mimic joint names.
+  std::vector<urdf::JointConstSharedPtr> mimic_urdf_joints_; ///< URDF joint of mimic joints
+  std::vector<unsigned int> mimic_joint_ids_;          ///< index of target joint in joints_ vector
+
+  typename Segment::State mimic_current_state_;         ///< Preallocated workspace variable.
+  typename Segment::State mimic_desired_state_;         ///< Preallocated workspace variable.
+  typename Segment::State mimic_state_error_;           ///< Preallocated workspace variable.
+  HwIfaceAdapter          mimic_hw_iface_adapter_;      ///< Adapts desired trajectory state to HW interface.
+
   virtual bool updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePtr gh, std::string* error_string = 0);
   virtual void trajectoryCommandCB(const JointTrajectoryConstPtr& msg);
   virtual void goalCB(GoalHandle gh);


### PR DESCRIPTION
@mintar I have tested your `mimic_joint_gazebo_tutorial` and it works fine for the small example, but when I tried to apply that plugins to a more complex model, for example, humanoid hand model, it did not work well. I thank this because when we calculate
```
value = multiplier * other_joint_value + offset.
``` 
where the mimic joint plugin uses `other_joint_value` as current `Position` of the joint in gazebo simulation, but I think we have to use current `Desired(Commanded) Position` in the controller, because the current position in gazebo simulation oscillates and that makes mimic joint unstable.

Here is my workaround for supporting mimic joint in joint trajectory controller and it works well on your tutorial code. How do you think?

see https://github.com/k-okada/mimic_joint_gazebo_tutorial.git for example

```
gripper_controller:
  type: position_controllers/JointTrajectoryController
  joints:
    - right_finger_joint
  mimic_joints:
    - left_finger_joint
  gains:
    right_finger_joint: {p: 20.0, i: 0.1, d: 0.2}
    left_finger_joint: {p: 20.0, i: 0.1, d: 0.2}
```
we added `mimic_joints` tag for the list of the mimic joint, and you have to add gains section. Mimic joint params (muliplier/offset) is taken from urdf model