### PR TITLE
Split JointTrajectoryController::update() into smaller pieces

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -250,7 +250,7 @@ protected:
    * \brief Internal update function.
    * Update time data, current states and errors and check tolerances.
    */
-  virtual void updateStateAndTimeData(const ros::Time& time, const ros::Duration& period);
+  virtual void updateStateAndTimeData(const ros::Time& time, const ros::Duration& period, TimeData& time_data);
 
   /**
    * \brief Set current active goal to succeeded (if present).

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -248,21 +248,18 @@ protected:
 
   /**
    * \brief Internal update function.
-   *
    * Update time data, current states and errors and check tolerances.
    */
   void updateStateAndTimeData(const ros::Time& time, const ros::Duration& period);
 
   /**
    * \brief Set current active goal to succeeded (if present).
-   *
    * \note This method is realtime-safe.
    */
   void setGoalAsSucceeded();
 
   /**
    * \brief Set action feedback (if active goal present).
-   *
    * \note This method is realtime-safe.
    */
   void setActionFeedback();

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -246,7 +246,40 @@ protected:
    */
   void setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh=RealtimeGoalHandlePtr());
 
+  /**
+   * \brief Internal update function.
+   *
+   * Update time data, current states and errors and check tolerances.
+   */
+  void updateStateAndTimeData(const ros::Time& time, const ros::Duration& period);
+
+  /**
+   * \brief Set current active goal to succeeded (if present).
+   *
+   * \note This method is realtime-safe.
+   */
+  void setGoalAsSucceeded();
+
+  /**
+   * \brief Set action feedback (if active goal present).
+   *
+   * \note This method is realtime-safe.
+   */
+  void setActionFeedback();
+
+  /**
+   * \brief Check if all segments finished successfully.
+   */
+  bool allSegmentsCompleted();
+
 };
+
+template <class SegmentImpl, class HardwareInterface>
+inline bool JointTrajectoryController<SegmentImpl, HardwareInterface>::
+allSegmentsCompleted()
+{
+  return successful_joint_traj_.count() == joints_.size();
+}
 
 } // namespace
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -270,13 +270,13 @@ protected:
   /**
    * \brief Check if all segments finished successfully.
    */
-  bool allSegmentsCompleted();
+  bool allSegmentsCompleted() const;
 
 };
 
 template <class SegmentImpl, class HardwareInterface>
 inline bool JointTrajectoryController<SegmentImpl, HardwareInterface>::
-allSegmentsCompleted()
+allSegmentsCompleted() const
 {
   return successful_joint_traj_.count() == joints_.size();
 }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -250,19 +250,19 @@ protected:
    * \brief Internal update function.
    * Update time data, current states and errors and check tolerances.
    */
-  void updateStateAndTimeData(const ros::Time& time, const ros::Duration& period);
+  virtual void updateStateAndTimeData(const ros::Time& time, const ros::Duration& period);
 
   /**
    * \brief Set current active goal to succeeded (if present).
    * \note This method is realtime-safe.
    */
-  void setGoalAsSucceeded();
+  virtual void setGoalAsSucceeded();
 
   /**
    * \brief Set action feedback (if active goal present).
    * \note This method is realtime-safe.
    */
-  void setActionFeedback();
+  virtual void setActionFeedback();
 
   /**
    * \brief Check if all segments finished successfully.

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -253,6 +253,11 @@ protected:
   virtual void updateStateAndTimeData(const ros::Time& time, const ros::Duration& period, TimeData& time_data);
 
   /**
+   * \brief Update commands on the hardware interface.
+   */
+  virtual void updateHardwareInterface(const TimeData& time_data);
+
+  /**
    * \brief Set current active goal to succeeded (if present).
    * \note This method is realtime-safe.
    */
@@ -270,6 +275,14 @@ protected:
   bool allSegmentsCompleted() const;
 
 };
+
+template <class SegmentImpl, class HardwareInterface>
+inline void JointTrajectoryController<SegmentImpl, HardwareInterface>::
+updateHardwareInterface(const TimeData& time_data)
+{
+  hw_iface_adapter_.updateCommand(time_data.uptime, time_data.period,
+                                  desired_state_, state_error_);
+}
 
 template <class SegmentImpl, class HardwareInterface>
 inline bool JointTrajectoryController<SegmentImpl, HardwareInterface>::

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -348,145 +348,20 @@ template <class SegmentImpl, class HardwareInterface>
 void JointTrajectoryController<SegmentImpl, HardwareInterface>::
 update(const ros::Time& time, const ros::Duration& period)
 {
-  // Get currently followed trajectory
-  TrajectoryPtr curr_traj_ptr;
-  curr_trajectory_box_.get(curr_traj_ptr);
-  Trajectory& curr_traj = *curr_traj_ptr;
+  updateStateAndTimeData(time, period);
 
-  // Update time data
-  TimeData time_data;
-  time_data.time   = time;                                     // Cache current time
-  time_data.period = period;                                   // Cache current control period
-  time_data.uptime = time_data_.readFromRT()->uptime + period; // Update controller uptime
-  time_data_.writeFromNonRT(time_data); // TODO: Grrr, we need a lock-free data structure here!
-
-  // NOTE: It is very important to execute the two above code blocks in the specified sequence: first get current
-  // trajectory, then update time data. Hopefully the following paragraph sheds a bit of light on the rationale.
-  // The non-rt thread responsible for processing new commands enqueues trajectories that can start at the _next_
-  // control cycle (eg. zero start time) or later (eg. when we explicitly request a start time in the future).
-  // If we reverse the order of the two blocks above, and update the time data first; it's possible that by the time we
-  // fetch the currently followed trajectory, it has been updated by the non-rt thread with something that starts in the
-  // next control cycle, leaving the current cycle without a valid trajectory.
-
-  // Update current state and state error
-  for (unsigned int i = 0; i < joints_.size(); ++i)
+  if (allSegmentsCompleted())
   {
-    current_state_.position[i] = joints_[i].getPosition();
-    current_state_.velocity[i] = joints_[i].getVelocity();
-    // There's no acceleration data available in a joint handle
-
-    typename TrajectoryPerJoint::const_iterator segment_it = sample(curr_traj[i], time_data.uptime.toSec(), desired_joint_state_);
-    if (curr_traj[i].end() == segment_it)
-    {
-      // Non-realtime safe, but should never happen under normal operation
-      ROS_ERROR_NAMED(name_,
-                      "Unexpected error: No trajectory defined at current time. Please contact the package maintainer.");
-      return;
-    }
-    desired_state_.position[i] = desired_joint_state_.position[0];
-    desired_state_.velocity[i] = desired_joint_state_.velocity[0];
-    desired_state_.acceleration[i] = desired_joint_state_.acceleration[0]; ;
-
-    state_joint_error_.position[0] = angles::shortest_angular_distance(current_state_.position[i],desired_joint_state_.position[0]);
-    state_joint_error_.velocity[0] = desired_joint_state_.velocity[0] - current_state_.velocity[i];
-    state_joint_error_.acceleration[0] = 0.0;
-
-    state_error_.position[i] = angles::shortest_angular_distance(current_state_.position[i],desired_joint_state_.position[0]);
-    state_error_.velocity[i] = desired_joint_state_.velocity[0] - current_state_.velocity[i];
-    state_error_.acceleration[i] = 0.0;
-
-    //Check tolerances
-    const RealtimeGoalHandlePtr rt_segment_goal = segment_it->getGoalHandle();
-    if (rt_segment_goal && rt_segment_goal == rt_active_goal_)
-    {
-      // Check tolerances
-      if (time_data.uptime.toSec() < segment_it->endTime())
-      {
-        // Currently executing a segment: check path tolerances
-        const SegmentTolerancesPerJoint<Scalar>& joint_tolerances = segment_it->getTolerances();
-        if (!checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance))
-        {
-          if (verbose_)
-          {
-            ROS_ERROR_STREAM_NAMED(name_,"Path tolerances failed for joint: " << joint_names_[i]);
-            checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance, true);
-          }
-          rt_segment_goal->preallocated_result_->error_code =
-          control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
-          rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
-          rt_active_goal_.reset();
-          successful_joint_traj_.reset();
-        }
-      }
-      else if (segment_it == --curr_traj[i].end())
-      {
-        if (verbose_)
-          ROS_DEBUG_STREAM_THROTTLE_NAMED(1,name_,"Finished executing last segment, checking goal tolerances");
-
-        // Controller uptime
-        const ros::Time uptime = time_data_.readFromRT()->uptime;
-
-        // Checks that we have ended inside the goal tolerances
-        const SegmentTolerancesPerJoint<Scalar>& tolerances = segment_it->getTolerances();
-        const bool inside_goal_tolerances = checkStateTolerancePerJoint(state_joint_error_, tolerances.goal_state_tolerance);
-
-        if (inside_goal_tolerances)
-        {
-          successful_joint_traj_[i] = 1;
-        }
-        else if (uptime.toSec() < segment_it->endTime() + tolerances.goal_time_tolerance)
-        {
-          // Still have some time left to meet the goal state tolerances
-        }
-        else
-        {
-          if (verbose_)
-          {
-            ROS_ERROR_STREAM_NAMED(name_,"Goal tolerances failed for joint: "<< joint_names_[i]);
-            // Check the tolerances one more time to output the errors that occurs
-            checkStateTolerancePerJoint(state_joint_error_, tolerances.goal_state_tolerance, true);
-          }
-
-          rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED;
-          rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
-          rt_active_goal_.reset();
-          successful_joint_traj_.reset();
-        }
-      }
-    }
-  }
-
-  //If there is an active goal and all segments finished successfully then set goal as succeeded
-  RealtimeGoalHandlePtr current_active_goal(rt_active_goal_);
-  if (current_active_goal && successful_joint_traj_.count() == joints_.size())
-  {
-    current_active_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::SUCCESSFUL;
-    current_active_goal->setSucceeded(current_active_goal->preallocated_result_);
-    current_active_goal.reset(); // do not publish feedback
-    rt_active_goal_.reset();
-    successful_joint_traj_.reset();
+    setGoalAsSucceeded();
   }
 
   // Hardware interface adapter: Generate and send commands
-  hw_iface_adapter_.updateCommand(time_data.uptime, time_data.period,
+  hw_iface_adapter_.updateCommand(time_data_.readFromRT()->uptime, time_data_.readFromRT()->period,
                                   desired_state_, state_error_);
 
-  // Set action feedback
-  if (current_active_goal)
-  {
-    current_active_goal->preallocated_feedback_->header.stamp          = time_data_.readFromRT()->time;
-    current_active_goal->preallocated_feedback_->desired.positions     = desired_state_.position;
-    current_active_goal->preallocated_feedback_->desired.velocities    = desired_state_.velocity;
-    current_active_goal->preallocated_feedback_->desired.accelerations = desired_state_.acceleration;
-    current_active_goal->preallocated_feedback_->actual.positions      = current_state_.position;
-    current_active_goal->preallocated_feedback_->actual.velocities     = current_state_.velocity;
-    current_active_goal->preallocated_feedback_->error.positions       = state_error_.position;
-    current_active_goal->preallocated_feedback_->error.velocities      = state_error_.velocity;
-    current_active_goal->setFeedback( current_active_goal->preallocated_feedback_ );
-  }
+  setActionFeedback();
 
-  // Publish state
-  publishState(time_data.uptime);
+  publishState(time_data_.readFromRT()->uptime);
 }
 
 template <class SegmentImpl, class HardwareInterface>
@@ -809,6 +684,152 @@ setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh)
     }
   }
   curr_trajectory_box_.set(hold_trajectory_ptr_);
+}
+
+template <class SegmentImpl, class HardwareInterface>
+void JointTrajectoryController<SegmentImpl, HardwareInterface>::
+updateStateAndTimeData(const ros::Time& time, const ros::Duration& period)
+{
+  // Get currently followed trajectory
+  TrajectoryPtr curr_traj_ptr;
+  curr_trajectory_box_.get(curr_traj_ptr);
+  Trajectory& curr_traj = *curr_traj_ptr;
+
+  // Update time data
+  TimeData time_data;
+  time_data.time   = time;                                     // Cache current time
+  time_data.period = period;                                   // Cache current control period
+  time_data.uptime = time_data_.readFromRT()->uptime + period; // Update controller uptime
+  time_data_.writeFromNonRT(time_data); // TODO: Grrr, we need a lock-free data structure here!
+
+  // NOTE: It is very important to execute the two above code blocks in the specified sequence: first get current
+  // trajectory, then update time data. Hopefully the following paragraph sheds a bit of light on the rationale.
+  // The non-rt thread responsible for processing new commands enqueues trajectories that can start at the _next_
+  // control cycle (eg. zero start time) or later (eg. when we explicitly request a start time in the future).
+  // If we reverse the order of the two blocks above, and update the time data first; it's possible that by the time we
+  // fetch the currently followed trajectory, it has been updated by the non-rt thread with something that starts in the
+  // next control cycle, leaving the current cycle without a valid trajectory.
+
+  // Update current state and state error
+  for (unsigned int i = 0; i < joints_.size(); ++i)
+  {
+    current_state_.position[i] = joints_[i].getPosition();
+    current_state_.velocity[i] = joints_[i].getVelocity();
+    // There's no acceleration data available in a joint handle
+
+    typename TrajectoryPerJoint::const_iterator segment_it = sample(curr_traj[i], time_data.uptime.toSec(), desired_joint_state_);
+    if (curr_traj[i].end() == segment_it)
+    {
+      // Non-realtime safe, but should never happen under normal operation
+      ROS_ERROR_NAMED(name_,
+                      "Unexpected error: No trajectory defined at current time. Please contact the package maintainer.");
+      return;
+    }
+    desired_state_.position[i] = desired_joint_state_.position[0];
+    desired_state_.velocity[i] = desired_joint_state_.velocity[0];
+    desired_state_.acceleration[i] = desired_joint_state_.acceleration[0]; ;
+
+    state_joint_error_.position[0] = angles::shortest_angular_distance(current_state_.position[i],desired_joint_state_.position[0]);
+    state_joint_error_.velocity[0] = desired_joint_state_.velocity[0] - current_state_.velocity[i];
+    state_joint_error_.acceleration[0] = 0.0;
+
+    state_error_.position[i] = angles::shortest_angular_distance(current_state_.position[i],desired_joint_state_.position[0]);
+    state_error_.velocity[i] = desired_joint_state_.velocity[0] - current_state_.velocity[i];
+    state_error_.acceleration[i] = 0.0;
+
+    //Check tolerances
+    const RealtimeGoalHandlePtr rt_segment_goal = segment_it->getGoalHandle();
+    if (rt_segment_goal && rt_segment_goal == rt_active_goal_)
+    {
+      // Check tolerances
+      if (time_data.uptime.toSec() < segment_it->endTime())
+      {
+        // Currently executing a segment: check path tolerances
+        const SegmentTolerancesPerJoint<Scalar>& joint_tolerances = segment_it->getTolerances();
+        if (!checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance))
+        {
+          if (verbose_)
+          {
+            ROS_ERROR_STREAM_NAMED(name_,"Path tolerances failed for joint: " << joint_names_[i]);
+            checkStateTolerancePerJoint(state_joint_error_, joint_tolerances.state_tolerance, true);
+          }
+          rt_segment_goal->preallocated_result_->error_code =
+          control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
+          rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
+          rt_active_goal_.reset();
+          successful_joint_traj_.reset();
+        }
+      }
+      else if (segment_it == --curr_traj[i].end())
+      {
+        if (verbose_)
+          ROS_DEBUG_STREAM_THROTTLE_NAMED(1,name_,"Finished executing last segment, checking goal tolerances");
+
+        // Controller uptime
+        const ros::Time uptime = time_data_.readFromRT()->uptime;
+
+        // Checks that we have ended inside the goal tolerances
+        const SegmentTolerancesPerJoint<Scalar>& tolerances = segment_it->getTolerances();
+        const bool inside_goal_tolerances = checkStateTolerancePerJoint(state_joint_error_, tolerances.goal_state_tolerance);
+
+        if (inside_goal_tolerances)
+        {
+          successful_joint_traj_[i] = 1;
+        }
+        else if (uptime.toSec() < segment_it->endTime() + tolerances.goal_time_tolerance)
+        {
+          // Still have some time left to meet the goal state tolerances
+        }
+        else
+        {
+          if (verbose_)
+          {
+            ROS_ERROR_STREAM_NAMED(name_,"Goal tolerances failed for joint: "<< joint_names_[i]);
+            // Check the tolerances one more time to output the errors that occurs
+            checkStateTolerancePerJoint(state_joint_error_, tolerances.goal_state_tolerance, true);
+          }
+
+          rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED;
+          rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
+          rt_active_goal_.reset();
+          successful_joint_traj_.reset();
+        }
+      }
+    }
+  }
+}
+
+template <class SegmentImpl, class HardwareInterface>
+void JointTrajectoryController<SegmentImpl, HardwareInterface>::
+setGoalAsSucceeded()
+{
+  RealtimeGoalHandlePtr current_active_goal(rt_active_goal_);
+  if (current_active_goal)
+  {
+    current_active_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::SUCCESSFUL;
+    current_active_goal->setSucceeded(current_active_goal->preallocated_result_);
+    rt_active_goal_.reset();
+    successful_joint_traj_.reset();
+  }
+}
+
+template <class SegmentImpl, class HardwareInterface>
+void JointTrajectoryController<SegmentImpl, HardwareInterface>::
+setActionFeedback()
+{
+  RealtimeGoalHandlePtr current_active_goal(rt_active_goal_);
+  if (current_active_goal)
+  {
+    current_active_goal->preallocated_feedback_->header.stamp          = time_data_.readFromRT()->time;
+    current_active_goal->preallocated_feedback_->desired.positions     = desired_state_.position;
+    current_active_goal->preallocated_feedback_->desired.velocities    = desired_state_.velocity;
+    current_active_goal->preallocated_feedback_->desired.accelerations = desired_state_.acceleration;
+    current_active_goal->preallocated_feedback_->actual.positions      = current_state_.position;
+    current_active_goal->preallocated_feedback_->actual.velocities     = current_state_.velocity;
+    current_active_goal->preallocated_feedback_->error.positions       = state_error_.position;
+    current_active_goal->preallocated_feedback_->error.velocities      = state_error_.velocity;
+    current_active_goal->setFeedback( current_active_goal->preallocated_feedback_ );
+  }
 }
 
 } // namespace

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -359,8 +359,7 @@ update(const ros::Time& time, const ros::Duration& period)
   }
 
   // Hardware interface adapter: Generate and send commands
-  hw_iface_adapter_.updateCommand(time_data.uptime, time_data.period,
-                                  desired_state_, state_error_);
+  updateHardwareInterface(time_data);
 
   setActionFeedback();
 


### PR DESCRIPTION
This introduces some subfunctions of update() in order to:
* make it more readable,
* facilitate overriding in derived classes.

The main objective is that we want to add a check on the updated states before they are set in the hardware_interface. Currently, we call the parent update() in the derived class and perform the check afterwards. But actually we need it before the commands are set.