### PR TITLE
Fix diff_drive_controller tests

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -301,8 +301,6 @@ namespace diff_drive_controller{
                           << ", left wheel radius "  << lwr
                           << ", right wheel radius " << rwr);
 
-    setOdomPubFields(root_nh, controller_nh);
-
     if (publish_cmd_)
     {
       cmd_vel_pub_.reset(new realtime_tools::RealtimePublisher<geometry_msgs::TwistStamped>(controller_nh, "cmd_vel_out", 100));
@@ -341,6 +339,8 @@ namespace diff_drive_controller{
       vel_left_previous_.resize(wheel_joints_size_, 0.0);
       vel_right_previous_.resize(wheel_joints_size_, 0.0);
     }
+
+    setOdomPubFields(root_nh, controller_nh);
 
     // Get the joint object to use in the realtime loop
     for (size_t i = 0; i < wheel_joints_size_; ++i)

--- a/diff_drive_controller/test/diff_drive_default_wheel_joint_controller_state_test.cpp
+++ b/diff_drive_controller/test/diff_drive_default_wheel_joint_controller_state_test.cpp
@@ -33,10 +33,7 @@
 TEST_F(DiffDriveControllerTest, testDefaultJointTrajectoryControllerStateTopic)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
 
   EXPECT_FALSE(isPublishingJointTrajectoryControllerState());
 

--- a/diff_drive_controller/test/diff_drive_dyn_reconf_test.cpp
+++ b/diff_drive_controller/test/diff_drive_dyn_reconf_test.cpp
@@ -36,12 +36,7 @@
 TEST_F(DiffDriveControllerTest, testDynReconfServerAlive)
 {
   // wait for ROS
-  while(!isControllerAlive() && ros::ok())
-  {
-    ros::Duration(0.1).sleep();
-  }
-  if (!ros::ok())
-    FAIL() << "Something went wrong while executing test";
+  waitForController();
 
   // Expect server is alive
   EXPECT_TRUE(ros::service::exists("diffbot_controller/set_parameters", true));

--- a/diff_drive_controller/test/diff_drive_limits_test.cpp
+++ b/diff_drive_controller/test/diff_drive_limits_test.cpp
@@ -33,10 +33,8 @@
 TEST_F(DiffDriveControllerTest, testLinearJerkLimits)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+
   // zero everything before test
   geometry_msgs::Twist cmd_vel;
   cmd_vel.linear.x = 0.0;

--- a/diff_drive_controller/test/diff_drive_nan_test.cpp
+++ b/diff_drive_controller/test/diff_drive_nan_test.cpp
@@ -35,9 +35,8 @@
 // TEST CASES
 TEST_F(DiffDriveControllerTest, testNaN) {
   // wait for ROS
-  while (!isControllerAlive()) {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+
   // zero everything before test
   geometry_msgs::Twist cmd_vel;
   cmd_vel.linear.x = 0.0;

--- a/diff_drive_controller/test/diff_drive_odom_tf_test.cpp
+++ b/diff_drive_controller/test/diff_drive_odom_tf_test.cpp
@@ -34,10 +34,8 @@
 TEST_F(DiffDriveControllerTest, testNoOdomFrame)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+  
   // set up tf listener
   tf::TransformListener listener;
   ros::Duration(2.0).sleep();

--- a/diff_drive_controller/test/diff_drive_publish_wheel_joint_controller_state_test.cpp
+++ b/diff_drive_controller/test/diff_drive_publish_wheel_joint_controller_state_test.cpp
@@ -33,10 +33,7 @@
 TEST_F(DiffDriveControllerTest, testPublishJointTrajectoryControllerStateTopic)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
 
   EXPECT_TRUE(isPublishingJointTrajectoryControllerState());
 

--- a/diff_drive_controller/test/diff_drive_timeout_test.cpp
+++ b/diff_drive_controller/test/diff_drive_timeout_test.cpp
@@ -33,10 +33,8 @@
 TEST_F(DiffDriveControllerTest, testTimeout)
 {
   // wait for ROS
-  while(!isControllerAlive())
-  {
-    ros::Duration(0.1).sleep();
-  }
+  waitForController();
+
   // zero everything before test
   geometry_msgs::Twist cmd_vel;
   cmd_vel.linear.x = 0.0;

--- a/diff_drive_controller/test/test_common.h
+++ b/diff_drive_controller/test/test_common.h
@@ -76,7 +76,7 @@ public:
   geometry_msgs::TwistStamped getLastCmdVelOut(){ return last_cmd_vel_out; }
   control_msgs::JointTrajectoryControllerState getLastJointTrajectoryControllerState(){ return last_joint_traj_controller_state; }
   void publish(geometry_msgs::Twist cmd_vel){ cmd_pub.publish(cmd_vel); }
-  bool isControllerAlive()const{ return (odom_sub.getNumPublishers() > 0) && (cmd_pub.getNumSubscribers() > 0); }
+  bool isControllerAlive()const{ return (odom_sub.getNumPublishers() > 0); }
   bool isPublishingCmdVelOut(const ros::Duration &timeout=ros::Duration(1)) const
   {
     ros::Time start = ros::Time::now();


### PR DESCRIPTION
This is an attempt to fix an annoying hard-to-debug error present in jobs [998.2](https://travis-ci.org/github/ros-controls/ros_controllers/jobs/721105437), [1010.2](https://travis-ci.org/github/ros-controls/ros_controllers/jobs/724116882), [1010.3](https://travis-ci.org/github/ros-controls/ros_controllers/jobs/724116883).

The updates are:
* Move odom publisher to the end of the `init` method, so it is created after the optional publishers (twist commands and wheel states), then simplify `isControllerAlive` to check odom_pub only. The objective is to make the verification of the optional publishers more robust.
* Apply `waitForController` check (which considers `ros::ok()`) to all tests