### PR TITLE
Check for nan cmd_vel

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -535,6 +535,12 @@ namespace diff_drive_controller{
         return;
       }
 
+      if(!std::isfinite(command.angular.z) || !std::isfinite(command.angular.x))
+      {
+        ROS_WARN_THROTTLE(1.0, "Received NaN in velocity command. Ignoring.");
+        return;
+      }
+
       command_struct_.ang   = command.angular.z;
       command_struct_.lin   = command.linear.x;
       command_struct_.stamp = ros::Time::now();

--- a/diff_drive_controller/test/diff_drive_controller_nan.test
+++ b/diff_drive_controller/test/diff_drive_controller_nan.test
@@ -2,6 +2,11 @@
   <!-- Load common test stuff -->
   <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
 
+  <rosparam>
+    diffbot_controller:
+      publish_cmd: True
+  </rosparam>
+
   <!-- Controller test -->
   <test test-name="diff_drive_nan_test"
         pkg="diff_drive_controller"
@@ -9,5 +14,6 @@
         time-limit="80.0">
     <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
     <remap from="odom" to="diffbot_controller/odom" />
+    <remap from="cmd_vel_out" to="diffbot_controller/cmd_vel_out" />
   </test>
 </launch>

--- a/diff_drive_controller/test/diff_drive_nan_test.cpp
+++ b/diff_drive_controller/test/diff_drive_nan_test.cpp
@@ -78,6 +78,42 @@ TEST_F(DiffDriveControllerTest, testNaN)
   EXPECT_NE(std::isnan(odom.pose.pose.orientation.w), true);
 }
 
+TEST_F(DiffDriveControllerTest, testNaNCmd)
+{
+  // wait for ROS
+  while(!isControllerAlive())
+  {
+    ros::Duration(0.1).sleep();
+  }
+  // zero everything before test
+  geometry_msgs::Twist cmd_vel;
+  cmd_vel.linear.x = 0.0;
+  cmd_vel.angular.z = 0.0;
+  publish(cmd_vel);
+  ros::Duration(0.1).sleep();
+
+  // send NaN
+  for(int i = 0; i < 10; ++i)
+  {
+    geometry_msgs::Twist cmd_vel;
+    cmd_vel.linear.x = NAN;
+    cmd_vel.angular.z = NAN;
+    publish(cmd_vel);
+    geometry_msgs::TwistStamped odom_msg = getLastCmdVelOut();
+    EXPECT_EQ(std::isnan(odom_msg.twist.linear.x), false);
+    EXPECT_EQ(std::isnan(odom_msg.twist.angular.z), false);
+    ros::Duration(0.1).sleep();
+  }
+
+  nav_msgs::Odometry odom = getLastOdom();
+  EXPECT_EQ(odom.twist.twist.linear.x, 0.0);
+  EXPECT_EQ(odom.pose.pose.position.x, 0.0);
+  EXPECT_EQ(odom.pose.pose.position.y, 0.0);
+
+  geometry_msgs::TwistStamped odom_msg = getLastCmdVelOut();
+  EXPECT_EQ(fabs(odom_msg.twist.linear.x), 0);
+}
+
 int main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Ignore `NaN` velocity commands sent to the differential drive controller.
cc: @bmagyar for review

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>