### PR TITLE
[melodic] Fix missing virtual destructor

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_builder.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_builder.h
@@ -63,6 +63,12 @@ namespace joint_trajectory_controller
 template<class SegmentImpl>
 class TrajectoryBuilder
 {
+public:
+  /**
+   * @brief Virtual destructor because this class is a base class.
+   */
+  virtual ~TrajectoryBuilder<SegmentImpl>() = default;
+
 private:
   using Segment               = JointTrajectorySegment<SegmentImpl>;
   using TrajectoryPerJoint    = std::vector<Segment>;
@@ -93,7 +99,7 @@ public:
    */
   virtual void reset();
 
-public: 
+public:
   /**
    * @brief Creates the type of trajectory described by the builder.
    *


### PR DESCRIPTION
This fixes this bug found by address sanitizer:

```c++
=================================================================
==11100==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x610000014340 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   184 bytes;
  size of the deallocated type: 32 bytes.
    #0 0x7f47993d79c8 in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe19c8)
    #1 0x7f47890e2dec in std::default_delete<joint_trajectory_controller::TrajectoryBuilder<trajectory_interface::QuinticSplineSegment<double> > >::operator()(joint_trajectory_controller::TrajectoryBuilder<trajectory_interface::QuinticSplineSegment<double> >*) const /usr/include/c++/7/bits/unique_ptr.h:78
    #2 0x7f47890e2dec in std::unique_ptr<joint_trajectory_controller::TrajectoryBuilder<trajectory_interface::QuinticSplineSegment<double> >, std::default_delete<joint_trajectory_controller::TrajectoryBuilder<trajectory_interface::QuinticSplineSegment<double> > > >::~unique_ptr() /usr/include/c++/7/bits/unique_ptr.h:263
    #3 0x7f47890e2dec in joint_trajectory_controller::JointTrajectoryController<trajectory_interface::QuinticSplineSegment<double>, hardware_interface::PositionJointInterface>::~JointTrajectoryController() /home/tyler/workspace/ws_ros_control/src/ros_controllers/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h:128
    #4 0x7f47890e31fe in virtual thunk to joint_trajectory_controller::JointTrajectoryController<trajectory_interface::QuinticSplineSegment<double>, hardware_interface::PositionJointInterface>::~JointTrajectoryController() (/home/tyler/workspace/ws_ros_control/devel/lib//libjoint_trajectory_controller.so+0xd01fe)
    #5 0x7f47990da0db in void class_loader::ClassLoader::onPluginDeletion<controller_interface::ControllerBase>(controller_interface::ControllerBase*) (/opt/ros/melodic/lib/libcontroller_manager.so+0x4c0db)
    #6 0x7f47990c6daf in std::_Sp_counted_deleter<controller_interface::ControllerBase*, std::function<void (controller_interface::ControllerBase*)>, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() (/opt/ros/melodic/lib/libcontroller_manager.so+0x38daf)
    #7 0x55563d16a0a4 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/7/bits/shared_ptr_base.h:154
    #8 0x55563d16a0a4 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/7/bits/shared_ptr_base.h:147
    #9 0x55563d16a0a4 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/7/bits/shared_ptr_base.h:684
    #10 0x55563d16a0a4 in std::__shared_ptr<controller_interface::ControllerBase, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/7/bits/shared_ptr_base.h:1123
    #11 0x55563d16a0a4 in std::shared_ptr<controller_interface::ControllerBase>::~shared_ptr() /usr/include/c++/7/bits/shared_ptr.h:93
    #12 0x55563d16a0a4 in controller_manager::ControllerSpec::~ControllerSpec() /opt/ros/melodic/include/controller_manager/controller_spec.h:51
    #13 0x55563d16a0a4 in void std::_Destroy<controller_manager::ControllerSpec>(controller_manager::ControllerSpec*) /usr/include/c++/7/bits/stl_construct.h:98
    #14 0x55563d16a0a4 in void std::_Destroy_aux<false>::__destroy<controller_manager::ControllerSpec*>(controller_manager::ControllerSpec*, controller_manager::ControllerSpec*) /usr/include/c++/7/bits/stl_construct.h:108
    #15 0x55563d16a0a4 in void std::_Destroy<controller_manager::ControllerSpec*>(controller_manager::ControllerSpec*, controller_manager::ControllerSpec*) /usr/include/c++/7/bits/stl_construct.h:137
    #16 0x55563d16a0a4 in void std::_Destroy<controller_manager::ControllerSpec*, controller_manager::ControllerSpec>(controller_manager::ControllerSpec*, controller_manager::ControllerSpec*, std::allocator<controller_manager::ControllerSpec>&) /usr/include/c++/7/bits/stl_construct.h:206
    #17 0x55563d16a0a4 in std::vector<controller_manager::ControllerSpec, std::allocator<controller_manager::ControllerSpec> >::~vector() /usr/include/c++/7/bits/stl_vector.h:434
    #18 0x55563d16a0a4 in controller_manager::ControllerManager::~ControllerManager() /opt/ros/melodic/include/controller_manager/controller_manager.h:78
    #19 0x55563d15394c in main /home/tyler/workspace/ws_ros_control/src/fake_joint/fake_joint_driver/src/fake_joint_driver_node.cpp:25
    #20 0x7f47978d6b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #21 0x55563d153c09 in _start (/home/tyler/workspace/ws_ros_control/devel/.private/fake_joint_driver/lib/fake_joint_driver/fake_joint_driver_node+0x10c09)

0x610000014340 is located 0 bytes inside of 184-byte region [0x610000014340,0x6100000143f8)
allocated by thread T5 here:
    #0 0x7f47993d6448 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0448)
    #1 0x7f4789206199 in joint_trajectory_controller::JointTrajectoryController<trajectory_interface::QuinticSplineSegment<double>, hardware_interface::PositionJointInterface>::init(hardware_interface::PositionJointInterface*, ros::NodeHandle&, ros::NodeHandle&) /home/tyler/workspace/ws_ros_control/src/ros_controllers/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h:322
    #2 0x7f47891cd41e in controller_interface::Controller<hardware_interface::PositionJointInterface>::initRequest(hardware_interface::RobotHW*, ros::NodeHandle&, ros::NodeHandle&, std::vector<hardware_interface::InterfaceResources, std::allocator<hardware_interface::InterfaceResources> >&) /opt/ros/melodic/include/controller_interface/controller.h:119
    #3 0x7f47990c1e7d in controller_manager::ControllerManager::loadController(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (/opt/ros/melodic/lib/libcontroller_manager.so+0x33e7d)
    #4 0x7f47990c31b2 in controller_manager::ControllerManager::loadControllerSrv(controller_manager_msgs::LoadControllerRequest_<std::allocator<void> >&, controller_manager_msgs::LoadControllerResponse_<std::allocator<void> >&) (/opt/ros/melodic/lib/libcontroller_manager.so+0x351b2)
    #5 0x7f47990d5fb5 in ros::ServiceCallbackHelperT<ros::ServiceSpec<controller_manager_msgs::LoadControllerRequest_<std::allocator<void> >, controller_manager_msgs::LoadControllerResponse_<std::allocator<void> > > >::call(ros::ServiceCallbackHelperCallParams&) (/opt/ros/melodic/lib/libcontroller_manager.so+0x47fb5)

Thread T5 created by T0 here:
    #0 0x7f479932dd2f in __interceptor_pthread_create (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x37d2f)
    #1 0x7f4795602b09 in boost::thread::start_thread_noexcept() (/usr/lib/x86_64-linux-gnu/libboost_thread.so.1.65.1+0x10b09)

SUMMARY: AddressSanitizer: new-delete-type-mismatch (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe19c8) in operator delete(void*, unsigned long)
==11100==HINT: if you don't care about these errors you may set ASAN_OPTIONS=new_delete_type_mismatch=0
==11100==ABORTING
```