### PR TITLE
Clean CMakeLists.txt and package.xml files of gripper_action_controller package

### DIFF
--- a/gripper_action_controller/CMakeLists.txt
+++ b/gripper_action_controller/CMakeLists.txt
@@ -9,19 +9,14 @@ endif()
 find_package(catkin
   REQUIRED COMPONENTS
       actionlib
-      angles
-      cmake_modules
-      controller_interface
-      controller_manager
       control_msgs
       control_toolbox
+      controller_interface
       hardware_interface
+      pluginlib
       realtime_tools
       roscpp
-      trajectory_msgs
       urdf
-      xacro
-      pluginlib
 )
 
 catkin_package(
@@ -29,38 +24,46 @@ INCLUDE_DIRS include
 LIBRARIES gripper_action_controller
 CATKIN_DEPENDS
   actionlib
-  cmake_modules
-  controller_interface
   control_msgs
+  control_toolbox
+  controller_interface
   hardware_interface
   realtime_tools
-  trajectory_msgs
+  roscpp
+  urdf
 )
 
-include_directories(
-  include ${catkin_INCLUDE_DIRS}
-)
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
+include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(gripper_action_controller
    src/gripper_action_controller.cpp
-   include/gripper_action_controller/gripper_action_controller.h
+)
+target_link_libraries(gripper_action_controller ${catkin_LIBRARIES})
+
+
+#############
+## Install ##
+#############
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-target_link_libraries(gripper_action_controller
- ${catkin_LIBRARIES}
-)
-
-# Install library
+# Install targets
 install(TARGETS gripper_action_controller
    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-)
-
+# Install plugins
 install(FILES ros_control_plugins.xml
    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller.h
@@ -39,9 +39,6 @@
 // ROS
 #include <ros/node_handle.h>
 
-// URDF
-#include <urdf/model.h>
-
 // ROS messages
 #include <control_msgs/GripperCommandAction.h>
 

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
@@ -29,6 +29,8 @@
 
 #pragma once
 
+// URDF
+#include <urdf/model.h>
 
 namespace gripper_action_controller
 {

--- a/gripper_action_controller/package.xml
+++ b/gripper_action_controller/package.xml
@@ -1,32 +1,35 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>gripper_action_controller</name>
   <version>0.17.0</version>
   <description>The gripper_action_controller package</description>
+
+  <license>BSD</license>
+
   <maintainer email="robot.moveit@gmail.com">Sachin Chitta</maintainer>
   <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
   <maintainer email="enrique.fernandez.perdomo@gmail.com">Enrique Fernandez</maintainer>
-
-  <license>BSD</license>
 
   <author email="robot.moveit@gmail.com">Sachin Chitta</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>actionlib</depend>
-  <depend>angles</depend>
-  <depend>cmake_modules</depend>
-  <depend>control_msgs</depend>
-  <depend>control_toolbox</depend>
   <depend>controller_interface</depend>
-  <depend>controller_manager</depend>
-  <depend>hardware_interface</depend>
+  <depend>control_toolbox</depend>
   <depend>realtime_tools</depend>
   <depend>roscpp</depend>
-  <depend>trajectory_msgs</depend>
   <depend>urdf</depend>
-  <depend>xacro</depend>
-  <depend>pluginlib</depend>
+
+  <build_depend>control_msgs</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+
+  <build_export_depend>control_msgs</build_export_depend>
+  <build_export_depend>hardware_interface</build_export_depend>
 
   <export>
     <controller_interface plugin="${prefix}/ros_control_plugins.xml"/>


### PR DESCRIPTION
Apply updates suggested in #513:

* Clean dependencies (find missing/unnecessary dependencies)
* Apply consistent format to package.xml and CMakeListst.txt
* Fix major inconsistencies detected by catkin_lint (e.g. double find_package)