### PR TITLE
Use nullptr

### DIFF
--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -59,7 +59,7 @@ static bool isCylinder(const urdf::LinkConstSharedPtr& link)
 {
   if (!link)
   {
-    ROS_ERROR("Link == NULL.");
+    ROS_ERROR("Link pointer is null.");
     return false;
   }
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -52,13 +52,13 @@ static double euclideanOfVectors(const urdf::Vector3& vec1, const urdf::Vector3&
 /*
 * \brief Check that a link exists and has a geometry collision.
 * \param link The link
-* \return true if the link has a collision element with geometry 
+* \return true if the link has a collision element with geometry
 */
 static bool hasCollisionGeometry(const urdf::LinkConstSharedPtr& link)
 {
   if (!link)
   {
-    ROS_ERROR("Link == NULL.");
+    ROS_ERROR("Link pointer is null.");
     return false;
   }
 
@@ -136,7 +136,7 @@ static bool getWheelRadius(const urdf::LinkConstSharedPtr& wheel_link, double& w
     wheel_radius = (static_cast<urdf::Sphere*>(wheel_link->collision->geometry.get()))->radius;
     return true;
   }
-  
+
   ROS_ERROR_STREAM("Wheel link " << wheel_link->name << " is NOT modeled as a cylinder or sphere!");
   return false;
 }

--- a/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
+++ b/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
@@ -78,7 +78,7 @@ template<>
 class HardwareInterfaceAdapter<hardware_interface::PositionJointInterface>
 {
 public:
-  HardwareInterfaceAdapter() : joint_handle_ptr_(0) {}
+  HardwareInterfaceAdapter() : joint_handle_ptr_(nullptr) {}
 
   bool init(hardware_interface::JointHandle& joint_handle, ros::NodeHandle& controller_nh)
   {
@@ -128,7 +128,7 @@ template<>
 class HardwareInterfaceAdapter<hardware_interface::EffortJointInterface>
 {
 public:
-  HardwareInterfaceAdapter() : joint_handle_ptr_(0) {}
+  HardwareInterfaceAdapter() : joint_handle_ptr_(nullptr) {}
 
   bool init(hardware_interface::JointHandle& joint_handle, ros::NodeHandle& controller_nh)
   {

--- a/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hardware_interface_adapter.h
@@ -94,7 +94,7 @@ template <class State>
 class HardwareInterfaceAdapter<hardware_interface::PositionJointInterface, State>
 {
 public:
-  HardwareInterfaceAdapter() : joint_handles_ptr_(0) {}
+  HardwareInterfaceAdapter() : joint_handles_ptr_(nullptr) {}
 
   bool init(std::vector<hardware_interface::JointHandle>& joint_handles, ros::NodeHandle& /*controller_nh*/)
   {
@@ -144,7 +144,7 @@ template <class State>
 class ClosedLoopHardwareInterfaceAdapter
 {
 public:
-  ClosedLoopHardwareInterfaceAdapter() : joint_handles_ptr_(0) {}
+  ClosedLoopHardwareInterfaceAdapter() : joint_handles_ptr_(nullptr) {}
 
   bool init(std::vector<hardware_interface::JointHandle>& joint_handles, ros::NodeHandle& controller_nh)
   {
@@ -290,7 +290,7 @@ template <class State>
 class HardwareInterfaceAdapter<hardware_interface::PosVelJointInterface, State>
 {
 public:
-  HardwareInterfaceAdapter() : joint_handles_ptr_(0) {}
+  HardwareInterfaceAdapter() : joint_handles_ptr_(nullptr) {}
 
   bool init(std::vector<hardware_interface::PosVelJointHandle>& joint_handles, ros::NodeHandle& /*controller_nh*/)
   {
@@ -327,7 +327,7 @@ template <class State>
 class HardwareInterfaceAdapter<hardware_interface::PosVelAccJointInterface, State>
 {
 public:
-  HardwareInterfaceAdapter() : joint_handles_ptr_(0) {}
+  HardwareInterfaceAdapter() : joint_handles_ptr_(nullptr) {}
 
   bool init(std::vector<hardware_interface::PosVelAccJointHandle>& joint_handles, ros::NodeHandle& /*controller_nh*/)
   {

--- a/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h
@@ -100,14 +100,14 @@ struct InitJointTrajectoryOptions
   typedef typename Segment::Scalar                                                            Scalar;
 
   InitJointTrajectoryOptions()
-    : current_trajectory(0),
-      joint_names(0),
-      angle_wraparound(0),
+    : current_trajectory(nullptr),
+      joint_names(nullptr),
+      angle_wraparound(nullptr),
       rt_goal_handle(),
-      default_tolerances(0),
-      other_time_base(0),
+      default_tolerances(nullptr),
+      other_time_base(nullptr),
       allow_partial_joints_goal(false),
-      error_string(0)
+      error_string(nullptr)
   {}
 
   Trajectory*                current_trajectory;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -221,7 +221,7 @@ protected:
   ros::Timer         goal_handle_timer_;
   ros::Time          last_state_publish_time_;
 
-  virtual bool updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePtr gh, std::string* error_string = 0);
+  virtual bool updateTrajectoryCommand(const JointTrajectoryConstPtr& msg, RealtimeGoalHandlePtr gh, std::string* error_string = nullptr);
   virtual void trajectoryCommandCB(const JointTrajectoryConstPtr& msg);
   virtual void goalCB(GoalHandle gh);
   virtual void cancelCB(GoalHandle gh);


### PR DESCRIPTION
Part of ros-controls/ros_control#403. Corresponds to ros-controls/ros_control#405.

Use `nullptr` instead of 0 or `NULL` for null pointers.

Note: `ackermann_steering_controller.cpp` and `diff_drive_controller.cpp` contain the following snippet:

```
if (!link)
{
 ROS_ERROR("Link == NULL.");
  return false;
}
```

Here, I did not change the `NULL` to `nullptr` since it's in a string. Would you like this updated as well? "Link == nullptr" or perhaps "Link pointer is null"?