### PR TITLE
Fix joint_trajectory_controller tolerance tests

### DIFF
--- a/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
+++ b/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp
@@ -1338,7 +1338,7 @@ TEST_F(JointTrajectoryControllerTest, goalToleranceViolationSingleJoint)
 
   /*** JOINT0 ***/
   // Make robot respond with a delay on joint0
-  smoothings.data.assign({0.95, 0.});
+  smoothings.data.assign({0.97, 0.});
   smoothings_pub.publish(smoothings);
   ASSERT_TRUE(waitForRobotReady());
 


### PR DESCRIPTION
As highlighted by @dougsm at #497, the joint_trajectory_controller is comparing all joint tolerances to a single joint. The current [tests](https://github.com/ros-controls/ros_controllers/blob/b551a652147a2095a9d0391b100cbc0043fac2ec/joint_trajectory_controller/test/joint_trajectory_controller_test.cpp#L1179-L1258) do not capture this bug because the forced error is always applied to both joints of the robot through the [smoothing](https://github.com/ros-controls/ros_controllers/blob/b551a652147a2095a9d0391b100cbc0043fac2ec/joint_trajectory_controller/test/rrbot.cpp#L113-L145) parameter.

This update allows setting the smoothing factor to the rrbot's joints individually and tests the tolerance violation error caused by a deviation in only one of the joints.

The CI tests cannot pass against the current `noetic-devel` branch. However, it is supposed to pass against `dougsm:fix_jtc_tolerances` (from PR #497). I suggest running the CI tests here to verify that only the new added tests fail, then change the target branch to [`dougsm:fix_jtc_tolerances`](https://github.com/ros-controls/ros_controllers/pull/497)