### PR TITLE
Added robot namespace to gui of rqt_joint_trajectory_controller

### DIFF
--- a/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -120,6 +120,8 @@ class JointTrajectoryController(Plugin):
                                'joint_trajectory_controller.ui')
         loadUi(ui_file, self._widget)
         self._widget.setObjectName('JointTrajectoryControllerUi')
+        ns = rospy.get_namespace()[1:-1]
+        self._widget.controller_group.setTitle('ns: ' + ns)
 
         # Setup speed scaler
         speed_scaling = DoubleEditor(1.0, 100.0)
@@ -360,6 +362,7 @@ class JointTrajectoryController(Plugin):
         # Clear joint widgets
         # NOTE: Implementation is a workaround for:
         # https://bugreports.qt-project.org/browse/QTBUG-15990 :(
+					
         layout = self._widget.joint_group.layout()
         if layout is not None:
             while layout.count():


### PR DESCRIPTION
Mainly useful in multi-robot situations where multiple instances of rqt_joint_trajectory_controller run in different namespaces. Prevents confusion by showing the correct robot namespace to choose from the "controller manager ns" dropdown menu in the controller's window.