### PR TITLE
Use C++11 std::this_thread::sleep_for to replace usleep

### DIFF
--- a/diff_drive_controller/test/diffbot.cpp
+++ b/diff_drive_controller/test/diffbot.cpp
@@ -29,6 +29,7 @@
 
 #include "diffbot.h"
 #include <chrono>
+#include <thread>
 #include <controller_manager/controller_manager.h>
 #include <ros/ros.h>
 #include <rosgraph_msgs/Clock.h>
@@ -78,7 +79,7 @@ int main(int argc, char **argv)
     else
     {
       ROS_DEBUG_STREAM_THROTTLE(1.0, "Control cycle is, elapsed: " << elapsed_secs);
-      usleep((dt.toSec() - elapsed_secs) * 1e6);
+      std::this_thread::sleep_for(std::chrono::duration<double>(dt.toSec() - elapsed_secs));
     }
 
     rosgraph_msgs::Clock clock;

--- a/diff_drive_controller/test/skidsteerbot.cpp
+++ b/diff_drive_controller/test/skidsteerbot.cpp
@@ -29,6 +29,7 @@
 
 #include "diffbot.h"
 #include <chrono>
+#include <thread>
 #include <controller_manager/controller_manager.h>
 #include <ros/ros.h>
 #include <rosgraph_msgs/Clock.h>
@@ -78,7 +79,7 @@ int main(int argc, char **argv)
     else
     {
       ROS_DEBUG_STREAM_THROTTLE(1.0, "Control cycle is, elapsed: " << elapsed_secs);
-      usleep((dt.toSec() - elapsed_secs) * 1e6);
+      std::this_thread::sleep_for(std::chrono::duration<double>(dt.toSec() - elapsed_secs));
     }
 
     rosgraph_msgs::Clock clock;

--- a/four_wheel_steering_controller/test/src/four_wheel_steering.cpp
+++ b/four_wheel_steering_controller/test/src/four_wheel_steering.cpp
@@ -2,6 +2,7 @@
 
 #include "four_wheel_steering.h"
 #include <chrono>
+#include <thread>
 #include <controller_manager/controller_manager.h>
 #include <ros/ros.h>
 #include <rosgraph_msgs/Clock.h>
@@ -50,7 +51,7 @@ int main(int argc, char **argv)
     else
     {
       ROS_DEBUG_STREAM_THROTTLE(1.0, "Control cycle is, elapsed: " << elapsed_secs);
-      usleep((dt.toSec() - elapsed_secs) * 1e6);
+      std::this_thread::sleep_for(std::chrono::duration<double>(dt.toSec() - elapsed_secs));
     }
 
     rosgraph_msgs::Clock clock;


### PR DESCRIPTION
Use C++11 `std::this_thread::sleep_for` to replace `usleep`, which makes test code more portable for other platforms.

Verified in https://aka.ms/ros project.