### PR TITLE
[noetic] Fix missing virtual destructor

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_builder.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/trajectory_builder.h
@@ -63,6 +63,12 @@ namespace joint_trajectory_controller
 template<class SegmentImpl>
 class TrajectoryBuilder
 {
+public:
+  /**
+   * @brief Virtual destructor because this class is a base class.
+   */
+  virtual ~TrajectoryBuilder<SegmentImpl>() = default;
+
 private:
   using Segment               = JointTrajectorySegment<SegmentImpl>;
   using TrajectoryPerJoint    = std::vector<Segment>;
@@ -93,7 +99,7 @@ public:
    */
   virtual void reset();
 
-public: 
+public:
   /**
    * @brief Creates the type of trajectory described by the builder.
    *


### PR DESCRIPTION
forward port of this bug fix: https://github.com/ros-controls/ros_controllers/pull/517

This is just a cherry-pick of the commit from the other PR onto the noetic branch.  Because this repo doesn't have a master branch and I care about this fix making it into melodic (where I'm using ros_controllers) I originally made the pr against melodic-devel.  Please advise if I should have done this differently.