### PR TITLE
Update testing repository URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ env:
     - CATKIN_PARALLEL_TEST_JOBS=-p1
     - ROS_PARALLEL_TEST_JOBS=-j1
   matrix:
-    - ROS_DISTRO="melodic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="melodic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-testing/ubuntu
-    - ROS_DISTRO="melodic"  UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
+    - ROS_DISTRO=melodic  ROS_REPO=ros
+    - ROS_DISTRO=melodic  ROS_REPO=ros-testing
+    - ROS_DISTRO=melodic  UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - ROS_PARALLEL_TEST_JOBS=-j1
   matrix:
     - ROS_DISTRO="melodic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO="melodic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu
+    - ROS_DISTRO="melodic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-testing/ubuntu
     - ROS_DISTRO="melodic"  UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/ros-controls/ros_control/$ROS_DISTRO-devel/ros_control.rosinstall
 install:
   - git clone --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci


### PR DESCRIPTION
In response to the security breach last month, all packages should move from using the `ros-shadow-fixed` repository to the new `ros-testing` repository.

See [@tfoote's post on the discourse](https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454).