### PR TITLE
Clean CMakeLists.txt and package.xml files of acckermann_steering_controller_package

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -15,13 +15,13 @@ find_package(catkin REQUIRED COMPONENTS
   realtime_tools
   roscpp
   tf
-  urdf
 )
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 
+find_package(urdfdom REQUIRED)
+
 catkin_package(
-  INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS
     controller_interface
@@ -38,10 +38,11 @@ include_directories(
   include
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
+  ${urdfdom_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} src/ackermann_steering_controller.cpp src/odometry.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${urdfdom_LIBRARIES})
 
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -49,65 +50,73 @@ install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-install(FILES ackermann_steering_controller_plugins.xml
+install(FILES ${PROJECT_NAME}_plugins.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS
-    controller_manager
-    geometry_msgs
-    rostest
-    rosunit
-    std_msgs
-    std_srvs
-    tf
-    xacro
+  find_package(controller_manager REQUIRED)
+  find_package(controller_manager_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(std_srvs REQUIRED)
+  find_package(rostest REQUIRED)
+
+  include_directories(
+    ${controller_manager_INCLUDE_DIRS}
+    ${controller_manager_msgs_INCLUDE_DIRS}
+    ${std_msgs_INCLUDE_DIRS}
+    ${std_srvs_INCLUDE_DIRS}
   )
-  include_directories(${catkin_INCLUDE_DIRS})
+
+  set(test_LIBRARIES
+    ${controller_manager_LIBRARIES}
+    ${controller_manager_msgs_LIBRARIES}
+    ${std_msgs_LIBRARIES}
+    ${std_srvs_LIBRARIES}
+  )
 
   add_executable(${PROJECT_NAME}_ackermann_steering_bot test/common/src/ackermann_steering_bot.cpp)
   add_dependencies(tests ${PROJECT_NAME}_ackermann_steering_bot)
+  target_link_libraries(${PROJECT_NAME}_ackermann_steering_bot ${catkin_LIBRARIES} ${test_LIBRARIES})
 
-  target_link_libraries(${PROJECT_NAME}_ackermann_steering_bot ${catkin_LIBRARIES})
   add_rostest_gtest(${PROJECT_NAME}_test
     test/ackermann_steering_controller_test/ackermann_steering_controller.test
     test/ackermann_steering_controller_test/ackermann_steering_controller_test.cpp)
-  target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest_gtest(${PROJECT_NAME}_nan_test
     test/ackermann_steering_controller_nan_test/ackermann_steering_controller_nan.test
     test/ackermann_steering_controller_nan_test/ackermann_steering_controller_nan_test.cpp)
-  target_link_libraries(${PROJECT_NAME}_nan_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_nan_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest_gtest(${PROJECT_NAME}_limits_test
     test/ackermann_steering_controller_limits_test/ackermann_steering_controller_limits.test
     test/ackermann_steering_controller_limits_test/ackermann_steering_controller_limits_test.cpp)
-  target_link_libraries(${PROJECT_NAME}_limits_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_limits_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest_gtest(${PROJECT_NAME}_timeout_test
     test/ackermann_steering_controller_timeout_test/ackermann_steering_controller_timeout.test
     test/ackermann_steering_controller_timeout_test/ackermann_steering_controller_timeout_test.cpp)
-  target_link_libraries(${PROJECT_NAME}_timeout_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_timeout_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest_gtest(ackermann_steering_controller_fail_test
     test/ackermann_steering_controller_fail_test/ackermann_steering_controller_wrong.test
     test/ackermann_steering_controller_fail_test/ackermann_steering_controller_fail_test.cpp)
-  target_link_libraries(ackermann_steering_controller_fail_test ${catkin_LIBRARIES})
+  target_link_libraries(ackermann_steering_controller_fail_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest_gtest(${PROJECT_NAME}_odom_tf_test
     test/ackermann_steering_controller_odom_tf_test/ackermann_steering_controller_odom_tf.test
     test/ackermann_steering_controller_odom_tf_test/ackermann_steering_controller_odom_tf_test.cpp)
-  target_link_libraries(${PROJECT_NAME}_odom_tf_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_odom_tf_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest_gtest(${PROJECT_NAME}_default_odom_frame_test
     test/ackermann_steering_controller_default_odom_frame_test/ackermann_steering_controller_default_odom_frame.test
     test/ackermann_steering_controller_default_odom_frame_test/ackermann_steering_controller_default_odom_frame_test.cpp)
-  target_link_libraries(${PROJECT_NAME}_default_odom_frame_test ${catkin_LIBRARIES})
+  target_link_libraries(${PROJECT_NAME}_default_odom_frame_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest_gtest(ackermann_steering_controller_odom_frame_test
     test/ackermann_steering_controller_odom_frame_test/ackermann_steering_controller_odom_frame.test
     test/ackermann_steering_controller_odom_frame_test/ackermann_steering_controller_odom_frame_test.cpp)
-  target_link_libraries(ackermann_steering_controller_odom_frame_test ${catkin_LIBRARIES})
+  target_link_libraries(ackermann_steering_controller_odom_frame_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_rostest(test/ackermann_steering_controller_open_loop_test/ackermann_steering_controller_open_loop.test)
   add_rostest(test/ackermann_steering_controller_no_wheel_test/ackermann_steering_controller_no_wheel.test)

--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -6,6 +6,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+# Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   controller_interface
   diff_drive_controller
@@ -21,6 +22,7 @@ find_package(Boost REQUIRED COMPONENTS system thread)
 
 find_package(urdfdom REQUIRED)
 
+# Declare a catkin package
 catkin_package(
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS
@@ -34,6 +36,11 @@ catkin_package(
   DEPENDS Boost
 )
 
+###########
+## Build ##
+###########
+
+# Specify header include paths
 include_directories(
   include
   ${Boost_INCLUDE_DIRS}
@@ -44,14 +51,9 @@ include_directories(
 add_library(${PROJECT_NAME} src/ackermann_steering_controller.cpp src/odometry.cpp)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${urdfdom_LIBRARIES})
 
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
-
-install(FILES ${PROJECT_NAME}_plugins.xml
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+#############
+## Testing ##
+#############
 
 if (CATKIN_ENABLE_TESTING)
   find_package(controller_manager REQUIRED)
@@ -125,3 +127,18 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest(test/ackermann_steering_controller_radius_param_fail_test/ackermann_steering_controller_radius_param_fail.test)
   add_rostest(test/ackermann_steering_controller_separation_param_test/ackermann_steering_controller_separation_param.test)
 endif()
+
+#############
+## Install ##
+#############
+
+# Install targets
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Install plugins
+install(FILES ${PROJECT_NAME}_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -24,14 +24,16 @@
   <depend>tf</depend>
 
   <build_depend>pluginlib</build_depend>
-  <build_depend>urdf</build_depend>
+  <build_depend>liburdfdom-dev</build_depend>
 
   <exec_depend>pluginlib</exec_depend>
-  <exec_depend>urdf</exec_depend>
+  <exec_depend>liburdfdom-dev</exec_depend>
 
   <!--Tests-->
   <test_depend>controller_manager</test_depend>
+  <test_depend>controller_manager_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>
+  <test_depend>gtest</test_depend>
   <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>std_msgs</test_depend>

--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>ackermann_steering_controller</name>
   <version>0.17.0</version>
   <description>Controller for a steer drive mobile base.</description>
+
   <maintainer email="p595201m@mail.kyutech.jp">Masaru Morita</maintainer>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
 
@@ -10,6 +14,7 @@
 
   <url type="bugtracker">https://github.com/ros-controls/ros_controllers/issues</url>
   <url type="repository">https://github.com/ros-controls/ros_controllers/ackermann_steering_controller</url>
+
   <author email="p595201m@mail.kyutech.jp">Masaru Morita</author>
 
   <buildtool_depend>catkin</buildtool_depend>

--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -34,12 +34,9 @@
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>liburdfdom-dev</exec_depend>
 
-  <!--Tests-->
   <test_depend>controller_manager</test_depend>
   <test_depend>controller_manager_msgs</test_depend>
   <test_depend>geometry_msgs</test_depend>
-  <test_depend>gtest</test_depend>
-  <test_depend>rosunit</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>std_msgs</test_depend>
   <test_depend>std_srvs</test_depend>


### PR DESCRIPTION
Apply updates suggested in https://github.com/ros-controls/ros_controllers/issues/513:
* Clean dependencies (find missing/unnecessary dependencies)
* Apply consistent format to package.xml and CMakeListst.txt
* Fix major inconsistencies detected by catkin_lint (e.g. double find_package)

Note: I was not sure about keeping/removing the dependency on google-test and rosunit. Following the ros_control's packages, I removed them.