### PR TITLE
Add code_coverage target to CMakeLists.txt

### DIFF
--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -42,6 +42,11 @@ catkin_package(
 
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
+if(CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
+  find_package(code_coverage REQUIRED)
+  APPEND_COVERAGE_COMPILER_FLAGS()
+endif()
+
 add_library(${PROJECT_NAME} src/joint_trajectory_controller.cpp
                             include/joint_trajectory_controller/hardware_interface_adapter.h
                             include/joint_trajectory_controller/init_joint_trajectory.h
@@ -120,6 +125,11 @@ if(CATKIN_ENABLE_TESTING)
                     test/joint_trajectory_controller_wrapping.test
                     test/joint_trajectory_controller_wrapping_test.cpp)
   target_link_libraries(joint_trajectory_controller_wrapping_test ${catkin_LIBRARIES})
+
+  if(ENABLE_COVERAGE_TESTING)
+    set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
+    add_code_coverage(NAME ${PROJECT_NAME}_coverage)
+  endif()
 
 endif()
 

--- a/joint_trajectory_controller/package.xml
+++ b/joint_trajectory_controller/package.xml
@@ -34,6 +34,7 @@
   <test_depend>rostest</test_depend>
   <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
+  <test_depend>code_coverage</test_depend>
 
   <export>
     <controller_interface plugin="${prefix}/ros_control_plugins.xml"/>


### PR DESCRIPTION
Add option `ENABLE_COVERAGE_TESTING` for running coverage analysis of package joint_trajectory_controller. See https://github.com/mikeferguson/code_coverage