### PR TITLE
Revert cmake include catkin_INCLUDE_DIRS as system

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -24,11 +24,7 @@ catkin_package(
 )
 
 include_directories(
-  include
-)
-
-include_directories(SYSTEM
-  ${catkin_INCLUDE_DIRS}
+  include ${catkin_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)


### PR DESCRIPTION
PR #315 changed the `include_directories()` of `diff_drive_controller`'s `CMakeLists.txt` to include catkin includes as SYSTEM.

This was done to suppresses compilation errors from upstream packages. However, it also mangles the header search list which causes issues with cross-compilation with (at least) GCC 6.1.1. A more thorough explanation can be found in [this Stack Overflow answer](https://stackoverflow.com/a/37218954/1932358), but in short, specifying `-isystem` breaks GCC's use of `#include_next` for system headers such as `cmath` and `cstdlib`.

Specifying `include_directories(SYSTEM ${catkin_INCLUDE_DIRS})` doesn't seem to be a common patttern in ROS packages. In fact, of the 147 packages resulting from `$ rosinstall_generator robot ros_control ros_controllers`, `diff_drive_controller` is the only package which does this (and consequently is the only package breaking my cross-compilation :stuck_out_tongue:).