### PR TITLE
Add guard to dt negative case and break the controller for safety

### DIFF
--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -322,7 +322,7 @@ namespace ackermann_steering_controller{
 
     // Limit velocities and accelerations:
     const double cmd_dt = (period.toSec() > 0) ? period.toSec() : 0.0;
-    if(cmd_dt < 0)
+    if(period.toSec() < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");
     }

--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -321,7 +321,7 @@ namespace ackermann_steering_controller{
     }
 
     // Limit velocities and accelerations:
-    const double cmd_dt(period.toSec());
+    const double cmd_dt = (period.toSec() > 0) ? period.toSec() : 0.0;
     if(cmd_dt < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");

--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -322,6 +322,12 @@ namespace ackermann_steering_controller{
 
     // Limit velocities and accelerations:
     const double cmd_dt(period.toSec());
+    if(cmd_dt < 0)
+    {
+      ROS_ERROR("Invalid time interval, delta time cannot be negative");
+      curr_cmd.lin = 0.0;
+      curr_cmd.ang = 0.0;
+    }
 
     limiter_lin_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, cmd_dt);
     limiter_ang_.limit(curr_cmd.ang, last0_cmd_.ang, last1_cmd_.ang, cmd_dt);

--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -325,8 +325,6 @@ namespace ackermann_steering_controller{
     if(cmd_dt < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");
-      curr_cmd.lin = 0.0;
-      curr_cmd.ang = 0.0;
     }
 
     limiter_lin_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, cmd_dt);

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -471,6 +471,12 @@ namespace diff_drive_controller{
 
     // Limit velocities and accelerations:
     const double cmd_dt(period.toSec());
+    if(cmd_dt < 0)
+    {
+      ROS_ERROR("Invalid time interval, delta time cannot be negative");
+      curr_cmd.lin = 0.0;
+      curr_cmd.ang = 0.0;
+    }
 
     limiter_lin_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, cmd_dt);
     limiter_ang_.limit(curr_cmd.ang, last0_cmd_.ang, last1_cmd_.ang, cmd_dt);

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -470,7 +470,7 @@ namespace diff_drive_controller{
     }
 
     // Limit velocities and accelerations:
-    const double cmd_dt(period.toSec());
+    const double cmd_dt = (period.toSec() > 0) ? period.toSec() : 0.0;
     if(cmd_dt < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -474,8 +474,6 @@ namespace diff_drive_controller{
     if(cmd_dt < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");
-      curr_cmd.lin = 0.0;
-      curr_cmd.ang = 0.0;
     }
 
     limiter_lin_.limit(curr_cmd.lin, last0_cmd_.lin, last1_cmd_.lin, cmd_dt);

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -471,7 +471,7 @@ namespace diff_drive_controller{
 
     // Limit velocities and accelerations:
     const double cmd_dt = (period.toSec() > 0) ? period.toSec() : 0.0;
-    if(cmd_dt < 0)
+    if(period.toSec() > 0 < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");
     }

--- a/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
+++ b/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
@@ -363,7 +363,7 @@ namespace four_wheel_steering_controller{
     }
 
     const double cmd_dt = (period.toSec() > 0) ? period.toSec() : 0.0;
-    if(cmd_dt < 0)
+    if(period.toSec() < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");
     }

--- a/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
+++ b/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
@@ -366,12 +366,6 @@ namespace four_wheel_steering_controller{
     if(cmd_dt < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");
-      curr_cmd_twist.lin_x = 0.0;
-      curr_cmd_twist.lin_y = 0.0;
-      curr_cmd_twist.ang = 0.0;
-      curr_cmd_4ws.lin = 0.0;
-      curr_cmd_4ws.front_steering = 0.0;
-      curr_cmd_4ws.rear_steering = 0.0;
     }
 
     const double angular_speed = odometry_.getAngular();

--- a/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
+++ b/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
@@ -362,7 +362,7 @@ namespace four_wheel_steering_controller{
       curr_cmd_4ws.rear_steering = 0.0;
     }
 
-    const double cmd_dt(period.toSec());
+    const double cmd_dt = (period.toSec() > 0) ? period.toSec() : 0.0;
     if(cmd_dt < 0)
     {
       ROS_ERROR("Invalid time interval, delta time cannot be negative");

--- a/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
+++ b/four_wheel_steering_controller/src/four_wheel_steering_controller.cpp
@@ -363,6 +363,16 @@ namespace four_wheel_steering_controller{
     }
 
     const double cmd_dt(period.toSec());
+    if(cmd_dt < 0)
+    {
+      ROS_ERROR("Invalid time interval, delta time cannot be negative");
+      curr_cmd_twist.lin_x = 0.0;
+      curr_cmd_twist.lin_y = 0.0;
+      curr_cmd_twist.ang = 0.0;
+      curr_cmd_4ws.lin = 0.0;
+      curr_cmd_4ws.front_steering = 0.0;
+      curr_cmd_4ws.rear_steering = 0.0;
+    }
 
     const double angular_speed = odometry_.getAngular();
     const double steering_track = track_-2*wheel_steering_y_offset_;


### PR DESCRIPTION
Hi,

This PR adds a guard to the case when the time step on the diff_drive_controller is computed as negative due to some error coming from the hardware interface, as in https://github.com/ros-controls/ros_controllers/issues/561

At my company we are experiencing the same backward movement behavior but less consistent and less predicable. This safe guards the controller to this type of error, what can be common given we are also experiencing the same issue.