### PR TITLE
Fix warning dynamic_reconfigure

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -234,8 +234,8 @@ namespace diff_drive_controller{
 
     /// Dynamic Reconfigure server
     typedef dynamic_reconfigure::Server<DiffDriveControllerConfig> ReconfigureServer;
-
     std::shared_ptr<ReconfigureServer> dyn_reconf_server_;
+    boost::recursive_mutex dyn_reconf_server_mutex_;
 
   private:
     /**

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -374,8 +374,13 @@ namespace diff_drive_controller{
     config.publish_rate = publish_rate;
     config.enable_odom_tf = enable_odom_tf_;
 
-    dyn_reconf_server_ = std::make_shared<ReconfigureServer>(controller_nh);
+    dyn_reconf_server_ = std::make_shared<ReconfigureServer>(dyn_reconf_server_mutex_, controller_nh);
+
+    // Update parameters
+    dyn_reconf_server_mutex_.lock();
     dyn_reconf_server_->updateConfig(config);
+    dyn_reconf_server_mutex_.unlock();
+
     dyn_reconf_server_->setCallback(boost::bind(&DiffDriveController::reconfCallback, this, _1, _2));
 
     return true;


### PR DESCRIPTION
Hi all,

I was working on my package when I approach this warning on my screen 
![image](https://user-images.githubusercontent.com/4551246/78597897-36c2c780-7846-11ea-872c-b38e86e3c176.png)

> [ WARN] [1586198292.260228386]: updateConfig() called on a dynamic_reconfigure::Server that provides its own mutex. This can lead to deadlocks if updateConfig() is called during an update. Providing a mutex to the constructor is highly recommended in this case. Please forward this message to the node author.

This pull-request fix the initialisation dynamic_reconfigure and now this warning is not show anymore.

PS: This pull-request should fix this answer https://answers.ros.org/question/310267/updateconfig-called-on-a-dynamic_reconfigureserver-that-provides-its-own-mutex/