### PR TITLE
Use version-agnostic FindBoost macro for header-only usage

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-find_package(Boost REQUIRED COMPONENTS headers)
+find_package(Boost REQUIRED)
 
 find_package(urdfdom REQUIRED)
 

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
     urdf
 )
 
-find_package(Boost REQUIRED COMPONENTS headers)
+find_package(Boost REQUIRED)
 
 # Declare a catkin package
 generate_dynamic_reconfigure_options(cfg/DiffDriveController.cfg)


### PR DESCRIPTION
Should fix #537, though I don't have a Debian machine to actually test this on. But these changes bring `diff_drive_controller` and `ackermann_steering_controller` in line with `joint_trajectory_controller`, which builds fine, so I think it's pretty safe.

See https://github.com/ros-controls/ros_controllers/issues/537#issuecomment-736919602 for more details.