### PR TITLE
[diff_drive_controller] swap implementation of read and write methods of Diffbot class

### DIFF
--- a/diff_drive_controller/test/diffbot.h
+++ b/diff_drive_controller/test/diffbot.h
@@ -82,18 +82,7 @@ public:
 
   void read()
   {
-    std::ostringstream os;
-    for (unsigned int i = 0; i < NUM_JOINTS - 1; ++i)
-    {
-      os << cmd_[i] << ", ";
-    }
-    os << cmd_[NUM_JOINTS - 1];
-
-    ROS_INFO_STREAM("Commands for joints: " << os.str());
-  }
-
-  void write()
-  {
+    // Read the joint state of the robot into the hardware interface
     if (running_)
     {
       for (unsigned int i = 0; i < NUM_JOINTS; ++i)
@@ -110,6 +99,19 @@ public:
       std::fill_n(pos_, NUM_JOINTS, std::numeric_limits<double>::quiet_NaN());
       std::fill_n(vel_, NUM_JOINTS, std::numeric_limits<double>::quiet_NaN());
     }
+  }
+
+  void write()
+  {
+    // Write the commands to the joints
+    std::ostringstream os;
+    for (unsigned int i = 0; i < NUM_JOINTS - 1; ++i)
+    {
+      os << cmd_[i] << ", ";
+    }
+    os << cmd_[NUM_JOINTS - 1];
+
+    ROS_INFO_STREAM("Commands for joints: " << os.str());
   }
 
   bool start_callback(std_srvs::Empty::Request& /*req*/, std_srvs::Empty::Response& /*res*/)


### PR DESCRIPTION
This PR was discussed with @matthew-reynolds in #462 and swaps the implementations of the `read()` and `write()` methods of the `Diffbot` class in the `diff_drive_controller` package.

I've run all the tests for `diff_drive_controller` successfully. 

If this is PR gets accepted I can start looking at the other mentioned tests in #462. 