### PR TITLE
Clean CMakeLists.txt and package.xml files of four_wheel_steering_controller package

### DIFF
--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -6,62 +6,119 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-set(${PROJECT_NAME}_CATKIN_DEPS
-    controller_interface
-    nav_msgs
-    four_wheel_steering_msgs
-    realtime_tools
-    tf
-    urdf_geometry_parser
-    pluginlib)
+# Load catkin and all dependencies required for this package
+find_package(catkin REQUIRED COMPONENTS 
+  controller_interface
+  four_wheel_steering_msgs
+  hardware_interface
+  nav_msgs
+  pluginlib
+  realtime_tools
+  roscpp
+  tf
+  urdf_geometry_parser
+)
 
-find_package(catkin REQUIRED COMPONENTS ${${PROJECT_NAME}_CATKIN_DEPS})
+find_package(Boost REQUIRED COMPONENTS headers)
 
+# Declare a catkin package
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS ${${PROJECT_NAME}_CATKIN_DEPS}
+  CATKIN_DEPENDS
+    controller_interface
+    four_wheel_steering_msgs
+    hardware_interface
+    nav_msgs
+    realtime_tools
+    roscpp
+    tf
+  DEPENDS Boost
 )
 
+
+###########
+## Build ##
+###########
+
+# Specify header include paths
 include_directories(
-  include ${catkin_INCLUDE_DIRS}
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME} src/four_wheel_steering_controller.cpp src/odometry.cpp src/speed_limiter.cpp)
+add_library(${PROJECT_NAME}
+  src/four_wheel_steering_controller.cpp
+  src/odometry.cpp
+  src/speed_limiter.cpp
+)
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
-# Install library
-install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-  )
 
-install(FILES four_wheel_steering_controller_plugins.xml
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+#############
+## Testing ##
+#############
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(catkin REQUIRED COMPONENTS rosgraph_msgs rostest std_srvs controller_manager tf)
-  include_directories(${catkin_INCLUDE_DIRS})
+  find_package(controller_manager REQUIRED)
+  find_package(geometry_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(std_srvs REQUIRED)
+  find_package(rosgraph_msgs REQUIRED)
+  find_package(rostest REQUIRED)
+  
+  include_directories(
+    ${controller_manager_INCLUDE_DIRS}
+    ${geometry_msgs_INCLUDE_DIRS}
+    ${std_msgs_INCLUDE_DIRS}
+    ${std_srvs_INCLUDE_DIRS}
+    ${rosgraph_msgs_INCLUDE_DIRS}
+  )
 
   add_executable(four_wheel_steering test/src/four_wheel_steering.cpp)
-  target_link_libraries(four_wheel_steering ${catkin_LIBRARIES})
+  target_link_libraries(four_wheel_steering ${catkin_LIBRARIES} ${controller_manager_LIBRARIES})
 
   add_dependencies(tests four_wheel_steering)
 
   add_rostest_gtest(four_wheel_steering_controller_twist_cmd_test
                     test/four_wheel_steering_controller_twist_cmd.test
-                    test/src/four_wheel_steering_twist_cmd_test.cpp)
+                    test/src/four_wheel_steering_twist_cmd_test.cpp
+  )
   target_link_libraries(four_wheel_steering_controller_twist_cmd_test ${catkin_LIBRARIES})
 
   add_rostest_gtest(four_wheel_steering_controller_4ws_cmd_test
                     test/four_wheel_steering_controller_4ws_cmd.test
-                    test/src/four_wheel_steering_4ws_cmd_test.cpp)
+                    test/src/four_wheel_steering_4ws_cmd_test.cpp
+  )
   target_link_libraries(four_wheel_steering_controller_4ws_cmd_test ${catkin_LIBRARIES})
 
   add_rostest_gtest(four_wheel_steering_wrong_config_test
                     test/four_wheel_steering_wrong_config.test
-                    test/src/four_wheel_steering_wrong_config.cpp)
+                    test/src/four_wheel_steering_wrong_config.cpp
+  )
   target_link_libraries(four_wheel_steering_wrong_config_test ${catkin_LIBRARIES})
 
 endif()
+
+
+#############
+## Install ##
+#############
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+# Install targets
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+)
+
+# Install plugins
+install(FILES four_wheel_steering_controller_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(catkin REQUIRED COMPONENTS
   urdf_geometry_parser
 )
 
-find_package(Boost REQUIRED COMPONENTS headers)
+find_package(Boost REQUIRED)
 
 # Declare a catkin package
 catkin_package(

--- a/four_wheel_steering_controller/include/four_wheel_steering_controller/four_wheel_steering_controller.h
+++ b/four_wheel_steering_controller/include/four_wheel_steering_controller/four_wheel_steering_controller.h
@@ -38,7 +38,6 @@
 
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/joint_command_interface.h>
-#include <pluginlib/class_list_macros.hpp>
 
 #include <nav_msgs/Odometry.h>
 #include <four_wheel_steering_msgs/FourWheelSteeringStamped.h>
@@ -231,5 +230,4 @@ namespace four_wheel_steering_controller{
 
   };
 
-  PLUGINLIB_EXPORT_CLASS(four_wheel_steering_controller::FourWheelSteeringController, controller_interface::ControllerBase);
 } // namespace four_wheel_steering_controller

--- a/four_wheel_steering_controller/package.xml
+++ b/four_wheel_steering_controller/package.xml
@@ -1,9 +1,13 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>four_wheel_steering_controller</name>
   <version>0.18.0</version>
   <description>Controller for a four wheel steering mobile base.</description>
+
   <maintainer email="vincent.rousseau@irstea.fr">Vincent Rousseau</maintainer>
-  <author email="vincent.rousseau@irstea.fr">Vincent Rousseau</author>
 
   <license>BSD</license>
 
@@ -11,20 +15,31 @@
   <url type="bugtracker">https://github.com/ros-controls/ros_controllers/issues</url>
   <url type="repository">https://github.com/ros-controls/ros_controllers</url>
 
+  <author email="vincent.rousseau@irstea.fr">Vincent Rousseau</author>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>controller_interface</depend>
-  <depend>nav_msgs</depend>
-  <depend>four_wheel_steering_msgs</depend>
   <depend>realtime_tools</depend>
+  <depend>roscpp</depend>
   <depend>tf</depend>
-  <depend>urdf_geometry_parser</depend>
-  <depend>pluginlib</depend>
 
+  <build_depend>four_wheel_steering_msgs</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>urdf_geometry_parser</build_depend>
+
+  <build_export_depend>four_wheel_steering_msgs</build_export_depend>
+  <build_export_depend>hardware_interface</build_export_depend>
+  <build_export_depend>nav_msgs</build_export_depend>
+
+  <test_depend>controller_manager</test_depend>
+  <test_depend>geometry_msgs</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>std_srvs</test_depend>
   <test_depend>rosgraph_msgs</test_depend>
   <test_depend>rostest</test_depend>
-  <test_depend>std_srvs</test_depend>
-  <test_depend>controller_manager</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/four_wheel_steering_controller/package.xml
+++ b/four_wheel_steering_controller/package.xml
@@ -26,12 +26,14 @@
 
   <build_depend>four_wheel_steering_msgs</build_depend>
   <build_depend>hardware_interface</build_depend>
+  <build_depend>libboost-dev</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_depend>urdf_geometry_parser</build_depend>
 
   <build_export_depend>four_wheel_steering_msgs</build_export_depend>
   <build_export_depend>hardware_interface</build_export_depend>
+  <build_export_depend>libboost-dev</build_export_depend>
   <build_export_depend>nav_msgs</build_export_depend>
 
   <test_depend>controller_manager</test_depend>

--- a/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
+++ b/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
@@ -35,6 +35,7 @@
 
 #include <cmath>
 #include <four_wheel_steering_controller/four_wheel_steering_controller.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <tf/transform_datatypes.h>
 #include <urdf_geometry_parser/urdf_geometry_parser.h>
 
@@ -671,3 +672,5 @@ namespace four_wheel_steering_controller{
   }
 
 } // namespace four_wheel_steering_controller
+
+PLUGINLIB_EXPORT_CLASS(four_wheel_steering_controller::FourWheelSteeringController, controller_interface::ControllerBase)

--- a/ros_controllers/package.xml
+++ b/ros_controllers/package.xml
@@ -1,4 +1,8 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>ros_controllers</name>
   <version>0.18.0</version>
   <description>Library of ros controllers</description>


### PR DESCRIPTION
Apply updates suggested in #513:

Clean dependencies (find missing/unnecessary dependencies)
Apply consistent format to package.xml and CMakeListst.txt
Fix major inconsistencies detected by catkin_lint (e.g. double find_package)

This PR also updates the package.xml of the meta-package to format 3

This is the last package, so it closes #513.