### PR TITLE
Fix: JointTrajectoryController tolerance checking using incorrect joint error

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -382,6 +382,11 @@ update(const ros::Time& time, const ros::Duration& period)
       return;
     }
 
+    // Get state error for current joint
+    state_joint_error_.position[0] = state_error_.position[i];
+    state_joint_error_.velocity[0] = state_error_.velocity[i];
+    state_joint_error_.acceleration[0] = 0.0;
+
     //Check tolerances
     const RealtimeGoalHandlePtr rt_segment_goal = segment_it->getGoalHandle();
     if (rt_segment_goal && rt_segment_goal == rt_active_goal_)

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -385,7 +385,7 @@ update(const ros::Time& time, const ros::Duration& period)
     // Get state error for current joint
     state_joint_error_.position[0] = state_error_.position[i];
     state_joint_error_.velocity[0] = state_error_.velocity[i];
-    state_joint_error_.acceleration[0] = 0.0;
+    state_joint_error_.acceleration[0] = state_error_.acceleration[i];
 
     //Check tolerances
     const RealtimeGoalHandlePtr rt_segment_goal = segment_it->getGoalHandle();
@@ -768,14 +768,10 @@ updateStates(const ros::Time& sample_time, const Trajectory* const traj)
 
     desired_state_.position[joint_index] = desired_joint_state_.position[0];
     desired_state_.velocity[joint_index] = desired_joint_state_.velocity[0];
-    desired_state_.acceleration[joint_index] = desired_joint_state_.acceleration[0]; ;
+    desired_state_.acceleration[joint_index] = desired_joint_state_.acceleration[0];
 
-    state_joint_error_.position[0] = angles::shortest_angular_distance(current_state_.position[joint_index],desired_joint_state_.position[0]);
-    state_joint_error_.velocity[0] = desired_joint_state_.velocity[0] - current_state_.velocity[joint_index];
-    state_joint_error_.acceleration[0] = 0.0;
-
-    state_error_.position[joint_index] = state_joint_error_.position[0];
-    state_error_.velocity[joint_index] = state_joint_error_.velocity[0];
+    state_error_.position[joint_index] = angles::shortest_angular_distance(current_state_.position[joint_index],desired_joint_state_.position[0]);
+    state_error_.velocity[joint_index] = desired_joint_state_.velocity[0] - current_state_.velocity[joint_index];
     state_error_.acceleration[joint_index] = 0.0;
   }
 }

--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -1338,7 +1338,7 @@ TEST_F(JointTrajectoryControllerTest, goalToleranceViolationSingleJoint)
 
   /*** JOINT0 ***/
   // Make robot respond with a delay on joint0
-  smoothings.data.assign({0.95, 0.});
+  smoothings.data.assign({0.97, 0.});
   smoothings_pub.publish(smoothings);
   ASSERT_TRUE(waitForRobotReady());
 


### PR DESCRIPTION
`state_joint_error_` is used as a temp variable inside a loop over joints in `updateStates`, so always contains the error values for the last joint in the loop.  As such, tolerance checking was only ever checking the error of the last joint, but against the tolerances for each joint. 

This simple fix just puts the correct error values into `state_joint_error_` before the tolerances are checked.  