### PR TITLE
swap implementations of read and write methods

### DIFF
--- a/ackermann_steering_controller/test/common/include/ackermann_steering_bot.h
+++ b/ackermann_steering_controller/test/common/include/ackermann_steering_bot.h
@@ -77,37 +77,7 @@ public:
 
   void read()
   {
-    std::ostringstream os;
-    // directly get from controller
-    os << rear_wheel_jnt_vel_cmd_ << ", ";
-    os << front_steer_jnt_pos_cmd_ << ", ";
-
-    // convert to each joint velocity
-    //-- differential drive
-    for (unsigned int i = 0; i < virtual_rear_wheel_jnt_vel_cmd_.size(); i++)
-    {
-      virtual_rear_wheel_jnt_vel_cmd_[i] = rear_wheel_jnt_vel_cmd_;
-      os << virtual_rear_wheel_jnt_vel_cmd_[i] << ", ";
-    }
-
-    //-- ackerman link
-    const double h = wheel_separation_h_;
-    const double w = wheel_separation_w_;
-    virtual_front_steer_jnt_pos_cmd_[INDEX_RIGHT] = atan2(2*h*tan(front_steer_jnt_pos_cmd_), 2*h + w/2.0*tan(front_steer_jnt_pos_cmd_));
-    virtual_front_steer_jnt_pos_cmd_[INDEX_LEFT] = atan2(2*h*tan(front_steer_jnt_pos_cmd_), 2*h - w/2.0*tan(front_steer_jnt_pos_cmd_));
-
-    for (unsigned int i = 0; i < virtual_front_steer_jnt_pos_cmd_.size(); i++)
-    {
-      os << virtual_front_steer_jnt_pos_cmd_[i] << ", ";
-    }
-
-    if (rear_wheel_jnt_vel_cmd_ != 0.0 || front_steer_jnt_pos_cmd_ != 0.0)
-      ROS_INFO_STREAM("Commands for joints: " << os.str());
-
-  }
-
-  void write()
-  {
+    // Read the joint state of the robot into the hardware interface
     std::ostringstream os;
     if (running_)
     {
@@ -177,6 +147,39 @@ public:
       }
     }
     ROS_INFO_STREAM("running_ = " << running_ << ". commands are " << os.str());
+  }
+
+  void write()
+  {
+    // Write the commands to the joints
+    std::ostringstream os;
+    // directly get from controller
+    os << rear_wheel_jnt_vel_cmd_ << ", ";
+    os << front_steer_jnt_pos_cmd_ << ", ";
+
+    // convert to each joint velocity
+    //-- differential drive
+    for (unsigned int i = 0; i < virtual_rear_wheel_jnt_vel_cmd_.size(); i++)
+    {
+      virtual_rear_wheel_jnt_vel_cmd_[i] = rear_wheel_jnt_vel_cmd_;
+      os << virtual_rear_wheel_jnt_vel_cmd_[i] << ", ";
+    }
+
+    //-- ackerman link
+    const double h = wheel_separation_h_;
+    const double w = wheel_separation_w_;
+    virtual_front_steer_jnt_pos_cmd_[INDEX_RIGHT] = atan2(2*h*tan(front_steer_jnt_pos_cmd_), 2*h + w/2.0*tan(front_steer_jnt_pos_cmd_));
+    virtual_front_steer_jnt_pos_cmd_[INDEX_LEFT] = atan2(2*h*tan(front_steer_jnt_pos_cmd_), 2*h - w/2.0*tan(front_steer_jnt_pos_cmd_));
+
+    for (unsigned int i = 0; i < virtual_front_steer_jnt_pos_cmd_.size(); i++)
+    {
+      os << virtual_front_steer_jnt_pos_cmd_[i] << ", ";
+    }
+
+    if (rear_wheel_jnt_vel_cmd_ != 0.0 || front_steer_jnt_pos_cmd_ != 0.0)
+    {
+      ROS_INFO_STREAM("Commands for joints: " << os.str());
+    }
   }
 
   bool startCallback(std_srvs::Empty::Request& /*req*/, std_srvs::Empty::Response& /*res*/)

--- a/four_wheel_steering_controller/test/src/four_wheel_steering.h
+++ b/four_wheel_steering_controller/test/src/four_wheel_steering.h
@@ -61,26 +61,7 @@ public:
 
   void read()
   {
-    std::ostringstream os;
-    for (unsigned int i = 0; i < 3; ++i)
-    {
-      os << joints_[i].velocity_command << ", ";
-    }
-    os << joints_[3].velocity_command;
-
-    ROS_DEBUG_STREAM("Commands for joints: " << os.str());
-
-    os.str("");
-    for (unsigned int i = 0; i < 3; ++i)
-    {
-      os << steering_joints_[i].position_command << ", ";
-    }
-    os << steering_joints_[3].position_command;
-    ROS_DEBUG_STREAM("Commands for steering joints: " << os.str());
-  }
-
-  void write()
-  {
+    // Read the joint state of the robot into the hardware interface
     if (running_)
     {
       for (unsigned int i = 0; i < 4; ++i)
@@ -109,6 +90,28 @@ public:
         steering_joints_[i].velocity = std::numeric_limits<double>::quiet_NaN();
       }
     }
+  }
+
+  void write()
+  {
+    // Write the commands to the joints
+    std::ostringstream os;
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      os << joints_[i].velocity_command << ", ";
+    }
+    os << joints_[3].velocity_command;
+
+    ROS_DEBUG_STREAM("Commands for joints: " << os.str());
+
+    os.str("");
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+      os << steering_joints_[i].position_command << ", ";
+    }
+    os << steering_joints_[3].position_command;
+    ROS_DEBUG_STREAM("Commands for steering joints: " << os.str());
+
   }
 
   bool start_callback(std_srvs::Empty::Request& /*req*/, std_srvs::Empty::Response& /*res*/)


### PR DESCRIPTION
The discussion for this PR is in #462 and it is similar to #474 (swap `read` and `write` methods of DiffBot). 

With this PR [`ackermann_steering_bot.h`](https://github.com/ros-controls/ros_controllers/blob/62270677a23a0812c82f73d36328fb90a739c409/ackermann_steering_controller/test/common/include/ackermann_steering_bot.h#L78) and [`four_wheel_steering.h`](https://github.com/ros-controls/ros_controllers/blob/62270677a23a0812c82f73d36328fb90a739c409/four_wheel_steering_controller/test/src/four_wheel_steering.h#L62)
follow the intended use of [hardware_interface::RobotHW](https://github.com/ros-controls/ros_control/blob/melodic-devel/hardware_interface/include/hardware_interface/robot_hw.h), see its documentation for details and [this related PR](https://github.com/ros-controls/ros_control/pull/433).