### PR TITLE
User/wmmc88/fix diff drive controller nan check

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -541,7 +541,7 @@ namespace diff_drive_controller{
         return;
       }
 
-      if(!std::isfinite(command.angular.z) || !std::isfinite(command.angular.x))
+      if(!std::isfinite(command.angular.z) || !std::isfinite(command.linear.x))
       {
         ROS_WARN_THROTTLE(1.0, "Received NaN in velocity command. Ignoring.");
         return;

--- a/diff_drive_controller/test/diff_drive_nan_test.cpp
+++ b/diff_drive_controller/test/diff_drive_nan_test.cpp
@@ -91,6 +91,16 @@ TEST_F(DiffDriveControllerTest, testNaNCmd) {
   for (int i = 0; i < 10; ++i) {
     geometry_msgs::Twist cmd_vel;
     cmd_vel.linear.x = NAN;
+    cmd_vel.angular.z = 0.0;
+    publish(cmd_vel);
+    geometry_msgs::TwistStamped odom_msg = getLastCmdVelOut();
+    EXPECT_FALSE(std::isnan(odom_msg.twist.linear.x));
+    EXPECT_FALSE(std::isnan(odom_msg.twist.angular.z));
+    ros::Duration(0.1).sleep();
+  }
+  for (int i = 0; i < 10; ++i) {
+    geometry_msgs::Twist cmd_vel;
+    cmd_vel.linear.x = 0.0;
     cmd_vel.angular.z = NAN;
     publish(cmd_vel);
     geometry_msgs::TwistStamped odom_msg = getLastCmdVelOut();


### PR DESCRIPTION
diff_drive controller was checking the wrong member for finite values. The existing test was written such that it didn't test each branch in the if statement so it didn't catch the typo. 

