### PR TITLE
Allow position control limits outside [-pi,pi]

### DIFF
--- a/effort_controllers/src/joint_group_position_controller.cpp
+++ b/effort_controllers/src/joint_group_position_controller.cpp
@@ -138,7 +138,7 @@ namespace effort_controllers
         // Compute position error
         if (joint_urdfs_[i]->type == urdf::Joint::REVOLUTE)
         {
-         angles::shortest_angular_distance_with_limits(
+          angles::shortest_angular_distance_with_large_limits(
             current_position,
             command_position,
             joint_urdfs_[i]->limits->lower,

--- a/effort_controllers/src/joint_position_controller.cpp
+++ b/effort_controllers/src/joint_position_controller.cpp
@@ -181,7 +181,7 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   // Compute position error
   if (joint_urdf_->type == urdf::Joint::REVOLUTE)
   {
-   angles::shortest_angular_distance_with_limits(
+    angles::shortest_angular_distance_with_large_limits(
       current_position,
       command_position,
       joint_urdf_->limits->lower,

--- a/velocity_controllers/src/joint_position_controller.cpp
+++ b/velocity_controllers/src/joint_position_controller.cpp
@@ -182,7 +182,7 @@ void JointPositionController::update(const ros::Time& time, const ros::Duration&
   // Compute position error
   if (joint_urdf_->type == urdf::Joint::REVOLUTE)
   {
-   angles::shortest_angular_distance_with_limits(
+    angles::shortest_angular_distance_with_large_limits(
       current_position,
       command_position,
       joint_urdf_->limits->lower,


### PR DESCRIPTION
Several joint position controllers use the [angles::shortest_angular_distance_with_limits](http://docs.ros.org/melodic/api/angles/html/namespaceangles.html#a4436fe67ae0c9df020f6779101bbefab) function for `REVOLUTE` joints to compute the position error, but this function only supports joint limits within the interval [-pi, pi].

The [angles::shortest_angular_distance_with_large_limits](http://docs.ros.org/melodic/api/angles/html/namespaceangles.html#a0a260194cd877fe061195116274f1d85) function supports limits outside the interval [-pi, pi], which I think is more suitable for this computation. A difference from the other API is that the lower limit is required to be smaller than the upper limit.

Closes #261.