### PR TITLE
removed cyclic debug output from ackermann_steering_bot

### DIFF
--- a/ackermann_steering_controller/test/common/src/ackermann_steering_bot.cpp
+++ b/ackermann_steering_controller/test/common/src/ackermann_steering_bot.cpp
@@ -51,7 +51,6 @@ int main(int argc, char **argv)
   spinner.start();
   while(ros::ok())
   {
-    ROS_WARN_STREAM("period: " << robot.getPeriod().toSec());
     robot.read();
     cm.update(robot.getTime(), robot.getPeriod());
     robot.write();


### PR DESCRIPTION
this got logged at 100Hz and took >17k lines of test output