### PR TITLE
joint_trajectory_controller: add time_from_start feedback

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -784,7 +784,6 @@ updateStates(const ros::Time& sample_time, const Trajectory* const traj)
       state_error_.time_from_start = desired_state_.time_from_start - current_state_.time_from_start;
     }
 
-    state_error_.time_from_start = desired_state_.time_from_start - current_state_.time_from_start;
   }
 }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -807,6 +807,7 @@ setActionFeedback()
   current_active_goal->preallocated_feedback_->actual.time_from_start = ros::Duration(current_state_.time_from_start);
   current_active_goal->preallocated_feedback_->error.positions       = state_error_.position;
   current_active_goal->preallocated_feedback_->error.velocities      = state_error_.velocity;
+  current_active_goal->preallocated_feedback_->error.time_from_start = ros::Duration(state_error_.time_from_start);
   current_active_goal->setFeedback( current_active_goal->preallocated_feedback_ );
 
 }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -783,7 +783,6 @@ updateStates(const ros::Time& sample_time, const Trajectory* const traj)
       desired_state_.time_from_start = time_from_start;
       state_error_.time_from_start = desired_state_.time_from_start - current_state_.time_from_start;
     }
-
   }
 }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -781,6 +781,7 @@ updateStates(const ros::Time& sample_time, const Trajectory* const traj)
       const auto time_from_start = segment->timeFromStart();
       current_state_.time_from_start = sample_time.toSec() - segment->startTime() + time_from_start;
       desired_state_.time_from_start = time_from_start;
+      state_error_.time_from_start = desired_state_.time_from_start - current_state_.time_from_start;
     }
 
     state_error_.time_from_start = desired_state_.time_from_start - current_state_.time_from_start;

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -722,6 +722,7 @@ publishState(const ros::Time& time)
       state_publisher_->msg_.actual.time_from_start = ros::Duration(current_state_.time_from_start);
       state_publisher_->msg_.error.positions       = state_error_.position;
       state_publisher_->msg_.error.velocities      = state_error_.velocity;
+      state_publisher_->msg_.error.time_from_start = ros::Duration(state_error_.time_from_start);
 
       state_publisher_->unlockAndPublish();
     }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -782,6 +782,8 @@ updateStates(const ros::Time& sample_time, const Trajectory* const traj)
       current_state_.time_from_start = sample_time.toSec() - segment->startTime() + time_from_start;
       desired_state_.time_from_start = time_from_start;
     }
+
+    state_error_.time_from_start = desired_state_.time_from_start - current_state_.time_from_start;
   }
 }
 

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_segment.h
@@ -128,6 +128,8 @@ public:
         if (!point.velocities.empty())    {this->velocity[i]     = point.velocities[i];}
         if (!point.accelerations.empty()) {this->acceleration[i] = point.accelerations[i];}
       }
+
+      this->time_from_start = point.time_from_start.toSec();
     }
   };
 

--- a/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
+++ b/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
@@ -63,12 +63,14 @@ struct PosVelAccState
   PosVelAccState(const typename std::vector<Scalar>::size_type size)
     : position(    std::vector<Scalar>(size, static_cast<Scalar>(0))),
       velocity(    std::vector<Scalar>(size, static_cast<Scalar>(0))),
-      acceleration(std::vector<Scalar>(size, static_cast<Scalar>(0)))
+      acceleration(std::vector<Scalar>(size, static_cast<Scalar>(0))),
+      time_from_start(static_cast<Scalar>(0))
   {}
 
   std::vector<Scalar> position;
   std::vector<Scalar> velocity;
   std::vector<Scalar> acceleration;
+  Scalar time_from_start;
 };
 
 } // namespace

--- a/joint_trajectory_controller/include/trajectory_interface/quintic_spline_segment.h
+++ b/joint_trajectory_controller/include/trajectory_interface/quintic_spline_segment.h
@@ -61,7 +61,8 @@ public:
   QuinticSplineSegment()
     : coefs_(),
       duration_(static_cast<Scalar>(0)),
-      start_time_(static_cast<Scalar>(0))
+      start_time_(static_cast<Scalar>(0)),
+      time_from_start_(static_cast<Scalar>(0))
   {}
 
   /**
@@ -136,6 +137,9 @@ public:
   /** \return Segment end time. */
   Time endTime() const {return start_time_ + duration_;}
 
+  /** \return Segments time from trajectory start. */
+  Time timeFromStart() const {return time_from_start_;}
+
   /** \return Segment size (dimension). */
   unsigned int size() const {return coefs_.size();}
 
@@ -149,6 +153,7 @@ private:
   std::vector<SplineCoefficients> coefs_;
   Time duration_;
   Time start_time_;
+  Time time_from_start_;
 
   // These methods are borrowed from the previous controller's implementation
   // TODO: Clean their implementation, use the Horner algorithm for more numerically stable polynomial evaluation
@@ -220,6 +225,7 @@ void QuinticSplineSegment<ScalarType>::init(const Time&  start_time,
   // Time data
   start_time_ = start_time;
   duration_   = end_time - start_time;
+  time_from_start_ = start_state.time_from_start;
 
   // Spline coefficients
   coefs_.resize(dim);


### PR DESCRIPTION
The `current` state feedback gets the actual `time_from_start` and the interpolated time between the segments.
The `desired` state feedback gets the `time_from_start` of the beginning of the current segment.

I'm open for discussion what makes most sense, The current `time_from_start` is a must in my opinion. The actual start of the segment we are currently executing makes finding the source `JointTrajectoryPoint` in the trajectory easier. However, the desired states time is actually the same as the current one, as we are sampling with the current time.

An alternative option would be to make the end of the segment the desired `time_from_start` and also feed back the error `time_from_start` as the difference between the desired and current states time. But overall, that sounds confusing.

The current `time_from_start` is good enough for a client to find the source segment. However, requires more work, since we need to compare the timestamps.

fixes https://github.com/ros-controls/ros_controllers/issues/535