### PR TITLE
Modernize xacro

### DIFF
--- a/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_fail_test/ackermann_steering_controller_radius_param_fail.test
+++ b/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_fail_test/ackermann_steering_controller_radius_param_fail.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro'" />
   <!-- Don't provide the radius parameter, so the controller should break -->
   <!-- <param name="diffbot_controller/wheel_radius" value="0.11"/> -->
 

--- a/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_test/ackermann_steering_controller_radius_param.test
+++ b/ackermann_steering_controller/test/ackermann_steering_controller_radius_param_test/ackermann_steering_controller_radius_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="ackermann_steering_bot_controller/wheel_radius" value="0.11"/>
 

--- a/ackermann_steering_controller/test/ackermann_steering_controller_separation_param_test/ackermann_steering_controller_separation_param.test
+++ b/ackermann_steering_controller/test/ackermann_steering_controller_separation_param_test/ackermann_steering_controller_separation_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with spere urdf -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="ackermann_steering_bot_controller/wheel_radius" value="0.11"/>
   <!-- Provide the wheel separation -->

--- a/ackermann_steering_controller/test/common/launch/ackermann_steering_common.launch
+++ b/ackermann_steering_controller/test/common/launch/ackermann_steering_common.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- Load ackermann_steering_bot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro'" />
 
   <!-- Load controller config -->
   <rosparam command="load" file="$(find ackermann_steering_controller)/test/common/config/ackermann_steering_bot_controllers.yaml" />

--- a/ackermann_steering_controller/test/common/launch/view_ackermann_steering_bot.launch
+++ b/ackermann_steering_controller/test/common/launch/view_ackermann_steering_bot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro' --inorder" />
+      command="$(find xacro)/xacro '$(find ackermann_steering_controller)/test/common/urdf/ackermann_steering_bot.xacro'" />
 
   <!-- Load controller config -->
   <rosparam command="load" file="$(find ackermann_steering_controller)/test/common/config/ackermann_steering_bot_controllers.yaml" />

--- a/ackermann_steering_controller/test/common/urdf/ackermann_steering_bot.xacro
+++ b/ackermann_steering_controller/test/common/urdf/ackermann_steering_bot.xacro
@@ -8,8 +8,8 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
   <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
 
   <!-- Constants for robot dimensions -->
-  <xacro:property name="length" value="0.5" /> 
-  <xacro:property name="width" value="0.3" /> 
+  <xacro:property name="length" value="0.5" />
+  <xacro:property name="width" value="0.3" />
   <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
   <xacro:property name="thickness" value="0.086" /> <!-- Link 2 -->
   <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
@@ -58,29 +58,29 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
   </joint>
 
   <!-- joints for ackermann_steering_controller -->
-  <front_steer name="front" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+  <xacro:front_steer name="front" parent="base" radius="${wheel_radius}" thickness="${thickness}"
       length="${length}" width="${width}" axel_offset="${axel_offset}" steer_height="${wheel_radius+steer_offset}">
     <origin xyz="${length/2-axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </front_steer>
-  <rear_wheel name="rear" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:front_steer>
+  <xacro:rear_wheel name="rear" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-length/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </rear_wheel>
+  </xacro:rear_wheel>
 
   <!-- Wheels -->
-  <front_wheel_lr name="front_right" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+  <xacro:front_wheel_lr name="front_right" parent="base" radius="${wheel_radius}" thickness="${thickness}"
       length="${length}" width="${width}" axel_offset="${axel_offset}" right_left="1" steer_height="${wheel_radius+steer_offset}">
     <origin xyz="${length/2-axel_offset} ${width/2+axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </front_wheel_lr>
-  <front_wheel_lr name="front_left" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+  </xacro:front_wheel_lr>
+  <xacro:front_wheel_lr name="front_left" parent="base" radius="${wheel_radius}" thickness="${thickness}"
       length="${length}" width="${width}" axel_offset="${axel_offset}" right_left="-1" steer_height="${wheel_radius+steer_offset}">
     <origin xyz="${length/2-axel_offset} ${-width/2-axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </front_wheel_lr>
-  <rear_wheel_lr name="rear_right" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:front_wheel_lr>
+  <xacro:rear_wheel_lr name="rear_right" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-length/2+axel_offset} ${width/2+axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </rear_wheel_lr>
-  <rear_wheel_lr name="rear_left" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:rear_wheel_lr>
+  <xacro:rear_wheel_lr name="rear_left" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-length/2+axel_offset} ${-width/2-axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </rear_wheel_lr>
+  </xacro:rear_wheel_lr>
 
 
   <!-- Colour -->

--- a/ackermann_steering_controller/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro
+++ b/ackermann_steering_controller/test/common/urdf/ackermann_steering_bot_sphere_wheels.xacro
@@ -8,8 +8,8 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
   <xacro:property name="deg_to_rad" value="0.01745329251994329577"/>
 
   <!-- Constants for robot dimensions -->
-  <xacro:property name="length" value="0.5" /> 
-  <xacro:property name="width" value="0.3" /> 
+  <xacro:property name="length" value="0.5" />
+  <xacro:property name="width" value="0.3" />
   <xacro:property name="wheel_radius" value="0.11" /> <!-- Link 1 -->
   <xacro:property name="thickness" value="0.086" /> <!-- Link 2 -->
   <xacro:property name="axel_offset" value="0.05" /> <!-- Space btw top of beam and the each joint -->
@@ -58,29 +58,29 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
   </joint>
 
   <!-- joints for ackermann_steering_controller -->
-  <front_steer name="front" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+  <xacro:front_steer name="front" parent="base" radius="${wheel_radius}" thickness="${thickness}"
       length="${length}" width="${width}" axel_offset="${axel_offset}" steer_height="${wheel_radius+steer_offset}">
     <origin xyz="${length/2-axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </front_steer>
-  <rear_wheel name="rear" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:front_steer>
+  <xacro:rear_wheel name="rear" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-length/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </rear_wheel>
+  </xacro:rear_wheel>
 
   <!-- Wheels -->
-  <front_wheel_lr name="front_right" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+  <xacro:front_wheel_lr name="front_right" parent="base" radius="${wheel_radius}" thickness="${thickness}"
       length="${length}" width="${width}" axel_offset="${axel_offset}" right_left="1" steer_height="${wheel_radius+steer_offset}">
     <origin xyz="${length/2-axel_offset} ${width/2+axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </front_wheel_lr>
-  <front_wheel_lr name="front_left" parent="base" radius="${wheel_radius}" thickness="${thickness}" 
+  </xacro:front_wheel_lr>
+  <xacro:front_wheel_lr name="front_left" parent="base" radius="${wheel_radius}" thickness="${thickness}"
       length="${length}" width="${width}" axel_offset="${axel_offset}" right_left="-1" steer_height="${wheel_radius+steer_offset}">
     <origin xyz="${length/2-axel_offset} ${-width/2-axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </front_wheel_lr>
-  <rear_wheel_lr name="rear_right" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:front_wheel_lr>
+  <xacro:rear_wheel_lr name="rear_right" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-length/2+axel_offset} ${width/2+axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </rear_wheel_lr>
-  <rear_wheel_lr name="rear_left" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:rear_wheel_lr>
+  <xacro:rear_wheel_lr name="rear_left" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-length/2+axel_offset} ${-width/2-axel_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </rear_wheel_lr>
+  </xacro:rear_wheel_lr>
 
 
   <!-- Colour -->

--- a/diff_drive_controller/test/diff_drive_bad_urdf.test
+++ b/diff_drive_controller/test/diff_drive_bad_urdf.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_bad.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_bad.xacro'" />
 
   <!-- Controller test -->
   <test test-name="diff_drive_fail_test"

--- a/diff_drive_controller/test/diff_drive_common.launch
+++ b/diff_drive_controller/test/diff_drive_common.launch
@@ -4,7 +4,7 @@
 
   <!-- Load diffbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
 
   <!-- Start diffbot -->
   <node name="diffbot"

--- a/diff_drive_controller/test/diff_drive_multiple_cmd_vel_publishers.test
+++ b/diff_drive_controller/test/diff_drive_multiple_cmd_vel_publishers.test
@@ -4,12 +4,12 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Set allow_multiple_publishers to false -->
   <param name="diffbot_controller/allow_multiple_cmd_vel_publishers" value="false"/>
 
   <node name="cmd_vel_publisher" pkg="rostopic" type="rostopic" args="pub -r 2 /diffbot_controller/cmd_vel geometry_msgs/Twist '{linear: {x: 1.0}}'" />
-  
+
   <node name="cmd_vel_publisher2" pkg="rostopic" type="rostopic" args="pub -r 2 /diffbot_controller/cmd_vel geometry_msgs/Twist '{linear: {x: 2.0}}'" />
 
   <!-- Controller test -->

--- a/diff_drive_controller/test/diff_drive_radius_param.test
+++ b/diff_drive_controller/test/diff_drive_radius_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with square wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_square_wheels.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_square_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are boxes, not cylinders or spheres -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
 

--- a/diff_drive_controller/test/diff_drive_radius_param_fail.test
+++ b/diff_drive_controller/test/diff_drive_radius_param_fail.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with bad urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro.py '$(find diff_drive_controller)/test/diffbot_square_wheels.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_square_wheels.xacro'" />
   <!-- Don't provide the radius parameter, so the controller should break -->
   <!-- <param name="diffbot_controller/wheel_radius" value="0.11"/> -->
 

--- a/diff_drive_controller/test/diff_drive_separation_param.test
+++ b/diff_drive_controller/test/diff_drive_separation_param.test
@@ -4,7 +4,7 @@
 
   <!-- Override robot_description with sphere wheel urdf -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot_sphere_wheels.xacro'" />
   <!-- Provide the radius, since the bot's wheels are spheres, not cylinders -->
   <param name="diffbot_controller/wheel_radius" value="0.11"/>
   <!-- Provide the wheel separation -->

--- a/diff_drive_controller/test/diffbot.xacro
+++ b/diff_drive_controller/test/diffbot.xacro
@@ -57,12 +57,12 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
 
 
   <!-- Wheels -->
-  <wheel name="wheel_0" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  <xacro:wheel name="wheel_0" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
-  <wheel name="wheel_1" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:wheel>
+  <xacro:wheel name="wheel_1" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
+  </xacro:wheel>
 
 
   <!-- Colour -->

--- a/diff_drive_controller/test/diffbot_sphere_wheels.xacro
+++ b/diff_drive_controller/test/diffbot_sphere_wheels.xacro
@@ -55,12 +55,12 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
 
 
   <!-- Wheels -->
-  <sphere_wheel name="wheel_0" parent="base" radius="${wheel_radius}">
+  <xacro:sphere_wheel name="wheel_0" parent="base" radius="${wheel_radius}">
     <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </sphere_wheel>
-  <sphere_wheel name="wheel_1" parent="base" radius="${wheel_radius}">
+  </xacro:sphere_wheel>
+  <xacro:sphere_wheel name="wheel_1" parent="base" radius="${wheel_radius}">
     <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </sphere_wheel>
+  </xacro:sphere_wheel>
 
 
   <!-- Colour -->

--- a/diff_drive_controller/test/diffbot_square_wheels.xacro
+++ b/diff_drive_controller/test/diffbot_square_wheels.xacro
@@ -55,12 +55,12 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
 
 
   <!-- Wheels -->
-  <square_wheel name="wheel_0" parent="base" radius="${wheel_radius}">
+  <xacro:square_wheel name="wheel_0" parent="base" radius="${wheel_radius}">
     <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </square_wheel>
-  <square_wheel name="wheel_1" parent="base" radius="${wheel_radius}">
+  </xacro:square_wheel>
+  <xacro:square_wheel name="wheel_1" parent="base" radius="${wheel_radius}">
     <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </square_wheel>
+  </xacro:square_wheel>
 
 
   <!-- Colour -->

--- a/diff_drive_controller/test/skid_steer_common.launch
+++ b/diff_drive_controller/test/skid_steer_common.launch
@@ -4,7 +4,7 @@
 
   <!-- Load skidsteerbot model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"

--- a/diff_drive_controller/test/skidsteerbot.xacro
+++ b/diff_drive_controller/test/skidsteerbot.xacro
@@ -58,24 +58,24 @@ Robot model taken from http://wiki.ros.org/pr2_mechanism/Tutorials/SImple%20URDF
 
 
   <!-- Wheels -->
-  <wheel name="wheel_0" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  <xacro:wheel name="wheel_0" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${width/2+axel_offset} ${y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
-  <wheel name="wheel_1" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:wheel>
+  <xacro:wheel name="wheel_1" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
-  <wheel name="wheel_2" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:wheel>
+  <xacro:wheel name="wheel_2" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${width/2+axel_offset} ${-y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
-  <wheel name="wheel_3" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:wheel>
+  <xacro:wheel name="wheel_3" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-width/2+axel_offset} ${y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
-  <wheel name="wheel_4" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:wheel>
+  <xacro:wheel name="wheel_4" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-width/2+axel_offset} 0 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
-  <wheel name="wheel_5" parent="base" radius="${wheel_radius}" thickness="${thickness}">
+  </xacro:wheel>
+  <xacro:wheel name="wheel_5" parent="base" radius="${wheel_radius}" thickness="${thickness}">
     <origin xyz="${-width/2+axel_offset} ${-y_offset} 0" rpy="${-90 * deg_to_rad} 0 0"/>
-  </wheel>
+  </xacro:wheel>
 
 
   <!-- Colour -->

--- a/diff_drive_controller/test/view_diffbot.launch
+++ b/diff_drive_controller/test/view_diffbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/diffbot.xacro'" />
 
   <!-- Start diffbot -->
   <node name="diffbot"
@@ -23,4 +23,3 @@
   <node name="spawn_single_link" pkg="gazebo" type="spawn_model" args="-urdf -param robot_description -model diffbot -z 0.5" respawn="false" output="screen" />
 
 </launch>
-

--- a/diff_drive_controller/test/view_skidsteerbot.launch
+++ b/diff_drive_controller/test/view_skidsteerbot.launch
@@ -4,7 +4,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro' --inorder" />
+         command="$(find xacro)/xacro '$(find diff_drive_controller)/test/skidsteerbot.xacro'" />
 
   <!-- Start skidsteerbot -->
   <node name="skidsteerbot"
@@ -23,4 +23,3 @@
   <node name="spawn_single_link" pkg="gazebo" type="spawn_model" args="-urdf -param robot_description -model skidsteerbot -z 0.5" respawn="false" output="screen" />
 
 </launch>
-

--- a/four_wheel_steering_controller/test/launch/four_wheel_steering_common.launch
+++ b/four_wheel_steering_controller/test/launch/four_wheel_steering_common.launch
@@ -4,7 +4,7 @@
 
   <!-- Load four_wheel_steering model -->
   <param name="robot_description"
-         command="$(find xacro)/xacro --inorder '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
+         command="$(find xacro)/xacro '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
 
   <!-- Start four_wheel_steering -->
   <node name="four_wheel_steering"

--- a/four_wheel_steering_controller/test/launch/view_four_wheel_steering.launch
+++ b/four_wheel_steering_controller/test/launch/view_four_wheel_steering.launch
@@ -9,7 +9,7 @@
 
   <!-- load robot -->
   <param name="robot_description"
-         command="$(find xacro)/xacro --inorder '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
+         command="$(find xacro)/xacro '$(find four_wheel_steering_controller)/test/urdf/four_wheel_steering.urdf.xacro'" />
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
@@ -33,4 +33,3 @@
     <remap from="cmd_vel" to="/four_wheel_steering_controller/cmd_vel"/>
   </node>
 </launch>
-

--- a/joint_trajectory_controller/test/joint_trajectory_controller_wrapping.test
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_wrapping.test
@@ -4,7 +4,7 @@
 
   <!-- Load RRbot model -->
   <param name="robot_description"
-      command="$(find xacro)/xacro.py '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
+      command="$(find xacro)/xacro '$(find joint_trajectory_controller)/test/rrbot.xacro'" />
 
   <!-- Start RRbot -->
   <node name="rrbot_wrapping"


### PR DESCRIPTION
Drop deprecated `xacro` features in preparation for Noetic. See https://github.com/ros/xacro/blob/noetic-devel/CHANGELOG.rst

This fixes three warnings we get a lot in our tests at the moment:
 - `xacro: in-order processing became default in ROS Melodic. You can drop the option.`
 - `Deprecated: xacro tag 'XYZ' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)`
 - `xacro.py is deprecated; please use xacro instead`

Fixes for the second and third items could be backported to `kinetic-devel` if we want.