### PR TITLE
Solving issues with large rotational limits

### DIFF
--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -57,3 +57,18 @@ install(TARGETS ${PROJECT_NAME}
 
 install(FILES effort_controllers_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS controller_manager rostest)
+  include_directories(include ${catkin_INCLUDE_DIRS})
+
+  add_executable(simple_bot_hw test/simple_bot_hw.cpp)
+  target_link_libraries(simple_bot_hw ${catkin_LIBRARIES})
+  add_dependencies(tests simple_bot_hw)
+
+  add_rostest_gtest(effort_position_controller_test
+    test/effort_position_controller.test
+    test/simple_bot_goto_position.cpp
+  )
+  target_link_libraries(effort_position_controller_test ${catkin_LIBRARIES})
+endif()

--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -59,16 +59,35 @@ install(FILES effort_controllers_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS controller_manager rosgraph_msgs rostest)
-  include_directories(include ${catkin_INCLUDE_DIRS})
+  find_package(rostest REQUIRED)
+  find_package(controller_manager REQUIRED)
+  find_package(controller_manager_msgs REQUIRED)
+  find_package(rosgraph_msgs REQUIRED)
+  find_package(sensor_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
+
+  include_directories(
+    ${controller_manager_INCLUDE_DIRS}
+    ${hardware_interface_INCLUDE_DIRS}
+    ${rosgraph_msgs_INCLUDE_DIRS}
+    ${sensor_msgs_INCLUDE_DIRS}
+    ${std_msgs_INCLUDE_DIRS}
+  )
 
   add_executable(simple_bot_hw test/simple_bot_hw.cpp)
-  target_link_libraries(simple_bot_hw ${catkin_LIBRARIES})
+  target_link_libraries(simple_bot_hw
+    ${catkin_LIBRARIES}
+    ${controller_manager_LIBRARIES}
+    ${hardware_interface_LIBRARIES}
+  )
   add_dependencies(tests simple_bot_hw)
 
   add_rostest_gtest(effort_position_controller_test
     test/effort_position_controller.test
     test/simple_bot_goto_position.cpp
   )
-  target_link_libraries(effort_position_controller_test ${catkin_LIBRARIES})
+  target_link_libraries(
+    effort_position_controller_test
+    ${catkin_LIBRARIES}
+  )
 endif()

--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -59,7 +59,7 @@ install(FILES effort_controllers_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS controller_manager rostest)
+  find_package(catkin REQUIRED COMPONENTS controller_manager rosgraph_msgs rostest)
   include_directories(include ${catkin_INCLUDE_DIRS})
 
   add_executable(simple_bot_hw test/simple_bot_hw.cpp)

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -28,6 +28,7 @@
   <test_depend>rostest</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
+  <test_depend>robot_state_publisher</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/effort_controllers_plugins.xml"/>

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -26,10 +26,13 @@
   <depend>pluginlib</depend>
 
   <test_depend>rostest</test_depend>
-  <test_depend>rosgraph_msgs</test_depend>
   <test_depend>controller_manager</test_depend>
-  <test_depend>xacro</test_depend>
+  <test_depend>hardware_interface</test_depend>
   <test_depend>robot_state_publisher</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>xacro</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/effort_controllers_plugins.xml"/>

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -17,13 +17,17 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>angles</depend>
-  <depend>controller_interface</depend> 
-  <depend>control_msgs</depend> 
-  <depend>control_toolbox</depend> 
-  <depend>realtime_tools</depend> 
-  <depend>urdf</depend> 
+  <depend>controller_interface</depend>
+  <depend>control_msgs</depend>
+  <depend>control_toolbox</depend>
+  <depend>realtime_tools</depend>
+  <depend>urdf</depend>
   <depend>forward_command_controller</depend>
   <depend>pluginlib</depend>
+
+  <test_depend>rostest</test_depend>
+  <test_depend>controller_manager</test_depend>
+  <test_depend>xacro</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/effort_controllers_plugins.xml"/>

--- a/effort_controllers/package.xml
+++ b/effort_controllers/package.xml
@@ -26,6 +26,7 @@
   <depend>pluginlib</depend>
 
   <test_depend>rostest</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
   <test_depend>robot_state_publisher</test_depend>

--- a/effort_controllers/src/joint_group_position_controller.cpp
+++ b/effort_controllers/src/joint_group_position_controller.cpp
@@ -138,12 +138,24 @@ namespace effort_controllers
         // Compute position error
         if (joint_urdfs_[i]->type == urdf::Joint::REVOLUTE)
         {
-         angles::shortest_angular_distance_with_limits(
-            current_position,
-            command_position,
-            joint_urdfs_[i]->limits->lower,
-            joint_urdfs_[i]->limits->upper,
-            error);
+          if(joint_urdfs_[i]->limits->upper - joint_urdfs_[i]->limits->lower >= 2*M_PI)
+          {
+            angles::shortest_angular_distance_with_large_limits(
+              current_position,
+              command_position,
+              joint_urdfs_[i]->limits->lower,
+              joint_urdfs_[i]->limits->upper,
+              error);
+          }
+          else
+          {
+            angles::shortest_angular_distance_with_limits(
+              current_position,
+              command_position,
+              joint_urdfs_[i]->limits->lower,
+              joint_urdfs_[i]->limits->upper,
+              error);
+          }
         }
         else if (joint_urdfs_[i]->type == urdf::Joint::CONTINUOUS)
         {
@@ -165,9 +177,9 @@ namespace effort_controllers
   void JointGroupPositionController::commandCB(const std_msgs::Float64MultiArrayConstPtr& msg)
   {
     if(msg->data.size()!=n_joints_)
-    { 
+    {
       ROS_ERROR_STREAM("Dimension of command (" << msg->data.size() << ") does not match number of joints (" << n_joints_ << ")! Not executing!");
-      return; 
+      return;
     }
     commands_buffer_.writeFromNonRT(msg->data);
   }

--- a/effort_controllers/src/joint_group_position_controller.cpp
+++ b/effort_controllers/src/joint_group_position_controller.cpp
@@ -138,24 +138,12 @@ namespace effort_controllers
         // Compute position error
         if (joint_urdfs_[i]->type == urdf::Joint::REVOLUTE)
         {
-          if(joint_urdfs_[i]->limits->upper - joint_urdfs_[i]->limits->lower >= 2*M_PI)
-          {
-            angles::shortest_angular_distance_with_large_limits(
-              current_position,
-              command_position,
-              joint_urdfs_[i]->limits->lower,
-              joint_urdfs_[i]->limits->upper,
-              error);
-          }
-          else
-          {
-            angles::shortest_angular_distance_with_limits(
-              current_position,
-              command_position,
-              joint_urdfs_[i]->limits->lower,
-              joint_urdfs_[i]->limits->upper,
-              error);
-          }
+          angles::shortest_angular_distance_with_large_limits(
+            current_position,
+            command_position,
+            joint_urdfs_[i]->limits->lower,
+            joint_urdfs_[i]->limits->upper,
+            error);
         }
         else if (joint_urdfs_[i]->type == urdf::Joint::CONTINUOUS)
         {

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -181,24 +181,12 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   // Compute position error
   if (joint_urdf_->type == urdf::Joint::REVOLUTE)
   {
-    if(joint_urdf_->limits->upper - joint_urdf_->limits->lower >= 2*M_PI)
-    {
-      angles::shortest_angular_distance_with_large_limits(
-        current_position,
-        command_position,
-        joint_urdf_->limits->lower,
-        joint_urdf_->limits->upper,
-        error);
-    }
-    else
-    {
-      angles::shortest_angular_distance_with_limits(
-        current_position,
-        command_position,
-        joint_urdf_->limits->lower,
-        joint_urdf_->limits->upper,
-        error);
-    }
+    angles::shortest_angular_distance_with_large_limits(
+      current_position,
+      command_position,
+      joint_urdf_->limits->lower,
+      joint_urdf_->limits->upper,
+      error);
   }
   else if (joint_urdf_->type == urdf::Joint::CONTINUOUS)
   {

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -181,12 +181,24 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   // Compute position error
   if (joint_urdf_->type == urdf::Joint::REVOLUTE)
   {
-   angles::shortest_angular_distance_with_limits(
-      current_position,
-      command_position,
-      joint_urdf_->limits->lower,
-      joint_urdf_->limits->upper,
-      error);
+    if(joint_urdf_->limits->upper - joint_urdf_->limits->lower >= 2*M_PI)
+    {
+      angles::shortest_angular_distance_with_large_limits(
+        current_position,
+        command_position,
+        joint_urdf_->limits->lower,
+        joint_urdf_->limits->upper,
+        error);
+    }
+    else
+    {
+      angles::shortest_angular_distance_with_limits(
+        current_position,
+        command_position,
+        joint_urdf_->limits->lower,
+        joint_urdf_->limits->upper,
+        error);
+    }
   }
   else if (joint_urdf_->type == urdf::Joint::CONTINUOUS)
   {

--- a/effort_controllers/test/effort_position_controller.test
+++ b/effort_controllers/test/effort_position_controller.test
@@ -1,0 +1,9 @@
+<launch>
+  <!-- Start the simulated hardware -->
+  <include file="$(find effort_controllers)/test/simple_bot_hw.launch" />
+
+  <!-- Test the position controller -->
+  <test time-limit="50.0" test-name="effort_position_controller_test" pkg="effort_controllers" type="effort_position_controller_test">
+    <remap from="command" to="/position_controller/command"/>
+  </test>
+</launch>

--- a/effort_controllers/test/effort_position_controller.test
+++ b/effort_controllers/test/effort_position_controller.test
@@ -3,7 +3,7 @@
   <include file="$(find effort_controllers)/test/simple_bot_hw.launch" />
 
   <!-- Test the position controller -->
-  <test time-limit="50.0" test-name="effort_position_controller_test" pkg="effort_controllers" type="effort_position_controller_test">
+  <test time-limit="180.0" test-name="effort_position_controller_test" pkg="effort_controllers" type="effort_position_controller_test">
     <remap from="command" to="/position_controller/command"/>
   </test>
 </launch>

--- a/effort_controllers/test/effort_position_controller.test
+++ b/effort_controllers/test/effort_position_controller.test
@@ -3,7 +3,7 @@
   <include file="$(find effort_controllers)/test/simple_bot_hw.launch" />
 
   <!-- Test the position controller -->
-  <test time-limit="180.0" test-name="effort_position_controller_test" pkg="effort_controllers" type="effort_position_controller_test">
+  <test test-name="effort_position_controller_test" pkg="effort_controllers" type="effort_position_controller_test">
     <remap from="command" to="/position_controller/command"/>
   </test>
 </launch>

--- a/effort_controllers/test/simple_bot.xacro
+++ b/effort_controllers/test/simple_bot.xacro
@@ -16,7 +16,7 @@
     <child link="simple_bot"/>
     <axis xyz="0 0 1"/>
     <origin xyz="0 0 1"/>
-    <limit lower="-6.3" upper="6.3" effort="${1e6}" velocity="${1e4}"/>
+    <limit lower="-6.3" upper="6.3" effort="10" velocity="2"/>
   </joint>
 
   <transmission name="transimssion">

--- a/effort_controllers/test/simple_bot.xacro
+++ b/effort_controllers/test/simple_bot.xacro
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<robot name="simple_bot" xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <link name="world"/>
+
+  <link name="simple_bot">
+    <visual>
+      <geometry>
+        <box size="1 0.1 0.1"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <joint name="joint" type="revolute">
+    <parent link="world"/>
+    <child link="simple_bot"/>
+    <axis xyz="0 0 1"/>
+    <origin xyz="0 0 1"/>
+    <limit lower="-6.3" upper="6.3" effort="${1e6}" velocity="${1e4}"/>
+  </joint>
+
+  <transmission name="transimssion">
+    <type>transmission_interface/SimpleTransmission</type>
+    <joint name="joint">
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    </joint>
+    <actuator name="motor">
+      <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+      <mechanicalReduction>1</mechanicalReduction>
+    </actuator>
+  </transmission>
+
+</robot>

--- a/effort_controllers/test/simple_bot_controllers.yaml
+++ b/effort_controllers/test/simple_bot_controllers.yaml
@@ -5,4 +5,4 @@ joint_state_controller:
 position_controller:
   type: effort_controllers/JointPositionController
   joint: joint
-  pid: {p: 1.0, d: 2.05, i: 0.0}
+  pid: {p: 0.25, d: 1.0, i: 0.0}

--- a/effort_controllers/test/simple_bot_controllers.yaml
+++ b/effort_controllers/test/simple_bot_controllers.yaml
@@ -1,0 +1,8 @@
+joint_state_controller:
+    type: joint_state_controller/JointStateController
+    publish_rate: 50
+
+position_controller:
+  type: effort_controllers/JointPositionController
+  joint: joint
+  pid: {p: 1.0, d: 2.05, i: 0.0}

--- a/effort_controllers/test/simple_bot_goto_position.cpp
+++ b/effort_controllers/test/simple_bot_goto_position.cpp
@@ -1,0 +1,99 @@
+#include <ros/ros.h>
+#include <gtest/gtest.h>
+#include <std_msgs/Float64.h>
+#include <sensor_msgs/JointState.h>
+#include <controller_manager_msgs/LoadController.h>
+#include <controller_manager_msgs/UnloadController.h>
+#include <controller_manager_msgs/SwitchController.h>
+
+
+class SimpleBotFixture : public ::testing::Test {
+protected:
+  ros::Publisher pub;
+  ros::Subscriber sub;
+  ros::ServiceClient load, unload, start;
+  ros::NodeHandle nh;
+  double position;
+
+  int val;
+
+  void positionCB(const sensor_msgs::JointState& msg) {
+    position = msg.position[0];
+  }
+
+  bool waitToReachTarget(double target, double precision=5e-3) {
+    position = 1e3*precision + target; // make position != target
+    ros::Rate rate(20);
+    std_msgs::Float64 cmd;
+    cmd.data = target;
+
+    while(ros::ok()) {
+      pub.publish(cmd);
+      if(std::fabs(target-position) < precision)
+        return true;
+      rate.sleep();
+    }
+
+    return false;
+  }
+
+
+  void SetUp() override {
+    // setup
+    position = 0;
+    pub = nh.advertise<std_msgs::Float64>("position_controller/command", 1);
+    sub = nh.subscribe("joint_states", 1, &SimpleBotFixture::positionCB, this);
+    load = nh.serviceClient<controller_manager_msgs::LoadController>("controller_manager/load_controller");
+    unload = nh.serviceClient<controller_manager_msgs::UnloadController>("controller_manager/unload_controller");
+    start = nh.serviceClient<controller_manager_msgs::SwitchController>("controller_manager/switch_controller");
+  }
+};
+
+
+TEST_F(SimpleBotFixture, TestPosition) {
+  ros::Duration(1.0).sleep();
+
+  controller_manager_msgs::SwitchController switch_srv;
+  switch_srv.request.start_controllers.push_back("position_controller");
+  switch_srv.request.start_controllers.push_back("joint_state_controller");
+  switch_srv.request.strictness = switch_srv.request.STRICT;
+
+  for(const auto& controller : switch_srv.request.start_controllers) {
+    controller_manager_msgs::LoadController load_srv;
+    load_srv.request.name = controller;
+    ASSERT_TRUE(load.call(load_srv));
+    ASSERT_TRUE(load_srv.response.ok);
+  }
+
+  ASSERT_TRUE(start.call(switch_srv));
+  ASSERT_TRUE(switch_srv.response.ok);
+
+  ASSERT_TRUE(waitToReachTarget(1.0));
+  ASSERT_TRUE(waitToReachTarget(-1.0));
+  ASSERT_TRUE(waitToReachTarget(0.0));
+
+  switch_srv.request.stop_controllers = switch_srv.request.start_controllers;
+  switch_srv.request.start_controllers.clear();
+
+  ASSERT_TRUE(start.call(switch_srv));
+  ASSERT_TRUE(switch_srv.response.ok);
+
+  for(const auto& controller : switch_srv.request.stop_controllers) {
+    controller_manager_msgs::UnloadController unload_srv;
+    unload_srv.request.name = controller;
+    ASSERT_TRUE(unload.call(unload_srv));
+    ASSERT_TRUE(unload_srv.response.ok);
+  }
+}
+
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "dummy");
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  int ret = RUN_ALL_TESTS();
+  spinner.stop();
+  ros::shutdown();
+  return ret;
+}

--- a/effort_controllers/test/simple_bot_goto_position.cpp
+++ b/effort_controllers/test/simple_bot_goto_position.cpp
@@ -21,7 +21,7 @@ protected:
     position = msg.position[0];
   }
 
-  bool waitToReachTarget(double target, double precision=5e-3) {
+  bool waitToReachTarget(double target, double precision=1e-2) {
     position = 1e3*precision + target; // make position != target
     ros::Rate rate(20);
     std_msgs::Float64 cmd;

--- a/effort_controllers/test/simple_bot_goto_position.cpp
+++ b/effort_controllers/test/simple_bot_goto_position.cpp
@@ -1,7 +1,47 @@
-#include <ros/ros.h>
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  Copyright (c) 2012, hiDOF, Inc.
+ *  Copyright (c) 2020, Franco Fusco.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ Author: Franco Fusco
+*/
+
 #include <gtest/gtest.h>
-#include <std_msgs/Float64.h>
+#include <ros/ros.h>
 #include <sensor_msgs/JointState.h>
+#include <std_msgs/Float64.h>
 
 
 class SimpleBotFixture : public ::testing::Test {
@@ -11,15 +51,13 @@ protected:
   ros::NodeHandle nh;
   double position;
 
-  int val;
-
   void positionCB(const sensor_msgs::JointState& msg) {
     position = msg.position[0];
   }
 
-  bool waitToReachTarget(double target, std::string& err, double precision=5e-2, double timeout=20) {
+  bool waitToReachTarget(double target, std::string& err, double precision=5e-2, double timeout=20.0) {
     position = 1e3*precision + target; // make position != target
-    ros::Rate rate(20);
+    ros::Rate rate(20.0);
     std_msgs::Float64 cmd;
     cmd.data = target;
     ros::Time start = ros::Time::now();
@@ -42,7 +80,7 @@ protected:
 
   void SetUp() override {
     // setup
-    position = 0;
+    position = 0.0;
     pub = nh.advertise<std_msgs::Float64>("position_controller/command", 1);
     sub = nh.subscribe("joint_states", 1, &SimpleBotFixture::positionCB, this);
   }

--- a/effort_controllers/test/simple_bot_goto_position.cpp
+++ b/effort_controllers/test/simple_bot_goto_position.cpp
@@ -2,16 +2,12 @@
 #include <gtest/gtest.h>
 #include <std_msgs/Float64.h>
 #include <sensor_msgs/JointState.h>
-#include <controller_manager_msgs/LoadController.h>
-#include <controller_manager_msgs/UnloadController.h>
-#include <controller_manager_msgs/SwitchController.h>
 
 
 class SimpleBotFixture : public ::testing::Test {
 protected:
   ros::Publisher pub;
   ros::Subscriber sub;
-  ros::ServiceClient load, unload, start;
   ros::NodeHandle nh;
   double position;
 
@@ -49,52 +45,16 @@ protected:
     position = 0;
     pub = nh.advertise<std_msgs::Float64>("position_controller/command", 1);
     sub = nh.subscribe("joint_states", 1, &SimpleBotFixture::positionCB, this);
-    load = nh.serviceClient<controller_manager_msgs::LoadController>("controller_manager/load_controller");
-    unload = nh.serviceClient<controller_manager_msgs::UnloadController>("controller_manager/unload_controller");
-    start = nh.serviceClient<controller_manager_msgs::SwitchController>("controller_manager/switch_controller");
   }
 };
 
 
 TEST_F(SimpleBotFixture, TestPosition) {
   ros::Duration(1.0).sleep();
-
-  ASSERT_TRUE(load.waitForExistence(ros::Duration(20)));
-  ASSERT_TRUE(unload.waitForExistence(ros::Duration(20)));
-  ASSERT_TRUE(start.waitForExistence(ros::Duration(20)));
-
-  controller_manager_msgs::SwitchController switch_srv;
-  switch_srv.request.start_controllers.push_back("position_controller");
-  switch_srv.request.start_controllers.push_back("joint_state_controller");
-  switch_srv.request.strictness = switch_srv.request.STRICT;
-
-  for(const auto& controller : switch_srv.request.start_controllers) {
-    controller_manager_msgs::LoadController load_srv;
-    load_srv.request.name = controller;
-    ASSERT_TRUE(load.call(load_srv));
-    ASSERT_TRUE(load_srv.response.ok);
-  }
-
-  ASSERT_TRUE(start.call(switch_srv));
-  ASSERT_TRUE(switch_srv.response.ok);
-
   std::string err;
   ASSERT_TRUE(waitToReachTarget(1.0, err)) << err;
   ASSERT_TRUE(waitToReachTarget(-1.0, err)) << err;
   ASSERT_TRUE(waitToReachTarget(0.0, err)) << err;
-
-  switch_srv.request.stop_controllers = switch_srv.request.start_controllers;
-  switch_srv.request.start_controllers.clear();
-
-  ASSERT_TRUE(start.call(switch_srv));
-  ASSERT_TRUE(switch_srv.response.ok);
-
-  for(const auto& controller : switch_srv.request.stop_controllers) {
-    controller_manager_msgs::UnloadController unload_srv;
-    unload_srv.request.name = controller;
-    ASSERT_TRUE(unload.call(unload_srv));
-    ASSERT_TRUE(unload_srv.response.ok);
-  }
 }
 
 

--- a/effort_controllers/test/simple_bot_goto_position.cpp
+++ b/effort_controllers/test/simple_bot_goto_position.cpp
@@ -1,8 +1,6 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2008, Willow Garage, Inc.
- *  Copyright (c) 2012, hiDOF, Inc.
  *  Copyright (c) 2020, Franco Fusco.
  *  All rights reserved.
  *
@@ -34,9 +32,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/*
- Author: Franco Fusco
-*/
 
 #include <gtest/gtest.h>
 #include <ros/ros.h>
@@ -90,9 +85,9 @@ protected:
 TEST_F(SimpleBotFixture, TestPosition) {
   ros::Duration(1.0).sleep();
   std::string err;
-  ASSERT_TRUE(waitToReachTarget(1.0, err)) << err;
-  ASSERT_TRUE(waitToReachTarget(-1.0, err)) << err;
-  ASSERT_TRUE(waitToReachTarget(0.0, err)) << err;
+  EXPECT_TRUE(waitToReachTarget(1.0, err)) << err;
+  EXPECT_TRUE(waitToReachTarget(-1.0, err)) << err;
+  EXPECT_TRUE(waitToReachTarget(0.0, err)) << err;
 }
 
 

--- a/effort_controllers/test/simple_bot_hw.cpp
+++ b/effort_controllers/test/simple_bot_hw.cpp
@@ -48,6 +48,7 @@ public:
   : pos_(0)
   , vel_(0)
   , eff_(0)
+  , max_eff_(10)
   {
     // joint state interface
     hardware_interface::JointStateHandle state_handle("joint", &pos_, &vel_, &eff_);
@@ -68,12 +69,17 @@ public:
   void write() {
     // store current command
     eff_ = cmd_;
+    if(std::fabs(eff_) > max_eff_) {
+      ROS_WARN("Large effort command received: %f; cutting down to % f", eff_, max_eff_);
+      eff_ = eff_ > 0 ? max_eff_ : -max_eff_;
+    }
   }
 
 private:
   hardware_interface::JointStateInterface state_interface_;
   hardware_interface::EffortJointInterface effort_interface_;
   double cmd_, pos_, vel_, eff_;
+  double max_eff_;
 };
 
 

--- a/effort_controllers/test/simple_bot_hw.cpp
+++ b/effort_controllers/test/simple_bot_hw.cpp
@@ -1,36 +1,51 @@
-///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2013, PAL Robotics S.L.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//   * Redistributions of source code must retain the above copyright notice,
-//     this list of conditions and the following disclaimer.
-//   * Redistributions in binary form must reproduce the above copyright
-//     notice, this list of conditions and the following disclaimer in the
-//     documentation and/or other materials provided with the distribution.
-//   * Neither the name of PAL Robotics, Inc. nor the names of its
-//     contributors may be used to endorse or promote products derived from
-//     this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-// POSSIBILITY OF SUCH DAMAGE.
-//////////////////////////////////////////////////////////////////////////////
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2008, Willow Garage, Inc.
+ *  Copyright (c) 2012, hiDOF, Inc.
+ *  Copyright (c) 2020, Franco Fusco.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Willow Garage nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/*
+ Author: Franco Fusco
+*/
+
+#include <chrono>
+#include <cmath>
+#include <thread>
 
 // ROS
-#include <chrono>
-#include <thread>
 #include <ros/ros.h>
-#include <std_msgs/Float64.h>
 #include <rosgraph_msgs/Clock.h>
+#include <std_msgs/Float64.h>
 
 // ros_control
 #include <controller_manager/controller_manager.h>
@@ -45,10 +60,10 @@ public:
   static constexpr double period = 0.01;
 
   SimpleBot()
-  : pos_(0)
-  , vel_(0)
-  , eff_(0)
-  , max_eff_(10)
+  : pos_(0.0)
+  , vel_(0.0)
+  , eff_(0.0)
+  , max_eff_(10.0)
   {
     // joint state interface
     hardware_interface::JointStateHandle state_handle("joint", &pos_, &vel_, &eff_);
@@ -62,7 +77,7 @@ public:
 
   void read() {
     // update current state
-    pos_ += period * vel_ + 0.5*std::pow(period, 2.) * eff_;
+    pos_ += period * vel_ + 0.5*std::pow(period, 2.0) * eff_;
     vel_ += period * eff_;
   }
 
@@ -71,7 +86,7 @@ public:
     eff_ = cmd_;
     if(std::fabs(eff_) > max_eff_) {
       ROS_WARN("Large effort command received: %f; cutting down to % f", eff_, max_eff_);
-      eff_ = eff_ > 0 ? max_eff_ : -max_eff_;
+      eff_ = eff_ > 0.0 ? max_eff_ : -max_eff_;
     }
   }
 
@@ -94,9 +109,9 @@ int main(int argc, char **argv)
   ros::AsyncSpinner spinner(2);
   spinner.start();
 
-  ros::Rate rate(1./bot.period);
+  ros::Rate rate(1.0/bot.period);
   ros::Duration period(bot.period);
-  double sim_time = 0;
+  double sim_time = 0.0;
 
   // main "simulation"
   while(ros::ok()) {

--- a/effort_controllers/test/simple_bot_hw.cpp
+++ b/effort_controllers/test/simple_bot_hw.cpp
@@ -1,0 +1,100 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2013, PAL Robotics S.L.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of PAL Robotics, Inc. nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+// ROS
+#include <ros/ros.h>
+#include <std_msgs/Float64.h>
+
+// ros_control
+#include <controller_manager/controller_manager.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <hardware_interface/joint_state_interface.h>
+#include <hardware_interface/robot_hw.h>
+#include <realtime_tools/realtime_buffer.h>
+
+class SimpleBot : public hardware_interface::RobotHW
+{
+public:
+  static constexpr double period = 0.001;
+
+  SimpleBot()
+  : pos_(0)
+  , vel_(0)
+  , eff_(0)
+  {
+    // joint state interface
+    hardware_interface::JointStateHandle state_handle("joint", &pos_, &vel_, &eff_);
+    state_interface_.registerHandle(state_handle);
+    registerInterface(&state_interface_);
+    // effort interface
+    hardware_interface::JointHandle effort_handle(state_interface_.getHandle("joint"), &cmd_);
+    effort_interface_.registerHandle(effort_handle);
+    registerInterface(&effort_interface_);
+  }
+
+  void read() {
+    // update current state
+    pos_ += period * vel_ + 0.5*std::pow(period, 2.) * eff_;
+    vel_ += period * eff_;
+  }
+
+  void write() {
+    // store current command
+    eff_ = cmd_;
+  }
+
+private:
+  hardware_interface::JointStateInterface state_interface_;
+  hardware_interface::EffortJointInterface effort_interface_;
+  double cmd_, pos_, vel_, eff_;
+};
+
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "simple_bot_hw");
+  ros::NodeHandle nh;
+  SimpleBot bot;
+  controller_manager::ControllerManager cm(&bot, nh);
+  ros::AsyncSpinner spinner(2);
+  spinner.start();
+
+  ros::Rate rate(1./bot.period);
+  ros::Duration period(bot.period);
+
+  // main "simulation"
+  while(ros::ok()) {
+    bot.read();
+    cm.update(ros::Time::now(), period);
+    bot.write();
+    rate.sleep();
+  }
+
+  spinner.stop();
+
+  return 0;
+}

--- a/effort_controllers/test/simple_bot_hw.cpp
+++ b/effort_controllers/test/simple_bot_hw.cpp
@@ -1,8 +1,6 @@
 /*********************************************************************
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2008, Willow Garage, Inc.
- *  Copyright (c) 2012, hiDOF, Inc.
  *  Copyright (c) 2020, Franco Fusco.
  *  All rights reserved.
  *
@@ -34,9 +32,6 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/*
- Author: Franco Fusco
-*/
 
 #include <chrono>
 #include <cmath>

--- a/effort_controllers/test/simple_bot_hw.cpp
+++ b/effort_controllers/test/simple_bot_hw.cpp
@@ -64,6 +64,7 @@ public:
   , vel_(0.0)
   , eff_(0.0)
   , max_eff_(10.0)
+  , cmd_(0.0)
   {
     // joint state interface
     hardware_interface::JointStateHandle state_handle("joint", &pos_, &vel_, &eff_);

--- a/effort_controllers/test/simple_bot_hw.cpp
+++ b/effort_controllers/test/simple_bot_hw.cpp
@@ -39,7 +39,7 @@
 class SimpleBot : public hardware_interface::RobotHW
 {
 public:
-  static constexpr double period = 0.001;
+  static constexpr double period = 0.01;
 
   SimpleBot()
   : pos_(0)

--- a/effort_controllers/test/simple_bot_hw.launch
+++ b/effort_controllers/test/simple_bot_hw.launch
@@ -11,6 +11,8 @@
   <!-- Robot hardware -->
   <node name="simple_bot_hw" pkg="effort_controllers" type="simple_bot_hw"/>
 
+  <!-- Start controllers -->
+  <node name="controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="position_controller joint_state_controller" />
   <!-- Just to see the robot in RViz for "visual debugging" -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 </launch>

--- a/effort_controllers/test/simple_bot_hw.launch
+++ b/effort_controllers/test/simple_bot_hw.launch
@@ -1,0 +1,16 @@
+<launch>
+  <!-- URDF -->
+  <param name="robot_description" command="$(find xacro)/xacro '$(find effort_controllers)/test/simple_bot.xacro'"/>
+
+  <!-- ROS controllers -->
+  <rosparam command="load" file="$(find effort_controllers)/test/simple_bot_controllers.yaml" />
+
+  <!-- Robot hardware -->
+  <node name="simple_bot_hw" pkg="effort_controllers" type="simple_bot_hw"/>
+
+  <!-- Start robot controllers -->
+  <!-- <node name="controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="position_controller joint_state_controller" /> -->
+
+  <!-- Just to see the robot in RViz for "visual debugging" -->
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+</launch>

--- a/effort_controllers/test/simple_bot_hw.launch
+++ b/effort_controllers/test/simple_bot_hw.launch
@@ -8,9 +8,6 @@
   <!-- Robot hardware -->
   <node name="simple_bot_hw" pkg="effort_controllers" type="simple_bot_hw"/>
 
-  <!-- Start robot controllers -->
-  <!-- <node name="controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="position_controller joint_state_controller" /> -->
-
   <!-- Just to see the robot in RViz for "visual debugging" -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 </launch>

--- a/effort_controllers/test/simple_bot_hw.launch
+++ b/effort_controllers/test/simple_bot_hw.launch
@@ -13,6 +13,7 @@
 
   <!-- Start controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" output="screen" args="position_controller joint_state_controller" />
+
   <!-- Just to see the robot in RViz for "visual debugging" -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 </launch>

--- a/effort_controllers/test/simple_bot_hw.launch
+++ b/effort_controllers/test/simple_bot_hw.launch
@@ -1,4 +1,7 @@
 <launch>
+  <!-- Make sure simulated time is used -->
+  <param name="use_sim_time" value="true"/>
+
   <!-- URDF -->
   <param name="robot_description" command="$(find xacro)/xacro '$(find effort_controllers)/test/simple_bot.xacro'"/>
 

--- a/velocity_controllers/src/joint_position_controller.cpp
+++ b/velocity_controllers/src/joint_position_controller.cpp
@@ -182,24 +182,12 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   // Compute position error
   if (joint_urdf_->type == urdf::Joint::REVOLUTE)
   {
-    if(joint_urdf_->limits->upper - joint_urdf_->limits->lower >= 2*M_PI)
-    {
-      angles::shortest_angular_distance_with_large_limits(
-        current_position,
-        command_position,
-        joint_urdf_->limits->lower,
-        joint_urdf_->limits->upper,
-        error);
-    }
-    else
-    {
-      angles::shortest_angular_distance_with_limits(
-        current_position,
-        command_position,
-        joint_urdf_->limits->lower,
-        joint_urdf_->limits->upper,
-        error);
-    }
+    angles::shortest_angular_distance_with_large_limits(
+      current_position,
+      command_position,
+      joint_urdf_->limits->lower,
+      joint_urdf_->limits->upper,
+      error);
   }
   else if (joint_urdf_->type == urdf::Joint::CONTINUOUS)
   {

--- a/velocity_controllers/src/joint_position_controller.cpp
+++ b/velocity_controllers/src/joint_position_controller.cpp
@@ -182,12 +182,24 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   // Compute position error
   if (joint_urdf_->type == urdf::Joint::REVOLUTE)
   {
-   angles::shortest_angular_distance_with_limits(
-      current_position,
-      command_position,
-      joint_urdf_->limits->lower,
-      joint_urdf_->limits->upper,
-      error);
+    if(joint_urdf_->limits->upper - joint_urdf_->limits->lower >= 2*M_PI)
+    {
+      angles::shortest_angular_distance_with_large_limits(
+        current_position,
+        command_position,
+        joint_urdf_->limits->lower,
+        joint_urdf_->limits->upper,
+        error);
+    }
+    else
+    {
+      angles::shortest_angular_distance_with_limits(
+        current_position,
+        command_position,
+        joint_urdf_->limits->lower,
+        joint_urdf_->limits->upper,
+        error);
+    }
   }
   else if (joint_urdf_->type == urdf::Joint::CONTINUOUS)
   {


### PR DESCRIPTION
As found out by others as well, there is a small issue in some controllers when a revolute joints has "large" limits, see eg #365 

The problem is that some position controllers call the function `angles::shortest_angular_distance_with_limits`, which assumes that the total allowed range of rotation is lower than `2*PI`. Therefore, if one has as limits such as `[-PI-eps, PI+eps)`, `angles` will assume that the valid range has size `2*eps` instead of `2*(PI+eps)`. To allow dealing with larger rotations, the PR ros/angles#16 introduced the function `shortest_angular_distance_with_large_limits`.

I updated three controllers to use such function in case `upper_limit-lower_limit` is greater than or equal to `2*PI`. I tested it and the oscillations that could be experienced before now disappear.