### PR TITLE
Clean CMakeLists.txt and package.xml files of rqt_joint_trajectory_controller package

### DIFF
--- a/rqt_joint_trajectory_controller/CMakeLists.txt
+++ b/rqt_joint_trajectory_controller/CMakeLists.txt
@@ -1,18 +1,30 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(rqt_joint_trajectory_controller)
 
+# Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS)
+
 catkin_python_setup()
+
+# Declare a catkin package
 catkin_package()
 
+
+#############
+## Install ##
+#############
+
+# Install plugins
 install(FILES plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+# Intall extra
 install(DIRECTORY resource
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+# Install scripts
 catkin_install_python(PROGRAMS
   scripts/rqt_joint_trajectory_controller
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/rqt_joint_trajectory_controller/package.xml
+++ b/rqt_joint_trajectory_controller/package.xml
@@ -22,8 +22,8 @@
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>controller_manager_msgs</exec_depend>
   <exec_depend>python_qt_binding</exec_depend>
+  <exec_depend>python3-rospkg</exec_depend>
   <exec_depend>trajectory_msgs</exec_depend>
-  <exec_depend>rospkg</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>

--- a/rqt_joint_trajectory_controller/package.xml
+++ b/rqt_joint_trajectory_controller/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rqt_joint_trajectory_controller</name>
   <version>0.17.0</version>
   <description>Graphical frontend for interacting with joint_trajectory_controller instances.</description>
@@ -8,18 +11,23 @@
   <maintainer email="mathias.luedtke@ipa.fraunhofer.de">Mathias Lüdtke</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
 
-  <author email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodriguez Tsouroukdissian</author>
   <license>BSD</license>
+
   <url type="website">http://wiki.ros.org/rqt_joint_trajectory_controller</url>
+
+  <author email="adolfo.rodriguez@pal-robotics.com">Adolfo Rodriguez Tsouroukdissian</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <exec_depend>control_msgs</exec_depend>
   <exec_depend>controller_manager_msgs</exec_depend>
+  <exec_depend>python_qt_binding</exec_depend>
   <exec_depend>trajectory_msgs</exec_depend>
+  <exec_depend>rospkg</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
+  <exec_depend>qt_gui</exec_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>


### PR DESCRIPTION
Apply updates suggested in #513:

* Clean dependencies (find missing/unnecessary dependencies)
* Apply consistent format to package.xml and CMakeListst.txt
* Fix major inconsistencies detected by catkin_lint (e.g. double find_package)