### PR TITLE
Use #pragma once

### DIFF
--- a/ackermann_steering_controller/include/ackermann_steering_controller/ackermann_steering_controller.h
+++ b/ackermann_steering_controller/include/ackermann_steering_controller/ackermann_steering_controller.h
@@ -36,6 +36,9 @@
  * Author: Masaru Morita, Bence Magyar, Enrique Fernández
  */
 
+#pragma once
+
+
 #include <ackermann_steering_controller/odometry.h>
 #include <controller_interface/controller.h>
 #include <controller_interface/multi_interface_controller.h>

--- a/ackermann_steering_controller/include/ackermann_steering_controller/odometry.h
+++ b/ackermann_steering_controller/include/ackermann_steering_controller/odometry.h
@@ -40,8 +40,8 @@
  * Author: Masaru Morita
  */
 
-#ifndef ODOMETRY_ACKERMANN_STEERING_H_
-#define ODOMETRY_ACKERMANN_STEERING_H_
+#pragma once
+
 
 #include <ros/time.h>
 #include <boost/accumulators/accumulators.hpp>
@@ -206,5 +206,3 @@ namespace ackermann_steering_controller
     IntegrationFunction integrate_fun_;
   };
 }
-
-#endif /* ODOMETRY_ACKERMANN_STEERING_H_ */

--- a/ackermann_steering_controller/test/common/include/ackermann_steering_bot.h
+++ b/ackermann_steering_controller/test/common/include/ackermann_steering_bot.h
@@ -29,6 +29,9 @@
 
 // NOTE: The contents of this file have been taken largely from the ros_control wiki tutorials
 
+#pragma once
+
+
 // ROS
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>
@@ -197,7 +200,7 @@ public:
   }
 
 private:
-  
+
   void cleanUp()
   {
     // wheel

--- a/ackermann_steering_controller/test/common/include/test_common.h
+++ b/ackermann_steering_controller/test/common/include/test_common.h
@@ -28,6 +28,9 @@
 /// \author Bence Magyar
 /// \author Masaru Morita
 
+#pragma once
+
+
 #include <algorithm>
 #include <cmath>
 #include <mutex>

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -36,6 +36,9 @@
  * Author: Bence Magyar, Enrique Fernández
  */
 
+#pragma once
+
+
 #include <control_msgs/JointTrajectoryControllerState.h>
 #include <controller_interface/controller.h>
 #include <diff_drive_controller/DiffDriveControllerConfig.h>
@@ -231,7 +234,7 @@ namespace diff_drive_controller{
 
     /// Dynamic Reconfigure server
     typedef dynamic_reconfigure::Server<DiffDriveControllerConfig> ReconfigureServer;
-    
+
     std::shared_ptr<ReconfigureServer> dyn_reconf_server_;
 
   private:

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -39,8 +39,8 @@
  * Author: Paul Mathieu
  */
 
-#ifndef ODOMETRY_H_
-#define ODOMETRY_H_
+#pragma once
+
 
 #include <ros/time.h>
 #include <boost/accumulators/accumulators.hpp>
@@ -208,5 +208,3 @@ namespace diff_drive_controller
     IntegrationFunction integrate_fun_;
   };
 }
-
-#endif /* ODOMETRY_H_ */

--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.h
@@ -36,8 +36,8 @@
  * Author: Enrique Fernández
  */
 
-#ifndef SPEED_LIMITER_H
-#define SPEED_LIMITER_H
+#pragma once
+
 
 namespace diff_drive_controller
 {
@@ -127,5 +127,3 @@ namespace diff_drive_controller
   };
 
 } // namespace diff_drive_controller
-
-#endif // SPEED_LIMITER_H

--- a/diff_drive_controller/test/diffbot.h
+++ b/diff_drive_controller/test/diffbot.h
@@ -27,6 +27,9 @@
 
 // NOTE: The contents of this file have been taken largely from the ros_control wiki tutorials
 
+#pragma once
+
+
 // ROS
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -27,6 +27,9 @@
 
 /// \author Bence Magyar
 
+#pragma once
+
+
 #include <cmath>
 
 #include <gtest/gtest.h>
@@ -157,4 +160,3 @@ inline tf::Quaternion tfQuatFromGeomQuat(const geometry_msgs::Quaternion& quat)
 {
   return tf::Quaternion(quat.x, quat.y, quat.z, quat.w);
 }
-

--- a/effort_controllers/include/effort_controllers/joint_effort_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_effort_controller.h
@@ -34,8 +34,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS__JOINT_EFFORT_CONTROLLER_H
-#define EFFORT_CONTROLLERS__JOINT_EFFORT_CONTROLLER_H
+#pragma once
+
 
 #include <forward_command_controller/forward_command_controller.h>
 
@@ -58,5 +58,3 @@ namespace effort_controllers
 typedef forward_command_controller::ForwardCommandController<hardware_interface::EffortJointInterface>
         JointEffortController;
 }
-
-#endif

--- a/effort_controllers/include/effort_controllers/joint_group_effort_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_group_effort_controller.h
@@ -35,8 +35,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS_JOINT_GROUP_EFFORT_CONTROLLER_H
-#define EFFORT_CONTROLLERS_JOINT_GROUP_EFFORT_CONTROLLER_H
+#pragma once
+
 
 #include <forward_command_controller/forward_joint_group_command_controller.h>
 
@@ -59,5 +59,3 @@ namespace effort_controllers
 typedef forward_command_controller::ForwardJointGroupCommandController<hardware_interface::EffortJointInterface>
         JointGroupEffortController;
 }
-
-#endif

--- a/effort_controllers/include/effort_controllers/joint_group_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_group_position_controller.h
@@ -35,8 +35,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS_JOINT_GROUP_POSITION_CONTROLLER_H
-#define EFFORT_CONTROLLERS_JOINT_GROUP_POSITION_CONTROLLER_H
+#pragma once
+
 
 #include <control_msgs/JointControllerState.h>
 #include <control_toolbox/pid.h>
@@ -65,7 +65,7 @@ namespace effort_controllers
  * - \b command (std_msgs::Float64MultiArray) : The joint efforts to apply
  */
 class JointGroupPositionController : public controller_interface::Controller<hardware_interface::EffortJointInterface>
-{  
+{
 public:
   JointGroupPositionController();
   ~JointGroupPositionController();
@@ -90,5 +90,3 @@ private:
 }; // class
 
 } // namespace
-
-#endif

--- a/effort_controllers/include/effort_controllers/joint_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_position_controller.h
@@ -33,8 +33,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS__JOINT_POSITION_CONTROLLER_H
-#define EFFORT_CONTROLLERS__JOINT_POSITION_CONTROLLER_H
+#pragma once
+
 
 /**
    @class effort_controllers::JointPositionController
@@ -103,7 +103,7 @@ public:
    *
    * \returns True if initialization was successful and the controller
    * is ready to be started.
-   */  
+   */
   bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 
   /*!
@@ -128,7 +128,7 @@ public:
    * \param time The current time
    */
   void starting(const ros::Time& time);
-  
+
   /*!
    * \brief Issues commands to the joint. Should be called at regular intervals
    */
@@ -195,5 +195,3 @@ private:
 };
 
 } // namespace
-
-#endif

--- a/effort_controllers/include/effort_controllers/joint_velocity_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_velocity_controller.h
@@ -33,8 +33,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef EFFORT_CONTROLLERS__JOINT_VELOCITY_CONTROLLER_H
-#define EFFORT_CONTROLLERS__JOINT_VELOCITY_CONTROLLER_H
+#pragma once
+
 
 /**
    @class effort_controllers::JointVelocityController
@@ -92,7 +92,7 @@ public:
    *
    * \returns True if initialization was successful and the controller
    * is ready to be started.
-   */  
+   */
   bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
 
   /*!
@@ -143,7 +143,7 @@ public:
    * \brief Get the name of the joint this controller uses
    */
   std::string getJointName();
-  
+
   hardware_interface::JointHandle joint_;
   double command_;                                /**< Last commanded velocity. */
 
@@ -164,5 +164,3 @@ private:
 };
 
 } // namespace
-
-#endif

--- a/force_torque_sensor_controller/include/force_torque_sensor_controller/force_torque_sensor_controller.h
+++ b/force_torque_sensor_controller/include/force_torque_sensor_controller/force_torque_sensor_controller.h
@@ -28,8 +28,8 @@
 
 /// \author: Adolfo Rodriguez Tsouroukdissian
 
-#ifndef FORCE_TORQUE_SENSOR_CONTROLLER_FORCE_TORQUE_SENSOR_CONTROLLER_H
-#define FORCE_TORQUE_SENSOR_CONTROLLER_FORCE_TORQUE_SENSOR_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/controller.h>
 #include <geometry_msgs/WrenchStamped.h>
@@ -61,5 +61,3 @@ private:
 };
 
 }
-
-#endif

--- a/forward_command_controller/include/forward_command_controller/forward_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_command_controller.h
@@ -1,4 +1,3 @@
-
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
@@ -35,8 +34,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef FORWARD_COMMAND_CONTROLLER_FORWARD_COMMAND_CONTROLLER_H
-#define FORWARD_COMMAND_CONTROLLER_FORWARD_COMMAND_CONTROLLER_H
+#pragma once
+
 
 #include <ros/node_handle.h>
 #include <hardware_interface/joint_command_interface.h>
@@ -97,5 +96,3 @@ private:
 };
 
 }
-
-#endif

--- a/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
+++ b/forward_command_controller/include/forward_command_controller/forward_joint_group_command_controller.h
@@ -1,4 +1,3 @@
-
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
@@ -36,8 +35,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef FORWARD_COMMAND_CONTROLLER_FORWARD_JOINT_GROUP_COMMAND_CONTROLLER_H
-#define FORWARD_COMMAND_CONTROLLER_FORWARD_JOINT_GROUP_COMMAND_CONTROLLER_H
+#pragma once
+
 
 #include <vector>
 #include <string>
@@ -95,7 +94,7 @@ public:
     {
       try
       {
-        joints_.push_back(hw->getHandle(joint_names_[i]));  
+        joints_.push_back(hw->getHandle(joint_names_[i]));
       }
       catch (const hardware_interface::HardwareInterfaceException& e)
       {
@@ -125,17 +124,15 @@ public:
 
 private:
   ros::Subscriber sub_command_;
-  void commandCB(const std_msgs::Float64MultiArrayConstPtr& msg) 
+  void commandCB(const std_msgs::Float64MultiArrayConstPtr& msg)
   {
     if(msg->data.size()!=n_joints_)
-    { 
+    {
       ROS_ERROR_STREAM("Dimension of command (" << msg->data.size() << ") does not match number of joints (" << n_joints_ << ")! Not executing!");
-      return; 
+      return;
     }
     commands_buffer_.writeFromNonRT(msg->data);
   }
 };
 
 }
-
-#endif

--- a/four_wheel_steering_controller/include/four_wheel_steering_controller/four_wheel_steering_controller.h
+++ b/four_wheel_steering_controller/include/four_wheel_steering_controller/four_wheel_steering_controller.h
@@ -33,6 +33,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#pragma once
+
+
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
 #include <pluginlib/class_list_macros.hpp>

--- a/four_wheel_steering_controller/include/four_wheel_steering_controller/odometry.h
+++ b/four_wheel_steering_controller/include/four_wheel_steering_controller/odometry.h
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef ODOMETRY_H_
-#define ODOMETRY_H_
+#pragma once
+
 
 #include <ros/time.h>
 #include <boost/accumulators/accumulators.hpp>
@@ -263,5 +263,3 @@ namespace four_wheel_steering_controller
     double front_steer_vel_prev_, rear_steer_vel_prev_;
   };
 }
-
-#endif /* ODOMETRY_H_ */

--- a/four_wheel_steering_controller/include/four_wheel_steering_controller/speed_limiter.h
+++ b/four_wheel_steering_controller/include/four_wheel_steering_controller/speed_limiter.h
@@ -36,8 +36,8 @@
  * Author: Enrique Fernández
  */
 
-#ifndef SPEED_LIMITER_H
-#define SPEED_LIMITER_H
+#pragma once
+
 
 namespace four_wheel_steering_controller
 {
@@ -133,5 +133,3 @@ namespace four_wheel_steering_controller
   };
 
 } // namespace four_wheel_steering_controller
-
-#endif // SPEED_LIMITER_H

--- a/four_wheel_steering_controller/test/src/four_wheel_steering.h
+++ b/four_wheel_steering_controller/test/src/four_wheel_steering.h
@@ -1,5 +1,8 @@
 // NOTE: The contents of this file have been taken largely from the ros_control wiki tutorials
 
+#pragma once
+
+
 // ROS
 #include <ros/ros.h>
 #include <std_msgs/Float64.h>

--- a/four_wheel_steering_controller/test/src/test_common.h
+++ b/four_wheel_steering_controller/test/src/test_common.h
@@ -27,6 +27,9 @@
 
 /// \author Bence Magyar
 
+#pragma once
+
+
 #include <cmath>
 
 #include <gtest/gtest.h>
@@ -131,4 +134,3 @@ inline tf::Quaternion tfQuatFromGeomQuat(const geometry_msgs::Quaternion& quat)
 {
   return tf::Quaternion(quat.x, quat.y, quat.z, quat.w);
 }
-

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
@@ -27,8 +27,8 @@
 
 /// \author Sachin Chitta, Adolfo Rodriguez Tsouroukdissian
 
-#ifndef GRIPPER_ACTION_CONTROLLER_GRIPPER_ACTION_CONTROLLER_H
-#define GRIPPER_ACTION_CONTROLLER_GRIPPER_ACTION_CONTROLLER_H
+#pragma once
+
 
 // C++ standard
 #include <cassert>
@@ -80,14 +80,14 @@ public:
     double position_; // Last commanded position
     double max_effort_; // Max allowed effort
   };
-  
+
   GripperActionController();
-  
+
   /** \name Non Real-Time Safe Functions
    *\{*/
   bool init(HardwareInterface* hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh);
   /*\}*/
-  
+
   /** \name Real-Time Safe Functions
    *\{*/
   /** \brief Holds the current position. */
@@ -95,7 +95,7 @@ public:
 
   /** \brief Cancels the active action goal, if any. */
   void stopping(const ros::Time& time);
-  
+
   void update(const ros::Time& time, const ros::Duration& period);
   /*\}*/
 
@@ -112,8 +112,8 @@ private:
 
   typedef HardwareInterfaceAdapter<HardwareInterface> HwIfaceAdapter;
 
-  bool                                          update_hold_position_; 
-  
+  bool                                          update_hold_position_;
+
   bool                                         verbose_;            ///< Hard coded verbose flag to help in debugging
   std::string                                  name_;               ///< Controller name.
   hardware_interface::JointHandle joint_;                          ///< Handles to controlled joints.
@@ -153,5 +153,3 @@ private:
 } // namespace
 
 #include <gripper_action_controller/gripper_action_controller_impl.h>
-
-#endif // header guard

--- a/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
+++ b/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
@@ -28,8 +28,8 @@
 
 /// \author Sachin Chitta, Adolfo Rodriguez Tsouroukdissian
 
-#ifndef GRIPPER_ACTION_CONTROLLER_HARDWARE_INTERFACE_ADAPTER_H
-#define GRIPPER_ACTION_CONTROLLER_HARDWARE_INTERFACE_ADAPTER_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -145,13 +145,13 @@ public:
       ROS_WARN_STREAM("Failed to initialize PID gains from ROS parameter server.");
       return false;
     }
-  
+
     return true;
   }
 
   void starting(const ros::Time& time)
   {
-    if (!joint_handle_ptr_) 
+    if (!joint_handle_ptr_)
     {
       return;
     }
@@ -185,5 +185,3 @@ private:
   PidPtr pid_;
   hardware_interface::JointHandle* joint_handle_ptr_;
 };
-
-#endif // header guard

--- a/imu_sensor_controller/include/imu_sensor_controller/imu_sensor_controller.h
+++ b/imu_sensor_controller/include/imu_sensor_controller/imu_sensor_controller.h
@@ -28,8 +28,8 @@
 
 /// \author: Adolfo Rodriguez Tsouroukdissian
 
-#ifndef IMU_SENSOR_CONTROLLER_IMU_SENSOR_CONTROLLER_H
-#define IMU_SENSOR_CONTROLLER_IMU_SENSOR_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/controller.h>
 #include <hardware_interface/imu_sensor_interface.h>
@@ -60,5 +60,3 @@ private:
 };
 
 }
-
-#endif

--- a/joint_state_controller/include/joint_state_controller/joint_state_controller.h
+++ b/joint_state_controller/include/joint_state_controller/joint_state_controller.h
@@ -29,8 +29,8 @@
  * Author: Wim Meeussen
  */
 
-#ifndef JOINT_STATE_CONTROLLER_JOINT_STATE_CONTROLLER_H
-#define JOINT_STATE_CONTROLLER_JOINT_STATE_CONTROLLER_H
+#pragma once
+
 
 #include <controller_interface/controller.h>
 #include <hardware_interface/joint_state_interface.h>
@@ -99,5 +99,3 @@ private:
 };
 
 }
-
-#endif

--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_HARDWARE_INTERFACE_ADAPTER_H
-#define JOINT_TRAJECTORY_CONTROLLER_HARDWARE_INTERFACE_ADAPTER_H
+#pragma once
+
 
 #include <cassert>
 #include <string>
@@ -356,5 +356,3 @@ public:
 private:
   std::vector<hardware_interface::PosVelAccJointHandle>* joint_handles_ptr_;
 };
-
-#endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_INIT_JOINT_TRAJECTORY_H
-#define JOINT_TRAJECTORY_CONTROLLER_INIT_JOINT_TRAJECTORY_H
+#pragma once
+
 
 // C++ standard
 #include <algorithm>
@@ -524,5 +524,3 @@ Trajectory initJointTrajectory(const trajectory_msgs::JointTrajectory&       msg
 }
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -28,8 +28,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian, Stuart Glaser
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_CONTROLLER_H
-#define JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_CONTROLLER_H
+#pragma once
+
 
 // C++ standard
 #include <cassert>
@@ -119,7 +119,7 @@ namespace joint_trajectory_controller
  * \endcode
  *
  * \tparam HardwareInterface Controller hardware interface. Currently \p hardware_interface::PositionJointInterface,
- * \p hardware_interface::VelocityJointInterface, and \p hardware_interface::EffortJointInterface are supported 
+ * \p hardware_interface::VelocityJointInterface, and \p hardware_interface::EffortJointInterface are supported
  * out-of-the-box.
  */
 template <class SegmentImpl, class HardwareInterface>
@@ -251,5 +251,3 @@ protected:
 } // namespace
 
 #include <joint_trajectory_controller/joint_trajectory_controller_impl.h>
-
-#endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -28,8 +28,7 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian, Stuart Glaser
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_CONTROLLER_IMP_H
-#define JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_CONTROLLER_IMP_H
+#pragma once
 
 
 namespace joint_trajectory_controller
@@ -812,5 +811,3 @@ setHoldPosition(const ros::Time& time, RealtimeGoalHandlePtr gh)
 }
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_msg_utils.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_msg_utils.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_MSG_UTILS_H
-#define JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_MSG_UTILS_H
+#pragma once
+
 
 #include <algorithm>
 #include <iterator>
@@ -166,5 +166,3 @@ findPoint(const trajectory_msgs::JointTrajectory& msg,
 }
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_SEGMENT_H
-#define JOINT_TRAJECTORY_CONTROLLER_JOINT_TRAJECTORY_SEGMENT_H
+#pragma once
+
 
 // C++ standard
 #include <cmath>
@@ -241,5 +241,3 @@ Scalar wraparoundJointOffset(const Scalar& prev_position,
 }
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/tolerances.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_TOLERANCES_H
-#define JOINT_TRAJECTORY_CONTROLLER_TOLERANCES_H
+#pragma once
+
 
 // C++ standard
 #include <cassert>
@@ -314,5 +314,3 @@ SegmentTolerances<Scalar> getSegmentTolerances(const ros::NodeHandle& nh,
 }
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
+++ b/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
@@ -1,4 +1,3 @@
-
 ///////////////////////////////////////////////////////////////////////////////
 // Copyright (C) 2013, PAL Robotics S.L.
 // Copyright (c) 2008, Willow Garage, Inc.
@@ -29,8 +28,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRAJECTORY_INTERFACE_POS_VEL_ACC_STATE_H
-#define TRAJECTORY_INTERFACE_POS_VEL_ACC_STATE_H
+#pragma once
+
 
 #include <vector>
 
@@ -73,5 +72,3 @@ struct PosVelAccState
 };
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/include/trajectory_interface/quintic_spline_segment.h
+++ b/joint_trajectory_controller/include/trajectory_interface/quintic_spline_segment.h
@@ -28,8 +28,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian, Stuart Glaser, Mrinal Kalakrishnan
 
-#ifndef TRAJECTORY_INTERFACE_QUINTIC_SPLINE_SEGMENT_H
-#define TRAJECTORY_INTERFACE_QUINTIC_SPLINE_SEGMENT_H
+#pragma once
+
 
 #include <array>
 #include <iterator>
@@ -407,5 +407,3 @@ sampleWithTimeBounds(const SplineCoefficients& coefficients, const Scalar& durat
 }
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/include/trajectory_interface/trajectory_interface.h
+++ b/joint_trajectory_controller/include/trajectory_interface/trajectory_interface.h
@@ -27,8 +27,8 @@
 
 /// \author Adolfo Rodriguez Tsouroukdissian
 
-#ifndef TRAJECTORY_INTERFACE_TRAJECTORY_INTERFACE_H
-#define TRAJECTORY_INTERFACE_TRAJECTORY_INTERFACE_H
+#pragma once
+
 
 #include <algorithm>
 #include <iterator>
@@ -152,5 +152,3 @@ inline typename Trajectory::const_iterator sample(const Trajectory&             
 }
 
 } // namespace
-
-#endif // header guard

--- a/joint_trajectory_controller/test/test_common.h
+++ b/joint_trajectory_controller/test/test_common.h
@@ -27,8 +27,8 @@
 
 /// \author Immanuel Martini
 
-#ifndef JOINT_TRAJECTORY_CONTROLLER_TEST_COMMON_H
-#define JOINT_TRAJECTORY_CONTROLLER_TEST_COMMON_H
+#pragma once
+
 
 #include <ros/ros.h>
 
@@ -144,5 +144,3 @@ AssertionResult waitForActionGoalState(const std::shared_ptr<SimpleActionClient<
 }
 
 }  // namespace joint_trajectory_controller_tests
-
-#endif  // JOINT_TRAJECTORY_CONTROLLER_TEST_COMMON_H

--- a/position_controllers/include/position_controllers/joint_group_position_controller.h
+++ b/position_controllers/include/position_controllers/joint_group_position_controller.h
@@ -35,8 +35,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef POSITION_CONTROLLERS_JOINT_GROUP_POSITION_CONTROLLER_H
-#define POSITION_CONTROLLERS_JOINT_GROUP_POSITION_CONTROLLER_H
+#pragma once
+
 
 #include <forward_command_controller/forward_joint_group_command_controller.h>
 
@@ -59,5 +59,3 @@ namespace position_controllers
 typedef forward_command_controller::ForwardJointGroupCommandController<hardware_interface::PositionJointInterface>
         JointGroupPositionController;
 }
-
-#endif

--- a/position_controllers/include/position_controllers/joint_position_controller.h
+++ b/position_controllers/include/position_controllers/joint_position_controller.h
@@ -34,8 +34,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef POSITION_CONTROLLERS_JOINT_POSITION_CONTROLLER_H
-#define POSITION_CONTROLLERS_JOINT_POSITION_CONTROLLER_H
+#pragma once
+
 
 #include <forward_command_controller/forward_command_controller.h>
 
@@ -58,5 +58,3 @@ namespace position_controllers
 typedef forward_command_controller::ForwardCommandController<hardware_interface::PositionJointInterface>
         JointPositionController;
 }
-
-#endif

--- a/velocity_controllers/include/velocity_controllers/joint_group_velocity_controller.h
+++ b/velocity_controllers/include/velocity_controllers/joint_group_velocity_controller.h
@@ -35,8 +35,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef VELOCITY_CONTROLLERS_JOINT_GROUP_VELOCITY_CONTROLLER_H
-#define VELOCITY_CONTROLLERS_JOINT_GROUP_VELOCITY_CONTROLLER_H
+#pragma once
+
 
 #include <forward_command_controller/forward_joint_group_command_controller.h>
 
@@ -60,5 +60,3 @@ typedef forward_command_controller::ForwardJointGroupCommandController<hardware_
         JointGroupVelocityController;
 
 }
-
-#endif

--- a/velocity_controllers/include/velocity_controllers/joint_position_controller.h
+++ b/velocity_controllers/include/velocity_controllers/joint_position_controller.h
@@ -40,8 +40,8 @@
  Desc: Velocity-based position controller using basic PID loop
 */
 
-#ifndef VELOCITY_CONTROLLERS__JOINT_POSITION_CONTROLLER_H
-#define VELOCITY_CONTROLLERS__JOINT_POSITION_CONTROLLER_H
+#pragma once
+
 
 /**
    @class velocity_controllers::JointPositionController
@@ -135,7 +135,7 @@ public:
    * \param time The current time
    */
   void starting(const ros::Time& time);
-  
+
   /*!
    * \brief Issues commands to the joint. Should be called at regular intervals
    */
@@ -202,5 +202,3 @@ private:
 };
 
 } // namespace
-
-#endif

--- a/velocity_controllers/include/velocity_controllers/joint_velocity_controller.h
+++ b/velocity_controllers/include/velocity_controllers/joint_velocity_controller.h
@@ -34,8 +34,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-#ifndef VELOCITY_CONTROLLERS_JOINT_VELOCITY_CONTROLLER_H
-#define VELOCITY_CONTROLLERS_JOINT_VELOCITY_CONTROLLER_H
+#pragma once
+
 
 #include <forward_command_controller/forward_command_controller.h>
 
@@ -59,5 +59,3 @@ typedef forward_command_controller::ForwardCommandController<hardware_interface:
         JointVelocityController;
 
 }
-
-#endif


### PR DESCRIPTION
Part of ros-controls/ros_control#403. Corresponds to ros-controls/ros_control#406.

Replace all preprocessor header guards with `#pragma once`. Also adds missing header guard to a few files, including some tests. Every `.h` file now includes `#pragma once`.

(Note: my editor stripped all trailing whitespace in the files I touched. This is particularly apparent in `gripper_action_controller`. Although this change is unrelated to this PR, it doesn't really warrant its own PR, so I left it here since it ought to be dealt with at some point)
