### PR TITLE
Add extension point in update function to allow additional checks, etc.

### DIFF
--- a/joint_trajectory_controller/CHANGELOG.rst
+++ b/joint_trajectory_controller/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package joint_trajectory_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add extension point in update function
+* Refactor trajectory building
+* Contributors: Pilz GmbH and Co. KG
+
 0.16.0 (2020-04-16)
 -------------------
 * Bump CMake version to prevent CMP0048

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -87,6 +87,19 @@ if(CATKIN_ENABLE_TESTING)
   catkin_add_gtest(init_joint_trajectory_test test/init_joint_trajectory_test.cpp)
   target_link_libraries(init_joint_trajectory_test ${catkin_LIBRARIES})
 
+  catkin_add_gtest(trajectory_builder_test test/trajectory_builder_test.cpp)
+  target_link_libraries(trajectory_builder_test ${catkin_LIBRARIES})
+
+  catkin_add_gtest(hold_trajectory_builder_test
+                   test/hold_trajectory_builder_test.cpp
+                   test/test_common.cpp)
+  target_link_libraries(hold_trajectory_builder_test ${catkin_LIBRARIES})
+
+  catkin_add_gtest(stop_trajectory_builder_test
+                   test/stop_trajectory_builder_test.cpp
+                   test/test_common.cpp)
+  target_link_libraries(stop_trajectory_builder_test ${catkin_LIBRARIES})
+
   add_rostest_gtest(tolerances_test
                   test/tolerances.test
                   test/tolerances_test.cpp)

--- a/joint_trajectory_controller/include/joint_trajectory_controller/hold_trajectory_builder.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/hold_trajectory_builder.h
@@ -1,0 +1,112 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (c) 2008, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+#ifndef HOLD_TRAJECTORY_BUILDER_H
+#define HOLD_TRAJECTORY_BUILDER_H
+
+#include <vector>
+
+#include <joint_trajectory_controller/trajectory_builder.h>
+
+namespace joint_trajectory_controller
+{
+
+/**
+ * @brief Builder creating a trajectory "simply" holding (without motion)
+ * the specified position.
+ */
+template<class SegmentImpl, class HardwareInterface>
+class HoldTrajectoryBuilder : public TrajectoryBuilder<SegmentImpl>
+{
+private:
+  using Segment               = JointTrajectorySegment<SegmentImpl>;
+  using TrajectoryPerJoint    = std::vector<Segment>;
+  using Trajectory            = std::vector<TrajectoryPerJoint>;
+
+  using RealtimeGoalHandle    = realtime_tools::RealtimeServerGoalHandle<control_msgs::FollowJointTrajectoryAction>;
+  using RealtimeGoalHandlePtr = boost::shared_ptr<RealtimeGoalHandle>;
+
+  using JointHandle = typename HardwareInterface::ResourceHandleType;
+
+public:
+  //! @param joints Handles to the controlled joints. Stored for obtaining the current positions at any time.
+  HoldTrajectoryBuilder(const std::vector<JointHandle>&  joints);
+
+public:
+  /**
+   * @brief See base class.
+   */
+  bool buildTrajectory(Trajectory* hold_traj) override;
+
+private:
+  const std::vector<JointHandle>&  joints_;
+
+private: //Pre-allocated memory for real time usage of build function
+  typename Segment::State hold_start_state_ {typename Segment::State(1)};
+  typename Segment::State hold_end_state_   {typename Segment::State(1)};
+
+};
+
+template<class SegmentImpl, class HardwareInterface>
+HoldTrajectoryBuilder<SegmentImpl, HardwareInterface>::HoldTrajectoryBuilder(const std::vector<JointHandle>& joints)
+  : joints_(joints)
+{
+
+}
+
+template<class SegmentImpl, class HardwareInterface>
+bool HoldTrajectoryBuilder<SegmentImpl, HardwareInterface>::buildTrajectory(Trajectory* hold_traj)
+{
+  if(!TrajectoryBuilder<SegmentImpl>::getStartTime())
+  {
+    return false;
+  }
+
+  if(!TrajectoryBuilder<SegmentImpl>::isTrajectoryValid(hold_traj, joints_.size(), 1))
+  {
+    return false;
+  }
+
+  const typename Segment::Time start_time {TrajectoryBuilder<SegmentImpl>::getStartTime().value()};
+  RealtimeGoalHandlePtr goal_handle {TrajectoryBuilder<SegmentImpl>::createGoalHandlePtr()};
+  for (unsigned int joint_index = 0; joint_index < joints_.size(); ++joint_index)
+  {
+    hold_start_state_.position[0]     =  joints_[joint_index].getPosition();
+    hold_start_state_.velocity[0]     =  0.0;
+    hold_start_state_.acceleration[0] =  0.0;
+
+    Segment& segment {(*hold_traj)[joint_index].front()};
+    segment.init(start_time, hold_start_state_,
+                 start_time, hold_start_state_);
+    segment.setGoalHandle(goal_handle);
+  }
+  return true;
+}
+
+}
+
+#endif // HOLD_TRAJECTORY_BUILDER_H

--- a/joint_trajectory_controller/include/joint_trajectory_controller/stop_trajectory_builder.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/stop_trajectory_builder.h
@@ -1,0 +1,144 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+// Copyright (c) 2008, Willow Garage, Inc.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics S.L. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+#ifndef STOP_TRAJECTORY_BUILDER_H
+#define STOP_TRAJECTORY_BUILDER_H
+
+#include <vector>
+
+#include <joint_trajectory_controller/trajectory_builder.h>
+
+namespace joint_trajectory_controller
+{
+
+/**
+ * @brief Builder creating a trajectory stopping the robot.
+ */
+template<class SegmentImpl>
+class StopTrajectoryBuilder : public TrajectoryBuilder<SegmentImpl>
+{
+private:
+  using Segment               = JointTrajectorySegment<SegmentImpl>;
+  using TrajectoryPerJoint    = std::vector<Segment>;
+  using Trajectory            = std::vector<TrajectoryPerJoint>;
+
+  using RealtimeGoalHandle    = realtime_tools::RealtimeServerGoalHandle<control_msgs::FollowJointTrajectoryAction>;
+  using RealtimeGoalHandlePtr = boost::shared_ptr<RealtimeGoalHandle>;
+
+public:
+  /**
+   * @param stop_traj_duration Desired time span [seconds] in which the settle position has to be reached.
+   * @param hold_state Reference to the state where the stop motion shall start.
+   *
+   * @note If there is a time delay in the system it is better to calculate the stop trajectory
+   * starting from the desired position. Otherwise there would be a jerk in the motion.
+   */
+  StopTrajectoryBuilder(const typename Segment::Time& stop_traj_duration,
+                        const typename Segment::State& hold_state);
+
+public:
+  /**
+   * @brief Creates a trajectory which reaches the settle position in a fixed time.
+   *
+   * The calculation is done as follows:
+   * - Create segment that goes from current (pos,vel) to (pos,-vel) in 2x the desired stop time.
+
+   * - Assuming segment symmetry, sample segment at its midpoint (desired stop time). It should have zero velocity.
+   * - Create segment that goes from current state to above zero velocity state, in the desired time.
+   *
+   * @note The symmetry assumption from the second point above might not hold for all possible segment types.
+   *
+   * @returns true if the building of the stop trajectory succeeds, otherwise false.
+   */
+  bool buildTrajectory(Trajectory* hold_traj) override;
+
+private:
+  const typename Segment::Time stop_traj_duration_;
+  //! @brief Stores a reference to the state where the stop motion shall start.
+  const typename Segment::State& hold_state_;
+
+private: //Pre-allocated memory for real time usage of build function
+  typename Segment::State hold_start_state_ {typename Segment::State(1)};
+  typename Segment::State hold_end_state_   {typename Segment::State(1)};
+};
+
+template<class SegmentImpl>
+StopTrajectoryBuilder<SegmentImpl>::StopTrajectoryBuilder(const typename Segment::Time& stop_traj_duration,
+                                                          const typename Segment::State& hold_state)
+  : stop_traj_duration_(stop_traj_duration)
+  , hold_state_(hold_state)
+{
+}
+
+template<class SegmentImpl>
+bool StopTrajectoryBuilder<SegmentImpl>::buildTrajectory(Trajectory* hold_traj)
+{
+  const unsigned int number_of_joints = hold_state_.position.size();
+
+  if(!TrajectoryBuilder<SegmentImpl>::getStartTime())
+  {
+    return false;
+  }
+
+  if(!TrajectoryBuilder<SegmentImpl>::isTrajectoryValid(hold_traj, number_of_joints, 1))
+  {
+    return false;
+  }
+
+  const typename Segment::Time start_time {TrajectoryBuilder<SegmentImpl>::getStartTime().value()};
+  RealtimeGoalHandlePtr goal_handle {TrajectoryBuilder<SegmentImpl>::createGoalHandlePtr()};
+  const typename Segment::Time end_time    {start_time + stop_traj_duration_};
+  const typename Segment::Time end_time_2x {start_time + 2.0 * stop_traj_duration_};
+  for (unsigned int joint_index = 0; joint_index < number_of_joints; ++joint_index)
+  {
+    hold_start_state_.position[0]     =  hold_state_.position[joint_index];
+    hold_start_state_.velocity[0]     =  hold_state_.velocity[joint_index];
+    hold_start_state_.acceleration[0] =  0.0;
+
+    hold_end_state_.position[0]       =  hold_state_.position[joint_index];
+    hold_end_state_.velocity[0]       = -hold_state_.velocity[joint_index];
+    hold_end_state_.acceleration[0]   =  0.0;
+
+    Segment& segment {(*hold_traj)[joint_index].front()};
+    segment.init(start_time,  hold_start_state_,
+                 end_time_2x, hold_end_state_);
+    // Sample segment at its midpoint, that should have zero velocity
+    segment.sample(end_time, hold_end_state_);
+    // Now create segment that goes from current state to one with zero end velocity
+    segment.init(start_time,  hold_start_state_,
+                 end_time,    hold_end_state_);
+
+    segment.setGoalHandle(goal_handle);
+  }
+
+  return true;
+}
+
+
+} // namespace joint_trajectory_controller
+
+#endif // STOP_TRAJECTORY_BUILDER_H

--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_builder.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_builder.h
@@ -1,0 +1,192 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2020 Pilz GmbH & Co. KG
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of Pilz GmbH & Co. KG nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef TRAJECTORY_BUILDER_H
+#define TRAJECTORY_BUILDER_H
+
+#include <vector>
+
+// Boost
+#include <boost/shared_ptr.hpp>
+#include <boost/optional.hpp>
+
+// ROS messages
+#include <control_msgs/FollowJointTrajectoryAction.h>
+
+// realtime_tools
+#include <realtime_tools/realtime_server_goal_handle.h>
+
+#include <joint_trajectory_controller/joint_trajectory_segment.h>
+
+namespace joint_trajectory_controller
+{
+
+/**
+ * @brief Base class for classes used to construct diffent trajectory types.
+ *
+ * A derived class has to implement buildTrajectory().
+ *
+ * The following code snippet shows the intended usage of a builder class:
+ * @code
+ * builder.setStartTime(start_time);
+ * builder.setGoalHandle(goal_handle);
+ * builder.buildTrajectory(trajectory);
+ * @endcode
+ *
+ * Setting a start time is mandatory whereas setting a goal handle can be omitted.
+ * Also note that \p trajectory has to reference a valid trajectory (see isTrajectoryValid()).
+ */
+template<class SegmentImpl>
+class TrajectoryBuilder
+{
+private:
+  using Segment               = JointTrajectorySegment<SegmentImpl>;
+  using TrajectoryPerJoint    = std::vector<Segment>;
+  using Trajectory            = std::vector<TrajectoryPerJoint>;
+
+  using RealtimeGoalHandle    = realtime_tools::RealtimeServerGoalHandle<control_msgs::FollowJointTrajectoryAction>;
+  using RealtimeGoalHandlePtr = boost::shared_ptr<RealtimeGoalHandle>;
+
+public:
+  /**
+   * @brief Set the start time [seconds] of the trajectory to be built.
+   *
+   * The start time is reset by reset().
+   */
+  TrajectoryBuilder<SegmentImpl>* setStartTime(const typename Segment::Time& start_time);
+
+  /**
+   * @brief Set the goal handle that will be attached to the trajectory segments.
+   *
+   * The goal handle is reset by reset().
+   */
+  TrajectoryBuilder<SegmentImpl>* setGoalHandle(RealtimeGoalHandlePtr& goal_handle);
+
+public:
+  /**
+   * @brief Ensures re-usability by allowing the user to reset members
+   * of the builder which should be reset between calls to buildTrajectory().
+   */
+  virtual void reset();
+
+public: 
+  /**
+   * @brief Creates the type of trajectory described by the builder.
+   *
+   * @param trajectory [Out] Trajectory which has to be build.
+   *
+   */
+  virtual bool buildTrajectory(Trajectory* trajectory) = 0;
+
+protected:
+  //! @brief Return the set goal handle or a default one, if no goal handle was set.
+  RealtimeGoalHandlePtr createGoalHandlePtr() const;
+  //! @brief Return the set start time.
+  const boost::optional<typename Segment::Time>& getStartTime() const;
+
+protected:
+  static RealtimeGoalHandlePtr createDefaultGoalHandle();
+
+  /**
+   * @brief Check if the elements of a given trajectory are sized properly.
+   * @param trajectory
+   * @param expected_number_of_joints The count of TrajectoryPerJoint in \p trajectory has to match the number of joints.
+   * @param expected_number_of_segments Each TrajectoryPerJoint in \p trajectory has to contain this number of segments.
+   */
+  static bool isTrajectoryValid(const Trajectory* trajectory,
+                                const unsigned int expected_number_of_joints,
+                                const unsigned int expected_number_of_segments);
+
+private:
+  boost::optional<typename Segment::Time> start_time_   {boost::none};
+  // We do not want to participate in the life time management of the
+  // goal handle, therefore, only a reference is stored.
+  boost::optional<RealtimeGoalHandlePtr&> goal_handle_  {boost::none};
+
+};
+
+template<class SegmentImpl>
+inline TrajectoryBuilder<SegmentImpl>* TrajectoryBuilder<SegmentImpl>::setStartTime(const typename TrajectoryBuilder<SegmentImpl>::Segment::Time& start_time)
+{
+  start_time_ = start_time;
+  return this;
+}
+
+template<class SegmentImpl>
+inline const boost::optional<typename TrajectoryBuilder<SegmentImpl>::Segment::Time>& TrajectoryBuilder<SegmentImpl>::getStartTime() const
+{
+  return start_time_;
+}
+
+template<class SegmentImpl>
+inline TrajectoryBuilder<SegmentImpl>* TrajectoryBuilder<SegmentImpl>::setGoalHandle(TrajectoryBuilder<SegmentImpl>::RealtimeGoalHandlePtr& goal_handle)
+{
+  goal_handle_ = goal_handle;
+  return this;
+}
+
+template<class SegmentImpl>
+inline typename TrajectoryBuilder<SegmentImpl>::RealtimeGoalHandlePtr TrajectoryBuilder<SegmentImpl>::createGoalHandlePtr() const
+{
+  return goal_handle_ ? goal_handle_.value() : createDefaultGoalHandle();
+}
+
+template<class SegmentImpl>
+inline typename TrajectoryBuilder<SegmentImpl>::RealtimeGoalHandlePtr TrajectoryBuilder<SegmentImpl>::createDefaultGoalHandle()
+{
+  return RealtimeGoalHandlePtr();
+}
+
+template<class SegmentImpl>
+inline void TrajectoryBuilder<SegmentImpl>::reset()
+{
+  start_time_ = boost::none;
+  goal_handle_ = boost::none;
+}
+
+template<class SegmentImpl>
+bool TrajectoryBuilder<SegmentImpl>::isTrajectoryValid(const Trajectory* trajectory,
+                                                       const unsigned int expected_number_of_joints,
+                                                       const unsigned int expected_number_of_segments)
+{
+  if (trajectory->size() != expected_number_of_joints)
+  {
+    return false;
+  }
+  for (const auto& traj_per_joint : *trajectory)
+  {
+    if (traj_per_joint.size() != expected_number_of_segments)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+}
+
+#endif // TRAJECTORY_BUILDER_H

--- a/joint_trajectory_controller/test/hold_trajectory_builder_test.cpp
+++ b/joint_trajectory_controller/test/hold_trajectory_builder_test.cpp
@@ -1,0 +1,340 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2020 Pilz GmbH & Co. KG
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of Pilz GmbH & Co. KG nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <actionlib/server/action_server.h>
+
+#include <control_msgs/FollowJointTrajectoryAction.h>
+
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/posvel_command_interface.h>
+#include <hardware_interface/posvelacc_command_interface.h>
+
+#include <joint_trajectory_controller/hold_trajectory_builder.h>
+#include <joint_trajectory_controller/joint_trajectory_segment.h>
+
+#include <realtime_tools/realtime_server_goal_handle.h>
+
+#include <trajectory_interface/quintic_spline_segment.h>
+
+#include "test_common.h"
+
+namespace hold_trajectory_builder_test
+{
+static constexpr double EPS{1e-9};
+
+template<class SegmentType>
+bool statesAlmostEqual(const typename SegmentType::State& state1,
+                       const typename SegmentType::State& state2,
+                       const double& tolerance=EPS)
+{
+  using namespace joint_trajectory_controller_tests;
+  return vectorsAlmostEqual(state1.position, state2.position, tolerance) &&
+         vectorsAlmostEqual(state1.velocity, state2.velocity, tolerance) &&
+         vectorsAlmostEqual(state1.acceleration, state2.acceleration, tolerance);
+}
+
+using JointHandle = hardware_interface::JointHandle;
+using PosVelJointHandle = hardware_interface::PosVelJointHandle;
+using PosVelAccJointHandle = hardware_interface::PosVelAccJointHandle;
+using JointStateHandle = hardware_interface::JointStateHandle;
+
+using QuinticSplineSegment = trajectory_interface::QuinticSplineSegment<double>;
+using Segment = joint_trajectory_controller::JointTrajectorySegment<QuinticSplineSegment>;
+using TrajectoryPerJoint = std::vector<Segment>;
+using Trajectory = std::vector<TrajectoryPerJoint>;
+
+using GoalHandle = actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction>::GoalHandle;
+using RealTimeServerGoalHandle = realtime_tools::RealtimeServerGoalHandle<control_msgs::FollowJointTrajectoryAction>;
+
+/**
+ * @brief Provides all known hardware interfaces.
+ */
+class FakeRobot
+{
+public:
+  FakeRobot()
+    : jsh1_("joint1", &pos1_, &vel2_, &eff1_),
+      jsh2_("joint2", &pos2_, &vel2_, &eff2_)
+  {
+  }
+
+  template<typename HardwareInterface>
+  std::vector<typename HardwareInterface::ResourceHandleType> getJointHandles();
+
+  void setPositions(const double& pos1, const double& pos2)
+  {
+    pos1_ = pos1;
+    pos2_ = pos2;
+  }
+
+private:
+  std::vector<JointHandle> getJointCommandHandles()
+  {
+	  JointHandle joint1(jsh1_, &cmd1_);
+	  JointHandle joint2(jsh2_, &cmd2_);
+    return {joint1, joint2};
+  }
+
+private:
+	double pos1_{0.0}, vel1_{0.0}, eff1_{0.0}, cmd1_{0.0}, vel_cmd1_{0.0}, acc_cmd1_{0.0};
+	double pos2_{0.0}, vel2_{0.0}, eff2_{0.0}, cmd2_{0.0}, vel_cmd2_{0.0}, acc_cmd2_{0.0};
+  JointStateHandle jsh1_, jsh2_;
+};
+
+template<>
+std::vector<JointHandle> FakeRobot::getJointHandles<hardware_interface::PositionJointInterface>()
+{
+  return getJointCommandHandles();
+}
+
+template<>
+std::vector<JointHandle> FakeRobot::getJointHandles<hardware_interface::VelocityJointInterface>()
+{
+  return getJointCommandHandles();
+}
+
+template<>
+std::vector<JointHandle> FakeRobot::getJointHandles<hardware_interface::EffortJointInterface>()
+{
+  return getJointCommandHandles();
+}
+
+template<>
+std::vector<PosVelJointHandle> FakeRobot::getJointHandles<hardware_interface::PosVelJointInterface>()
+{
+	PosVelJointHandle joint1(jsh1_, &cmd1_, &vel_cmd1_);
+	PosVelJointHandle joint2(jsh2_, &cmd2_, &vel_cmd2_);
+  return {joint1, joint2};
+}
+
+template<>
+std::vector<PosVelAccJointHandle> FakeRobot::getJointHandles<hardware_interface::PosVelAccJointInterface>()
+{
+	PosVelAccJointHandle joint1(jsh1_, &cmd1_, &vel_cmd1_, &acc_cmd1_);
+	PosVelAccJointHandle joint2(jsh2_, &cmd2_, &vel_cmd2_, &acc_cmd2_);
+  return {joint1, joint2};
+}
+
+template<typename HardwareInterface>
+class HoldTrajectoryBuilderTest : public testing::Test
+{
+protected:
+  std::vector<typename HardwareInterface::ResourceHandleType> getJointHandles()
+  {
+    return robot_->getJointHandles<HardwareInterface>();
+  }
+
+  std::shared_ptr<FakeRobot> getRobot()
+  {
+    return robot_;
+  }
+
+private:
+  std::shared_ptr<FakeRobot> robot_ {std::make_shared<FakeRobot>()};
+};
+
+using HardwareInterfaceTypes = testing::Types<hardware_interface::PositionJointInterface,
+                                              hardware_interface::VelocityJointInterface,
+                                              hardware_interface::EffortJointInterface,
+                                              hardware_interface::PosVelJointInterface,
+                                              hardware_interface::PosVelAccJointInterface>;
+
+TYPED_TEST_CASE(HoldTrajectoryBuilderTest, HardwareInterfaceTypes);
+
+TYPED_TEST(HoldTrajectoryBuilderTest, testBuildNoStartTime)
+{
+  using Builder = joint_trajectory_controller::HoldTrajectoryBuilder<QuinticSplineSegment, TypeParam>;
+
+  const std::vector<typename TypeParam::ResourceHandleType> joints = this->getJointHandles();
+  const auto number_of_joints = joints.size();
+
+  Builder builder(joints);
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite start time is not set.";
+}
+
+TYPED_TEST(HoldTrajectoryBuilderTest, testBuildIncompleteTrajectory)
+{
+  using Builder = joint_trajectory_controller::HoldTrajectoryBuilder<QuinticSplineSegment, TypeParam>;
+
+  const std::vector<typename TypeParam::ResourceHandleType> joints = this->getJointHandles();
+  const auto number_of_joints = joints.size();
+  const double start_time{0.11};
+
+  Builder builder(joints);
+	builder.setStartTime(start_time);
+
+  Trajectory trajectory;
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite trajectory does not have enough TrajectoriesPerJoint.";
+
+  trajectory.resize(joints.size());
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite trajectory does not have enough segments.";
+}
+
+TYPED_TEST(HoldTrajectoryBuilderTest, testBuildSuccess)
+{
+  using Builder = joint_trajectory_controller::HoldTrajectoryBuilder<QuinticSplineSegment, TypeParam>;
+
+  const std::vector<typename TypeParam::ResourceHandleType> joints = this->getJointHandles();
+  const auto number_of_joints = joints.size();
+  const double start_time{0.11};
+
+  Builder builder(joints);
+	builder.setStartTime(start_time);
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  std::vector<double> positions{-48.9, 2.1};  // set some arbitrary positions
+  std::shared_ptr<FakeRobot> robot = this->getRobot();
+  robot->setPositions(positions.at(0), positions[1]);
+
+  EXPECT_TRUE(builder.buildTrajectory(&trajectory)) << "buildTrajectory() should have been successful.";
+
+  // check built trajectory
+  EXPECT_EQ(trajectory.size(), number_of_joints) << "Built trajectory has wrong number of trajectories per joint.";
+  for (const auto& jt : trajectory)
+  {
+    EXPECT_EQ(jt.size(), 1U) << "Unexpected number of trajectory points.";
+  }
+  EXPECT_NEAR(trajectory.at(0).at(0).startTime(), start_time, EPS) << "Unexpected deviation in start time.";
+
+  // check start and end state
+  Segment::State sampled_state{1};
+  Segment::State expected_state{1};
+  expected_state.velocity.at(0) = 0.0;
+  expected_state.acceleration.at(0) = 0.0;
+  for (unsigned int i = 0; i < number_of_joints; ++i)
+  {
+    expected_state.position.at(0) = positions.at(i);
+
+    trajectory.at(i).at(0).sample(trajectory.at(i).at(0).startTime(), sampled_state);
+    EXPECT_TRUE(statesAlmostEqual<Segment>(sampled_state, expected_state, EPS))
+      << "Start states not equal for joint " << joints.at(i).getName();
+
+    trajectory.at(i).at(0).sample(trajectory.at(i).at(0).endTime(), sampled_state);
+    EXPECT_TRUE(statesAlmostEqual<Segment>(sampled_state, expected_state, EPS))
+      << "End states not equal for joint " << joints.at(i).getName();
+  }
+}
+
+TYPED_TEST(HoldTrajectoryBuilderTest, testResetStartTime)
+{
+  using Builder = joint_trajectory_controller::HoldTrajectoryBuilder<QuinticSplineSegment, TypeParam>;
+
+  const std::vector<typename TypeParam::ResourceHandleType> joints = this->getJointHandles();
+  const auto number_of_joints = joints.size();
+  const double start_time{0.0};
+
+  Builder builder(joints);
+	builder.setStartTime(start_time);
+
+  builder.reset();
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite start time war reset.";
+}
+
+/**
+ * @note A non-empty goal handle cannot be created without an action server,
+ * therefore we check only how the use_count of the shared pointer changes.
+ */
+TYPED_TEST(HoldTrajectoryBuilderTest, testSetGoalHandle)
+{
+  using Builder = joint_trajectory_controller::HoldTrajectoryBuilder<QuinticSplineSegment, TypeParam>;
+
+  const std::vector<typename TypeParam::ResourceHandleType> joints = this->getJointHandles();
+  const auto number_of_joints = joints.size();
+  const double start_time{0.0};
+  GoalHandle gh;
+  boost::shared_ptr<RealTimeServerGoalHandle> rt_goal_handle = boost::make_shared<RealTimeServerGoalHandle>(gh);
+
+  Builder builder(joints);
+	builder.setStartTime(start_time);
+  builder.setGoalHandle(rt_goal_handle);
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1) << "Builder should only store a reference on GoalHandlePtr.";
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_TRUE(builder.buildTrajectory(&trajectory)) << "buildTrajectory() should have been successful.";
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1 + joints.size())
+    << "Unexpected owner count of the goal handle after building the trajectory.";
+}
+
+/**
+ * @note A non-empty goal handle cannot be created without an action server,
+ * therefore we check only how the use_count of the shared pointer changes.
+ */
+TYPED_TEST(HoldTrajectoryBuilderTest, testResetGoalHandle)
+{
+  using Builder = joint_trajectory_controller::HoldTrajectoryBuilder<QuinticSplineSegment, TypeParam>;
+
+  const std::vector<typename TypeParam::ResourceHandleType> joints = this->getJointHandles();
+  const auto number_of_joints = joints.size();
+  const double start_time{0.0};
+  GoalHandle gh;
+  boost::shared_ptr<RealTimeServerGoalHandle> rt_goal_handle = boost::make_shared<RealTimeServerGoalHandle>(gh);
+
+  Builder builder(joints);
+  builder.setGoalHandle(rt_goal_handle);
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1) << "Builder should only store a reference on GoalHandlePtr.";
+
+  builder.reset();
+	builder.setStartTime(start_time);
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_TRUE(builder.buildTrajectory(&trajectory)) << "buildTrajectory() should have been successful.";
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1) << "Modified owner count of the goal handle despite reset.";
+}
+
+}  // namespace hold_trajectory_builder_test
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/joint_trajectory_controller/test/stop_trajectory_builder_test.cpp
+++ b/joint_trajectory_controller/test/stop_trajectory_builder_test.cpp
@@ -1,0 +1,215 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2020 Pilz GmbH & Co. KG
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of Pilz GmbH & Co. KG nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <joint_trajectory_controller/stop_trajectory_builder.h>
+
+#include <trajectory_interface/quintic_spline_segment.h>
+
+#include "test_common.h"
+
+namespace stop_trajectory_builder_test
+{
+static constexpr double EPS{1e-9};
+
+using QuinticSplineSegment = trajectory_interface::QuinticSplineSegment<double>;
+using Segment = joint_trajectory_controller::JointTrajectorySegment<QuinticSplineSegment>;
+using TrajectoryPerJoint = std::vector<Segment>;
+using Trajectory = std::vector<TrajectoryPerJoint>;
+
+using GoalHandle = actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction>::GoalHandle;
+using RealTimeServerGoalHandle = realtime_tools::RealtimeServerGoalHandle<control_msgs::FollowJointTrajectoryAction>;
+
+TEST(StopTrajectoryBuilderTest, testBuildNoStartTime)
+{
+  using Builder = joint_trajectory_controller::StopTrajectoryBuilder<QuinticSplineSegment>;
+
+	const unsigned int number_of_joints{2};
+	const double stop_trajectory_duration{0.2};
+  Segment::State hold_state{number_of_joints};
+  Builder builder(stop_trajectory_duration, hold_state);
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite start time is not set.";
+}
+
+TEST(StopTrajectoryBuilderTest, testBuildIncompleteTrajectory)
+{
+  using Builder = joint_trajectory_controller::StopTrajectoryBuilder<QuinticSplineSegment>;
+
+	const unsigned int number_of_joints{2};
+	const double stop_trajectory_duration{0.2};
+  Segment::State hold_state{number_of_joints};
+  Builder builder(stop_trajectory_duration, hold_state);
+
+  Trajectory trajectory;
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite trajectory does not have enough TrajectoriesPerJoint.";
+
+  trajectory.resize(number_of_joints);
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite trajectory does not have enough segments.";
+}
+
+TEST(StopTrajectoryBuilderTest, testBuildSuccess)
+{
+  using Builder = joint_trajectory_controller::StopTrajectoryBuilder<QuinticSplineSegment>;
+
+	const unsigned int number_of_joints{2};
+	const double stop_duration{0.2};
+  const double start_time{0.11};
+  Segment::State hold_state{number_of_joints};
+	hold_state.position.at(0) = 0.9;  // set arbitrary state
+	hold_state.velocity.at(0) = -0.03;
+	hold_state.position.at(1) = 1.68;
+	hold_state.velocity.at(1) = 3.7;
+  Builder builder(stop_duration, hold_state);
+
+	builder.setStartTime(start_time);
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_TRUE(builder.buildTrajectory(&trajectory)) << "buildTrajectory() should have been successful.";
+
+	// check built trajectory
+  EXPECT_EQ(trajectory.size(), number_of_joints) << "Built trajectory has wrong number of trajectories per joint.";
+  for (const auto& jt : trajectory)
+  {
+    EXPECT_EQ(jt.size(), 1U) << "Unexpected number of trajectory points.";
+  }
+  EXPECT_NEAR(trajectory.at(0).at(0).startTime(), start_time, EPS) << "Unexpected deviation in start time.";
+	EXPECT_NEAR(trajectory.at(0).at(0).endTime(), start_time + stop_duration, EPS) << "Unexpected deviation in end time.";
+
+  // check start and end state
+  Segment::State sampled_state{1};
+  for (unsigned int i = 0; i < number_of_joints; ++i)
+  {
+    trajectory.at(i).at(0).sample(trajectory.at(i).at(0).startTime(), sampled_state);
+		EXPECT_NEAR(sampled_state.position.at(0), hold_state.position.at(i), EPS)
+      << "Start state positions not equal for joint " << i;
+		EXPECT_NEAR(sampled_state.velocity.at(0), hold_state.velocity.at(i), EPS)
+      << "Start state velocities not equal for joint " << i;
+
+    trajectory.at(i).at(0).sample(trajectory.at(i).at(0).endTime(), sampled_state);
+		EXPECT_NEAR(sampled_state.velocity.at(0), 0.0, EPS) << "End state velocity should be zero.";
+	}
+}
+
+TEST(StopTrajectoryBuilderTest, testResetStartTime)
+{
+  using Builder = joint_trajectory_controller::StopTrajectoryBuilder<QuinticSplineSegment>;
+
+	const unsigned int number_of_joints{2};
+	const double stop_duration{0.2};
+  const double start_time{0.11};
+  Segment::State hold_state{number_of_joints};
+
+  Builder builder(stop_duration, hold_state);
+	builder.setStartTime(start_time);
+
+	builder.reset();
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_FALSE(builder.buildTrajectory(&trajectory))
+		<< "buildTrajectory() success despite start time war reset.";
+}
+
+/**
+ * @note A non-empty goal handle cannot be created without an action server,
+ * therefore we check only how the use_count of the shared pointer changes.
+ */
+TEST(StopTrajectoryBuilderTest, testSetGoalHandle)
+{
+  using Builder = joint_trajectory_controller::StopTrajectoryBuilder<QuinticSplineSegment>;
+
+	const unsigned int number_of_joints{2};
+	const double stop_duration{0.2};
+  const double start_time{0.11};
+  Segment::State hold_state{number_of_joints};
+  GoalHandle gh;
+  boost::shared_ptr<RealTimeServerGoalHandle> rt_goal_handle = boost::make_shared<RealTimeServerGoalHandle>(gh);
+
+  Builder builder(stop_duration, hold_state);
+	builder.setStartTime(start_time);
+  builder.setGoalHandle(rt_goal_handle);
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1) << "Builder should only store a reference on GoalHandlePtr.";
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_TRUE(builder.buildTrajectory(&trajectory)) << "buildTrajectory() should have been successful.";
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1 + number_of_joints)
+    << "Unexpected owner count of the goal handle after building the trajectory.";
+}
+
+/**
+ * @note A non-empty goal handle cannot be created without an action server,
+ * therefore we check only how the use_count of the shared pointer changes.
+ */
+TEST(StopTrajectoryBuilderTest, testResetGoalHandle)
+{
+  using Builder = joint_trajectory_controller::StopTrajectoryBuilder<QuinticSplineSegment>;
+
+	const unsigned int number_of_joints{2};
+	const double stop_duration{0.2};
+  const double start_time{0.11};
+  Segment::State hold_state{number_of_joints};
+  GoalHandle gh;
+  boost::shared_ptr<RealTimeServerGoalHandle> rt_goal_handle = boost::make_shared<RealTimeServerGoalHandle>(gh);
+
+  Builder builder(stop_duration, hold_state);
+  builder.setGoalHandle(rt_goal_handle);
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1) << "Builder should only store a reference on GoalHandlePtr.";
+
+	builder.reset();
+	builder.setStartTime(start_time);
+
+  Trajectory trajectory;
+  joint_trajectory_controller_tests::initDefaultTrajectory(number_of_joints, trajectory);
+
+  EXPECT_TRUE(builder.buildTrajectory(&trajectory)) << "buildTrajectory() should have been successful.";
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1) << "Modified owner count of the goal handle despite reset.";
+}
+
+}  // namespace stop_trajectory_builder_test
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/joint_trajectory_controller/test/test_common.cpp
+++ b/joint_trajectory_controller/test/test_common.cpp
@@ -62,4 +62,12 @@ AssertionResult waitForEvent(const std::function<bool()>& check_event,
   return AssertionFailure() << "ROS shutdown.";
 }
 
+void initDefaultTrajectory(unsigned int number_of_joints, std::vector<TrajectoryPerJoint>& trajectory)
+{
+  Segment::State state{1};
+	Segment segment(0.0, state, 1.0, state);
+	TrajectoryPerJoint joint_traj{segment};
+  trajectory.resize(number_of_joints, joint_traj);
+}
+
 }  // joint_trajectory_controller_tests

--- a/joint_trajectory_controller/test/test_common.h
+++ b/joint_trajectory_controller/test/test_common.h
@@ -40,6 +40,10 @@
 #include <trajectory_msgs/JointTrajectory.h>
 #include <trajectory_msgs/JointTrajectoryPoint.h>
 
+#include <joint_trajectory_controller/joint_trajectory_segment.h>
+#include <trajectory_interface/quintic_spline_segment.h>
+
+
 namespace joint_trajectory_controller_tests
 {
 
@@ -85,6 +89,12 @@ inline bool trajectoryPointsAlmostEqual(const trajectory_msgs::JointTrajectoryPo
          vectorsAlmostEqual(p1.velocities, p2.velocities, tolerance) &&
          vectorsAlmostEqual(p1.accelerations, p2.accelerations, tolerance);
 }
+
+using QuinticSplineSegment = trajectory_interface::QuinticSplineSegment<double>;
+using Segment = joint_trajectory_controller::JointTrajectorySegment<QuinticSplineSegment>;
+using TrajectoryPerJoint = std::vector<Segment>;
+
+void initDefaultTrajectory(unsigned int number_of_joints, std::vector<TrajectoryPerJoint>& trajectory);
 
 /////////////////////////////
 // action client functions //

--- a/joint_trajectory_controller/test/trajectory_builder_test.cpp
+++ b/joint_trajectory_controller/test/trajectory_builder_test.cpp
@@ -1,0 +1,133 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2020 Pilz GmbH & Co. KG
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of Pilz GmbH & Co. KG nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include <actionlib/server/action_server.h>
+
+#include <control_msgs/FollowJointTrajectoryAction.h>
+
+#include <joint_trajectory_controller/joint_trajectory_segment.h>
+#include <joint_trajectory_controller/trajectory_builder.h>
+
+#include <realtime_tools/realtime_server_goal_handle.h>
+
+#include <trajectory_interface/quintic_spline_segment.h>
+
+namespace trajectory_builder_tests
+{
+using QuinticSplineSegment = trajectory_interface::QuinticSplineSegment<double>;
+using TrajectoryBuilder = joint_trajectory_controller::TrajectoryBuilder<QuinticSplineSegment>;
+
+using GoalHandle = actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction>::GoalHandle;
+using RealTimeServerGoalHandle = realtime_tools::RealtimeServerGoalHandle<control_msgs::FollowJointTrajectoryAction>;
+
+class FakeTrajectoryBuilder : public TrajectoryBuilder
+{
+private:
+  using Segment = joint_trajectory_controller::JointTrajectorySegment<QuinticSplineSegment>;
+  using TrajectoryPerJoint = std::vector<Segment>;
+  using Trajectory = std::vector<TrajectoryPerJoint>;
+
+  FRIEND_TEST(TrajectoryBuilderTest, testSetStartTime);
+  FRIEND_TEST(TrajectoryBuilderTest, testResetStartTime);
+  FRIEND_TEST(TrajectoryBuilderTest, testSetGoalHandle);
+  FRIEND_TEST(TrajectoryBuilderTest, testResetGoalHandle);
+  FRIEND_TEST(TrajectoryBuilderTest, testDefaultGoalHandle);
+protected:
+  /**
+   * @brief Override pure virtual method. Not included in the tests.
+   */
+  bool buildTrajectory(Trajectory* hold_traj) override
+  {
+    return true;
+  }
+};
+
+TEST(TrajectoryBuilderTest, testSetStartTime)
+{
+  FakeTrajectoryBuilder builder;
+  EXPECT_FALSE(builder.getStartTime().is_initialized()) << "Obtained start time despite not set.";
+
+  const double start_time {0.1};
+  builder.setStartTime(start_time);
+
+  EXPECT_EQ(builder.getStartTime().get(), start_time) << "Start time was not set/returned correctly.";
+}
+
+TEST(TrajectoryBuilderTest, testResetStartTime)
+{
+  FakeTrajectoryBuilder builder;
+
+  const double start_time {0.1};
+  builder.setStartTime(start_time);
+
+  builder.reset();
+  EXPECT_FALSE(builder.getStartTime().is_initialized()) << "Obtained start time despite reset.";
+}
+
+TEST(TrajectoryBuilderTest, testSetGoalHandle)
+{
+  FakeTrajectoryBuilder builder;
+
+  EXPECT_FALSE(builder.createGoalHandlePtr()) << "Obtained goal handle despite not set.";
+
+  GoalHandle gh;
+  boost::shared_ptr<RealTimeServerGoalHandle> rt_goal_handle = boost::make_shared<RealTimeServerGoalHandle>(gh);
+  builder.setGoalHandle(rt_goal_handle);
+
+  EXPECT_EQ(rt_goal_handle.use_count(), 1) << "Builder should only store a reference on GoalHandlePtr.";
+
+  auto gh_return = builder.createGoalHandlePtr();
+  EXPECT_EQ(rt_goal_handle.get(), gh_return.get()) << "Goal handle pointer was not set/returned correctly.";
+}
+
+TEST(TrajectoryBuilderTest, testResetGoalHandle)
+{
+  FakeTrajectoryBuilder builder;
+
+  GoalHandle gh;
+  boost::shared_ptr<RealTimeServerGoalHandle> rt_goal_handle = boost::make_shared<RealTimeServerGoalHandle>(gh);
+  builder.setGoalHandle(rt_goal_handle);
+
+  builder.reset();
+  EXPECT_FALSE(builder.createGoalHandlePtr()) << "Obtained goal handle despite reset.";
+}
+
+TEST(TrajectoryBuilderTest, testDefaultGoalHandle)
+{
+  FakeTrajectoryBuilder builder;
+  EXPECT_FALSE(builder.createDefaultGoalHandle()) << "Default goal handle pointer is expected to be empty";
+}
+
+}  // namespace trajectory_builder_tests
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
As user user of the `JointTrajectoryController`, I need to be able to verify/check the newly calculated desired state before the [hardware interface  is updated](https://github.com/ros-controls/ros_controllers/blob/melodic-devel/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L471), in order, to react to e.g. Cartesian velocity violations, etc.

This PR tries to continue and, more importantly, tries to minimize the necessary changes needed to achieve the objective of PR #442.

This PR is tightly coupled with the needs of [PR #308 on PilzDE/pilz_robots](https://github.com/PilzDE/pilz_robots/pull/308).

**Please note:**
The general refactoring of the update function is now in a separate PR: #450.