### PR TITLE
Improve flakey tests

### DIFF
--- a/ackermann_steering_controller/test/ackermann_steering_controller_test/ackermann_steering_controller_test.cpp
+++ b/ackermann_steering_controller/test/ackermann_steering_controller_test/ackermann_steering_controller_test.cpp
@@ -44,7 +44,7 @@ TEST_F(AckermannSteeringControllerTest, testForward)
   cmd_vel.linear.x = 0.0;
   cmd_vel.angular.z = 0.0;
   publish(cmd_vel);
-  ros::Duration(0.1).sleep();
+  ros::Duration(2.0).sleep();
   // get initial odom
   nav_msgs::Odometry old_odom = getLastOdom();
   // send a velocity command of 0.1 m/s
@@ -91,12 +91,12 @@ TEST_F(AckermannSteeringControllerTest, testTurn)
   cmd_vel.linear.x = 0.0;
   cmd_vel.angular.z = 0.0;
   publish(cmd_vel);
-  ros::Duration(0.1).sleep();
+  ros::Duration(2.0).sleep();
   // get initial odom
   nav_msgs::Odometry old_odom = getLastOdom();
   // send a velocity command
   cmd_vel.angular.z = M_PI/10.0;
-  // send linear command too 
+  // send linear command too
   // because sending only angular command doesn't actuate wheels for steer drive mechanism
   cmd_vel.linear.x = 0.1;
   publish(cmd_vel);

--- a/diff_drive_controller/test/diff_drive_test.cpp
+++ b/diff_drive_controller/test/diff_drive_test.cpp
@@ -41,7 +41,7 @@ TEST_F(DiffDriveControllerTest, testForward)
   cmd_vel.linear.x = 0.0;
   cmd_vel.angular.z = 0.0;
   publish(cmd_vel);
-  ros::Duration(0.1).sleep();
+  ros::Duration(2.0).sleep();
   // get initial odom
   nav_msgs::Odometry old_odom = getLastOdom();
   // send a velocity command of 0.1 m/s
@@ -90,7 +90,7 @@ TEST_F(DiffDriveControllerTest, testTurn)
   cmd_vel.linear.x = 0.0;
   cmd_vel.angular.z = 0.0;
   publish(cmd_vel);
-  ros::Duration(0.1).sleep();
+  ros::Duration(2.0).sleep();
   // get initial odom
   nav_msgs::Odometry old_odom = getLastOdom();
   // send a velocity command


### PR DESCRIPTION
Closes #547, and should make it much less painful to merge all the new CIs that test downstream packages.

The flakey `diff_drive_controller` and `ackermann_steering_controller` tests seem to be because the accumulator in the odometry isn't being fully reset. The control loop runs at 100Hz, and the odometry accumulators have a window size of 10. So our 0.1sec delay isn't always sufficient to fully clear out the accumulator.

2.0sec (Used already in many of the tests, just not all) is plenty long enough to ensure the accumulators are fully reset. I did a `colcon test --retest-until-fail 100` on those two packages and came up clean, so fingers crossed this is the last of the flakeyness.

---

There's some more opportunity for cleaning up these tests, and maybe "properly" resetting the accumulators by stopping and restarting the controller, but this should be enough to deal with those flakey failures that we've got at the moment. I will keep working on cleaning things up though.