### PR TITLE
[melodic] add missing pluginlib deps.

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
     realtime_tools
     tf
     urdf
+    pluginlib
 )
 
 generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -22,6 +22,7 @@
   <depend>realtime_tools</depend>
   <depend>tf</depend>
   <depend>urdf</depend>
+  <depend>pluginlib</depend>
 
   <test_depend>controller_manager</test_depend>
   <test_depend>rosgraph_msgs</test_depend>

--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   forward_command_controller
   realtime_tools
   urdf
+  pluginlib
 )
 
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -23,6 +23,7 @@
   <depend>realtime_tools</depend> 
   <depend>urdf</depend> 
   <depend>forward_command_controller</depend>
+  <depend>pluginlib</depend>
 
   <export>
     <controller_interface plugin="${prefix}/effort_controllers_plugins.xml"/>

--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -12,7 +12,8 @@ set(${PROJECT_NAME}_CATKIN_DEPS
     four_wheel_steering_msgs
     realtime_tools
     tf
-    urdf_geometry_parser)
+    urdf_geometry_parser
+    pluginlib)
 
 find_package(catkin REQUIRED COMPONENTS ${${PROJECT_NAME}_CATKIN_DEPS})
 

--- a/four_wheel_steering_controller/package.xml
+++ b/four_wheel_steering_controller/package.xml
@@ -19,6 +19,7 @@
   <depend>realtime_tools</depend>
   <depend>tf</depend>
   <depend>urdf_geometry_parser</depend>
+  <depend>pluginlib</depend>
 
   <test_depend>rosgraph_msgs</test_depend>
   <test_depend>rostest</test_depend>

--- a/gripper_action_controller/CMakeLists.txt
+++ b/gripper_action_controller/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(catkin
       trajectory_msgs
       urdf
       xacro
+      pluginlib
 )
 
 catkin_package(

--- a/gripper_action_controller/package.xml
+++ b/gripper_action_controller/package.xml
@@ -26,6 +26,7 @@
   <depend>trajectory_msgs</depend>
   <depend>urdf</depend>
   <depend>xacro</depend>
+  <depend>pluginlib</depend>
 
   <export>
     <controller_interface plugin="${prefix}/ros_control_plugins.xml"/>

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin
     realtime_tools
     control_msgs
     trajectory_msgs
+    pluginlib
 )
 
 # Declare catkin package

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -29,6 +29,7 @@
   <depend>roscpp</depend>
   <depend>trajectory_msgs</depend>
   <depend>urdf</depend>
+  <depend>pluginlib</depend>
 
   <test_depend>rostest</test_depend>
   <test_depend>controller_manager</test_depend>

--- a/position_controllers/CMakeLists.txt
+++ b/position_controllers/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(position_controllers)
 
 # Load catkin and all dependencies required for this package
-find_package(catkin REQUIRED COMPONENTS controller_interface forward_command_controller)
+find_package(catkin REQUIRED COMPONENTS controller_interface forward_command_controller pluginlib)
 
 # Declare catkin project
 catkin_package(

--- a/position_controllers/package.xml
+++ b/position_controllers/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>controller_interface</depend> 
   <depend>forward_command_controller</depend> 
+  <depend>pluginlib</depend>
 
   <export>
     <controller_interface plugin="${prefix}/position_controllers_plugins.xml"/>

--- a/velocity_controllers/CMakeLists.txt
+++ b/velocity_controllers/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(catkin REQUIRED COMPONENTS
   forward_command_controller
   realtime_tools
   urdf
+  pluginlib
 )
 
 # Declare catkin package

--- a/velocity_controllers/package.xml
+++ b/velocity_controllers/package.xml
@@ -24,6 +24,7 @@
   <depend>forward_command_controller</depend>
   <depend>realtime_tools</depend>
   <depend>urdf</depend>
+  <depend>pluginlib</depend>
 
   <export>
     <controller_interface plugin="${prefix}/velocity_controllers_plugins.xml"/>


### PR DESCRIPTION
A recent refactoring work done in [`ros_control`](https://github.com/ros-controls/ros_control/pull/404) has removed the extra dependencies to `pluginlib` and which makes the downstream projects, which depends on `pluginlib` but have not yet to be explicit on that, have build breaks when running `catkin_make_isolated`.

This pull request is to be explicitly adding the dependencies on `pluginlib` for the project using plugin model.