### PR TITLE
Check if max_allowed_effort is set before applying limits

### DIFF
--- a/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
+++ b/gripper_action_controller/include/gripper_action_controller/hardware_interface_adapter.h
@@ -175,7 +175,10 @@ public:
 
     // Update PIDs
       double command = pid_->computeCommand(error_position, error_velocity, period);
-      command = std::min<double>(fabs(max_allowed_effort), std::max<double>(-fabs(max_allowed_effort), command));
+      if (max_allowed_effort)
+      {
+        command = std::min<double>(fabs(max_allowed_effort), std::max<double>(-fabs(max_allowed_effort), command));
+      }
       (*joint_handle_ptr_).setCommand(command);
       return command;
   }


### PR DESCRIPTION
By default, the max_effort value is zero, and it does not allow to the gripper to move in the current implementation.