### PR TITLE
Clean CMakeLists.txt and package.xml files of diff_drive_controller package

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-find_package(Boost REQUIRED COMPONENTS accumulators bind function)
+find_package(Boost REQUIRED COMPONENTS headers)
 
 find_package(urdfdom REQUIRED)
 
@@ -33,7 +33,6 @@ catkin_package(
     realtime_tools
     roscpp
     tf
-  DEPENDS Boost
 )
 
 ###########
@@ -49,7 +48,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME} src/ackermann_steering_controller.cpp src/odometry.cpp)
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${urdfdom_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${urdfdom_LIBRARIES})
 
 #############
 ## Testing ##

--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(Boost REQUIRED COMPONENTS accumulators bind function)
 
 find_package(urdfdom REQUIRED)
 

--- a/ackermann_steering_controller/package.xml
+++ b/ackermann_steering_controller/package.xml
@@ -19,7 +19,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>boost</depend>
   <depend>controller_interface</depend>
   <depend>diff_drive_controller</depend>
   <depend>hardware_interface</depend>
@@ -28,8 +27,11 @@
   <depend>roscpp</depend>
   <depend>tf</depend>
 
+  <build_depend>boost</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>liburdfdom-dev</build_depend>
+
+  <build_export_depend>boost</build_export_depend>
 
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>liburdfdom-dev</exec_depend>

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -10,22 +10,37 @@ find_package(catkin REQUIRED COMPONENTS
     controller_interface
     control_msgs
     dynamic_reconfigure
+    geometry_msgs
+    hardware_interface
     nav_msgs
+    pluginlib
     realtime_tools
     tf
     urdf
-    pluginlib
 )
+
+find_package(Boost REQUIRED COMPONENTS headers)
 
 generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)
 
 catkin_package(
   INCLUDE_DIRS include
+  CATKIN_DEPENDS
+    controller_interface
+    control_msgs
+    dynamic_reconfigure
+    geometry_msgs
+    hardware_interface
+    nav_msgs
+    realtime_tools
+    tf
   LIBRARIES ${PROJECT_NAME}
+  DEPENDS Boost
 )
 
 include_directories(
   include ${catkin_INCLUDE_DIRS}
+  include ${Boost_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
@@ -46,71 +61,85 @@ install(FILES diff_drive_controller_plugins.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 if (CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS controller_manager rosgraph_msgs rostest std_srvs tf)
-  include_directories(include ${catkin_INCLUDE_DIRS})
+  find_package(controller_manager REQUIRED)
+  find_package(rosgraph_msgs REQUIRED)
+  find_package(std_srvs REQUIRED)
+  find_package(rostest REQUIRED)
+  
+  include_directories(
+    ${controller_manager_INCLUDE_DIRS}
+    ${rosgraph_msgs_INCLUDE_DIRS}
+    ${std_srvs_INCLUDE_DIRS}
+  )
+
+  set(test_LIBRARIES
+    ${controller_manager_LIBRARIES}
+    ${rosgraph_msgs_LIBRARIES}
+    ${std_srvs_LIBRARIES}
+  )
 
   add_executable(diffbot test/diffbot.cpp)
-  target_link_libraries(diffbot ${catkin_LIBRARIES})
+  target_link_libraries(diffbot ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_executable(skidsteerbot test/skidsteerbot.cpp)
-  target_link_libraries(skidsteerbot ${catkin_LIBRARIES})
+  target_link_libraries(skidsteerbot ${catkin_LIBRARIES} ${test_LIBRARIES})
 
   add_dependencies(tests diffbot skidsteerbot)
 
   add_rostest_gtest(diff_drive_test
     test/diff_drive_controller.test
     test/diff_drive_test.cpp)
-  target_link_libraries(diff_drive_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_nan_test
     test/diff_drive_controller_nan.test
     test/diff_drive_nan_test.cpp)
-  target_link_libraries(diff_drive_nan_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_nan_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_limits_test
     test/diff_drive_controller_limits.test
     test/diff_drive_limits_test.cpp)
-  target_link_libraries(diff_drive_limits_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_limits_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_timeout_test
     test/diff_drive_timeout.test
     test/diff_drive_timeout_test.cpp)
-  target_link_libraries(diff_drive_timeout_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_timeout_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest(test/diff_drive_multipliers.test)
   add_rostest(test/diff_drive_left_right_multipliers.test)
   add_rostest_gtest(diff_drive_fail_test
     test/diff_drive_wrong.test
     test/diff_drive_fail_test.cpp)
-  target_link_libraries(diff_drive_fail_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_fail_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_odom_tf_test
     test/diff_drive_odom_tf.test
     test/diff_drive_odom_tf_test.cpp)
-  target_link_libraries(diff_drive_odom_tf_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_odom_tf_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_default_cmd_vel_out_test
     test/diff_drive_default_cmd_vel_out.test
     test/diff_drive_default_cmd_vel_out_test.cpp)
-  target_link_libraries(diff_drive_default_cmd_vel_out_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_default_cmd_vel_out_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_pub_cmd_vel_out_test
     test/diff_drive_pub_cmd_vel_out.test
     test/diff_drive_pub_cmd_vel_out_test.cpp)
-  target_link_libraries(diff_drive_pub_cmd_vel_out_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_pub_cmd_vel_out_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_default_wheel_joint_controller_state_test
     test/diff_drive_default_wheel_joint_controller_state.test
     test/diff_drive_default_wheel_joint_controller_state_test.cpp)
-  target_link_libraries(diff_drive_default_wheel_joint_controller_state_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_default_wheel_joint_controller_state_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_publish_wheel_joint_controller_state_test
     test/diff_drive_publish_wheel_joint_controller_state.test
     test/diff_drive_publish_wheel_joint_controller_state_test.cpp)
-  target_link_libraries(diff_drive_publish_wheel_joint_controller_state_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_publish_wheel_joint_controller_state_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_default_odom_frame_test
     test/diff_drive_default_odom_frame.test
     test/diff_drive_default_odom_frame_test.cpp)
-  target_link_libraries(diff_drive_default_odom_frame_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_default_odom_frame_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_odom_frame_test
     test/diff_drive_odom_frame.test
     test/diff_drive_odom_frame_test.cpp)
-  target_link_libraries(diff_drive_odom_frame_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_odom_frame_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest_gtest(diff_drive_multiple_cmd_vel_publishers_test
     test/diff_drive_multiple_cmd_vel_publishers.test
     test/diff_drive_multiple_cmd_vel_publishers_test.cpp)
-  target_link_libraries(diff_drive_multiple_cmd_vel_publishers_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_multiple_cmd_vel_publishers_test ${catkin_LIBRARIES} ${test_LIBRARIES})
   add_rostest(test/diff_drive_open_loop.test)
   add_rostest(test/skid_steer_controller.test)
   add_rostest(test/skid_steer_no_wheels.test)
@@ -122,5 +151,5 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest_gtest(diff_drive_dyn_reconf_test
     test/diff_drive_dyn_reconf.test
     test/diff_drive_dyn_reconf_test.cpp)
-  target_link_libraries(diff_drive_dyn_reconf_test ${catkin_LIBRARIES})
+  target_link_libraries(diff_drive_dyn_reconf_test ${catkin_LIBRARIES} ${test_LIBRARIES})
 endif()

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -6,6 +6,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+# Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
     controller_interface
     control_msgs
@@ -21,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 find_package(Boost REQUIRED COMPONENTS headers)
 
+# Declare a catkin package
 generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)
 
 catkin_package(
@@ -38,27 +40,29 @@ catkin_package(
   DEPENDS Boost
 )
 
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
 include_directories(
   include ${catkin_INCLUDE_DIRS}
   include ${Boost_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME} src/diff_drive_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
+add_library(${PROJECT_NAME}
+  src/diff_drive_controller.cpp
+  src/odometry.cpp
+  src/speed_limiter.cpp
+)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${PROJECT_NAME}_gencfg)
 
-install(DIRECTORY include/${PROJECT_NAME}/
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-# Install library
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-  )
-
-install(FILES diff_drive_controller_plugins.xml
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+#############
+## Testing ##
+#############
 
 if (CATKIN_ENABLE_TESTING)
   find_package(controller_manager REQUIRED)
@@ -88,68 +92,128 @@ if (CATKIN_ENABLE_TESTING)
 
   add_rostest_gtest(diff_drive_test
     test/diff_drive_controller.test
-    test/diff_drive_test.cpp)
+    test/diff_drive_test.cpp
+  )
   target_link_libraries(diff_drive_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_nan_test
     test/diff_drive_controller_nan.test
-    test/diff_drive_nan_test.cpp)
+    test/diff_drive_nan_test.cpp
+  )
   target_link_libraries(diff_drive_nan_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_limits_test
     test/diff_drive_controller_limits.test
-    test/diff_drive_limits_test.cpp)
+    test/diff_drive_limits_test.cpp
+  )
   target_link_libraries(diff_drive_limits_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_timeout_test
     test/diff_drive_timeout.test
-    test/diff_drive_timeout_test.cpp)
+    test/diff_drive_timeout_test.cpp
+  )
   target_link_libraries(diff_drive_timeout_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest(test/diff_drive_multipliers.test)
+
   add_rostest(test/diff_drive_left_right_multipliers.test)
+
   add_rostest_gtest(diff_drive_fail_test
     test/diff_drive_wrong.test
-    test/diff_drive_fail_test.cpp)
+    test/diff_drive_fail_test.cpp
+  )
   target_link_libraries(diff_drive_fail_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_odom_tf_test
     test/diff_drive_odom_tf.test
-    test/diff_drive_odom_tf_test.cpp)
+    test/diff_drive_odom_tf_test.cpp
+  )
   target_link_libraries(diff_drive_odom_tf_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_default_cmd_vel_out_test
     test/diff_drive_default_cmd_vel_out.test
-    test/diff_drive_default_cmd_vel_out_test.cpp)
+    test/diff_drive_default_cmd_vel_out_test.cpp
+  )
   target_link_libraries(diff_drive_default_cmd_vel_out_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_pub_cmd_vel_out_test
     test/diff_drive_pub_cmd_vel_out.test
-    test/diff_drive_pub_cmd_vel_out_test.cpp)
+    test/diff_drive_pub_cmd_vel_out_test.cpp
+  )
   target_link_libraries(diff_drive_pub_cmd_vel_out_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_default_wheel_joint_controller_state_test
     test/diff_drive_default_wheel_joint_controller_state.test
-    test/diff_drive_default_wheel_joint_controller_state_test.cpp)
+    test/diff_drive_default_wheel_joint_controller_state_test.cpp
+  )
   target_link_libraries(diff_drive_default_wheel_joint_controller_state_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_publish_wheel_joint_controller_state_test
     test/diff_drive_publish_wheel_joint_controller_state.test
-    test/diff_drive_publish_wheel_joint_controller_state_test.cpp)
+    test/diff_drive_publish_wheel_joint_controller_state_test.cpp
+  )
   target_link_libraries(diff_drive_publish_wheel_joint_controller_state_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_default_odom_frame_test
     test/diff_drive_default_odom_frame.test
-    test/diff_drive_default_odom_frame_test.cpp)
+    test/diff_drive_default_odom_frame_test.cpp
+  )
   target_link_libraries(diff_drive_default_odom_frame_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_odom_frame_test
     test/diff_drive_odom_frame.test
-    test/diff_drive_odom_frame_test.cpp)
+    test/diff_drive_odom_frame_test.cpp
+  )
   target_link_libraries(diff_drive_odom_frame_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest_gtest(diff_drive_multiple_cmd_vel_publishers_test
     test/diff_drive_multiple_cmd_vel_publishers.test
-    test/diff_drive_multiple_cmd_vel_publishers_test.cpp)
+    test/diff_drive_multiple_cmd_vel_publishers_test.cpp
+  )
   target_link_libraries(diff_drive_multiple_cmd_vel_publishers_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
   add_rostest(test/diff_drive_open_loop.test)
+
   add_rostest(test/skid_steer_controller.test)
+
   add_rostest(test/skid_steer_no_wheels.test)
+
   add_rostest(test/diff_drive_radius_sphere.test)
+
   add_rostest(test/diff_drive_radius_param.test)
+
   add_rostest(test/diff_drive_radius_param_fail.test)
+
   add_rostest(test/diff_drive_separation_param.test)
+
   add_rostest(test/diff_drive_bad_urdf.test)
+
   add_rostest_gtest(diff_drive_dyn_reconf_test
     test/diff_drive_dyn_reconf.test
-    test/diff_drive_dyn_reconf_test.cpp)
+    test/diff_drive_dyn_reconf_test.cpp
+  )
   target_link_libraries(diff_drive_dyn_reconf_test ${catkin_LIBRARIES} ${test_LIBRARIES})
+
 endif()
+
+
+#############
+## Install ##
+#############
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install library
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+# Install plugins
+install(FILES diff_drive_controller_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -49,7 +49,6 @@
 #include <hardware_interface/joint_command_interface.h>
 #include <memory>
 #include <nav_msgs/Odometry.h>
-#include <pluginlib/class_list_macros.hpp>
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_publisher.h>
 #include <tf/tfMessage.h>
@@ -310,5 +309,4 @@ namespace diff_drive_controller{
                           double right_wheel_radius);
   };
 
-  PLUGINLIB_EXPORT_CLASS(diff_drive_controller::DiffDriveController, controller_interface::ControllerBase);
 } // namespace diff_drive_controller

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -15,18 +15,26 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>boost</depend>
   <depend>controller_interface</depend>
   <depend>control_msgs</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>geometry_msgs</depend>
+  <depend>hardware_interface</depend>
   <depend>nav_msgs</depend>
   <depend>realtime_tools</depend>
   <depend>tf</depend>
-  <depend>urdf</depend>
-  <depend>pluginlib</depend>
+
+  <build_depend>pluginlib</build_depend>
+  <build_depend>urdf</build_depend>
+
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>urdf</exec_depend>
 
   <test_depend>controller_manager</test_depend>
   <test_depend>rosgraph_msgs</test_depend>
   <test_depend>rostest</test_depend>
+  <test_depend>rostopic</test_depend>
   <test_depend>std_srvs</test_depend>
   <test_depend>xacro</test_depend>
 

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -20,7 +20,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>boost</depend>
   <depend>controller_interface</depend>
   <depend>control_msgs</depend>
   <depend>dynamic_reconfigure</depend>
@@ -30,8 +29,11 @@
   <depend>realtime_tools</depend>
   <depend>tf</depend>
 
+  <build_depend>boost</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>urdf</build_depend>
+
+  <build_export_depend>boost</build_export_depend>
 
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>urdf</exec_depend>

--- a/diff_drive_controller/package.xml
+++ b/diff_drive_controller/package.xml
@@ -1,7 +1,12 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>diff_drive_controller</name>
   <version>0.17.0</version>
   <description>Controller for a differential drive mobile base.</description>
+
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -38,6 +38,7 @@
 
 #include <cmath>
 #include <diff_drive_controller/diff_drive_controller.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <tf/transform_datatypes.h>
 #include <urdf/urdfdom_compatibility.h>
 #include <urdf_parser/urdf_parser.h>
@@ -832,3 +833,5 @@ namespace diff_drive_controller{
   }
 
 } // namespace diff_drive_controller
+
+PLUGINLIB_EXPORT_CLASS(diff_drive_controller::DiffDriveController, controller_interface::ControllerBase);

--- a/diff_drive_controller/test/diffbot.h
+++ b/diff_drive_controller/test/diffbot.h
@@ -32,7 +32,6 @@
 
 // ROS
 #include <ros/ros.h>
-#include <std_msgs/Float64.h>
 #include <std_srvs/Empty.h>
 
 // ros_control


### PR DESCRIPTION
Apply updates suggested in #513:

Clean dependencies (find missing/unnecessary dependencies)
Apply consistent format to package.xml and CMakeListst.txt
Fix major inconsistencies detected by catkin_lint (e.g. double find_package)