### PR TITLE
Bump CMake version to avoid CMP0048

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ackermann_steering_controller)
 
 # Default to C++14

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(diff_drive_controller)
 
 # Default to C++14

--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(effort_controllers)
 
 # Default to C++14

--- a/force_torque_sensor_controller/CMakeLists.txt
+++ b/force_torque_sensor_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(force_torque_sensor_controller)
 
 # Default to C++14
@@ -32,7 +32,7 @@ catkin_package(
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
-  src/force_torque_sensor_controller.cpp 
+  src/force_torque_sensor_controller.cpp
   include/force_torque_sensor_controller/force_torque_sensor_controller.h
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(forward_command_controller)
 
 # Default to C++14

--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(four_wheel_steering_controller)
 
 # Default to C++14

--- a/gripper_action_controller/CMakeLists.txt
+++ b/gripper_action_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(gripper_action_controller)
 
 # Default to C++14
@@ -6,7 +6,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-find_package(catkin 
+find_package(catkin
   REQUIRED COMPONENTS
       actionlib
       angles
@@ -27,12 +27,12 @@ find_package(catkin
 catkin_package(
 INCLUDE_DIRS include
 LIBRARIES gripper_action_controller
-CATKIN_DEPENDS 
-  actionlib 
-  cmake_modules 
-  controller_interface 
-  control_msgs 
-  hardware_interface 
+CATKIN_DEPENDS
+  actionlib
+  cmake_modules
+  controller_interface
+  control_msgs
+  hardware_interface
   realtime_tools
   trajectory_msgs
 )

--- a/imu_sensor_controller/CMakeLists.txt
+++ b/imu_sensor_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(imu_sensor_controller)
 
 # Default to C++14
@@ -16,7 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 catkin_package(
-  CATKIN_DEPENDS 
+  CATKIN_DEPENDS
     controller_interface
     hardware_interface
     pluginlib
@@ -30,7 +30,7 @@ catkin_package(
 include_directories(include ${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}
-  src/imu_sensor_controller.cpp 
+  src/imu_sensor_controller.cpp
   include/imu_sensor_controller/imu_sensor_controller.h)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 

--- a/joint_state_controller/CMakeLists.txt
+++ b/joint_state_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(joint_state_controller)
 
 # Default to C++14

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(joint_trajectory_controller)
 
 # Default to C++14

--- a/position_controllers/CMakeLists.txt
+++ b/position_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(position_controllers)
 
 # Load catkin and all dependencies required for this package

--- a/ros_controllers/CMakeLists.txt
+++ b/ros_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ros_controllers)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/rqt_joint_trajectory_controller/CMakeLists.txt
+++ b/rqt_joint_trajectory_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rqt_joint_trajectory_controller)
 
 find_package(catkin REQUIRED COMPONENTS)

--- a/velocity_controllers/CMakeLists.txt
+++ b/velocity_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(velocity_controllers)
 
 # Default to C++14


### PR DESCRIPTION
See ros/catkin#1052.

Should be backported to Kinetic as well (See [REP 3](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021)).