### PR TITLE
Add test for #532

### DIFF
--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -188,6 +188,8 @@ if (CATKIN_ENABLE_TESTING)
 
   add_rostest(test/diff_drive_bad_urdf.test)
 
+  add_rostest(test/diff_drive_get_wheel_radius_fail.test)
+
   add_rostest_gtest(diff_drive_dyn_reconf_test
     test/diff_drive_dyn_reconf.test
     test/diff_drive_dyn_reconf_test.cpp

--- a/diff_drive_controller/test/diff_drive_get_wheel_radius_fail.test
+++ b/diff_drive_controller/test/diff_drive_get_wheel_radius_fail.test
@@ -1,0 +1,18 @@
+<launch>
+  <!-- Load common test stuff -->
+  <include file="$(find diff_drive_controller)/test/diff_drive_common.launch" />
+
+  <!-- Override with wrong controller configuration -->
+  <rosparam command="load" file="$(find diff_drive_controller)/test/diffbot_wrong.yaml" />
+  <param name="diffbot_controller/wheel_separation" value="0.08"/>
+
+
+  <!-- Controller test -->
+  <test test-name="diff_drive_fail_test"
+        pkg="diff_drive_controller"
+        type="diff_drive_fail_test"
+        time-limit="10.0">
+    <remap from="cmd_vel" to="diffbot_controller/cmd_vel" />
+    <remap from="odom" to="diffbot_controller/odom" />
+  </test>
+</launch>


### PR DESCRIPTION
**Description:**
  - This adds the rostest `diff_drive_get_wheel_radius_fail.test` that covers the problem solved by  #532.

**Without the patch:** 
  -  Test would fail due a rostest timeout since DiffDriveController crashes when tries to dereference a nullpointer.

**Now:**
  - Test pass since it accomplishes the requirements stated by [diff_drive_fail_test.cpp](https://github.com/ros-controls/ros_controllers/blob/noetic-devel/diff_drive_controller/test/diff_drive_fail_test.cpp)