### PR TITLE
Remove gazebo_ros test dependency

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -60,7 +60,7 @@ if (CATKIN_ENABLE_TESTING)
     rosunit
     std_msgs
     std_srvs
-    gazebo_ros
+    tf
     xacro
   )
   include_directories(${catkin_INCLUDE_DIRS})

--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -31,7 +31,6 @@
 
   <!--Tests-->
   <test_depend>controller_manager</test_depend>
-  <test_depend>gazebo_ros</test_depend>
   <test_depend>geometry_msgs</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>


### PR DESCRIPTION
Required for the Noetic release as this is currently blocking the release of this repo.
It is a dependency in 2 launch files to view urdfs, hardly critical and we should probably refactor them.