### PR TITLE
JointGroupPositionController: Set current position as target in starting()

### DIFF
--- a/effort_controllers/include/effort_controllers/joint_group_position_controller.h
+++ b/effort_controllers/include/effort_controllers/joint_group_position_controller.h
@@ -72,6 +72,7 @@ public:
 
   bool init(hardware_interface::EffortJointInterface* hw, ros::NodeHandle &n);
   void update(const ros::Time& /*time*/, const ros::Duration& /*period*/);
+  void starting(const ros::Time& /*time*/);
 
   std::vector< std::string > joint_names_;
   std::vector< hardware_interface::JointHandle > joints_;

--- a/effort_controllers/src/joint_group_position_controller.cpp
+++ b/effort_controllers/src/joint_group_position_controller.cpp
@@ -129,7 +129,7 @@ namespace effort_controllers
       enforceJointLimits(current_positions[i], i);
       pid_controllers_[i].reset();
     }
-    commands_buffer_.writeFromNonRT(current_positions);
+    commands_buffer_.initRT(current_positions);
   }
 
   void JointGroupPositionController::update(const ros::Time& time, const ros::Duration& period)

--- a/effort_controllers/src/joint_group_position_controller.cpp
+++ b/effort_controllers/src/joint_group_position_controller.cpp
@@ -120,6 +120,18 @@ namespace effort_controllers
     return true;
   }
 
+  void JointGroupPositionController::starting(const ros::Time& time)
+  {
+    std::vector<double> current_positions(n_joints_, 0.0);
+    for (std::size_t i = 0; i < n_joints_; ++i)
+    {
+      current_positions[i] = joints_[i].getPosition();
+      enforceJointLimits(current_positions[i], i);
+      pid_controllers_[i].reset();
+    }
+    commands_buffer_.writeFromNonRT(current_positions);
+  }
+
   void JointGroupPositionController::update(const ros::Time& time, const ros::Duration& period)
   {
     std::vector<double> & commands = *commands_buffer_.readFromRT();
@@ -127,7 +139,7 @@ namespace effort_controllers
     {
         double command_position = commands[i];
 
-        double error; //, vel_error;
+        double error;
         double commanded_effort;
 
         double current_position = joints_[i].getPosition();


### PR DESCRIPTION
Currently, the target position upon starting is all zeros. This is not great if a command is not issued immediately (and even then). To be safer, set the goal position to the current sensed position and also reset the PID internal state upon starting.

(This PR is on top of #503)