### PR TITLE
Print error messages for all exceptions in `joint_trajectory_controller`

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -558,7 +558,7 @@ updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePt
       return false;
     }
   }
-  catch(const std::invalid_argument& ex)
+  catch(const std::exception& ex)
   {
     ROS_ERROR_STREAM_NAMED(name_, ex.what());
     options.setErrorString(ex.what());


### PR DESCRIPTION
When initializing a trajectory, multiple different exceptions can be thrown. Having `catch(std::invalid_argument)` followed by `catch(...)` drops all information about any exceptions that aren't `std::invalid_argument`.