### PR TITLE
Add service to reset odometry

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -52,7 +52,7 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_publisher.h>
-#include <std_srvs/Trigger.h>
+#include <std_msgs/Bool.h>
 #include <tf/tfMessage.h>
 
 namespace diff_drive_controller{
@@ -143,7 +143,7 @@ namespace diff_drive_controller{
     /// Odometry related:
     std::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::Odometry> > odom_pub_;
     std::shared_ptr<realtime_tools::RealtimePublisher<tf::tfMessage> > tf_odom_pub_;
-    ros::ServiceServer reset_odometry_srv_;
+    ros::Subscriber sub_reset_odometry_;
     Odometry odometry_;
 
     /// Controller state publisher
@@ -189,6 +189,9 @@ namespace diff_drive_controller{
 
     /// Publish wheel data:
     bool publish_wheel_joint_controller_state_;
+
+    /// Reset odometry state
+    bool reset_odometry_;
 
     // A struct to hold dynamic parameters
     // set from dynamic_reconfigure server
@@ -254,7 +257,7 @@ namespace diff_drive_controller{
     /**
      * \brief Reset Odometry internal state callback
      */
-    bool resetOdometryCallback(std_srvs::TriggerRequest &req, std_srvs::TriggerResponse &res);
+    void resetOdometryCallback(const std_msgs::Bool::ConstPtr& msg);
 
     /**
      * \brief Get the wheel names from a wheel param

--- a/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
+++ b/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.h
@@ -52,6 +52,7 @@
 #include <pluginlib/class_list_macros.hpp>
 #include <realtime_tools/realtime_buffer.h>
 #include <realtime_tools/realtime_publisher.h>
+#include <std_srvs/Trigger.h>
 #include <tf/tfMessage.h>
 
 namespace diff_drive_controller{
@@ -142,6 +143,7 @@ namespace diff_drive_controller{
     /// Odometry related:
     std::shared_ptr<realtime_tools::RealtimePublisher<nav_msgs::Odometry> > odom_pub_;
     std::shared_ptr<realtime_tools::RealtimePublisher<tf::tfMessage> > tf_odom_pub_;
+    ros::ServiceServer reset_odometry_srv_;
     Odometry odometry_;
 
     /// Controller state publisher
@@ -248,6 +250,11 @@ namespace diff_drive_controller{
      * \param command Velocity command message (twist)
      */
     void cmdVelCallback(const geometry_msgs::Twist& command);
+
+    /**
+     * \brief Reset Odometry internal state callback
+     */
+    bool resetOdometryCallback(std_srvs::TriggerRequest &req, std_srvs::TriggerResponse &res);
 
     /**
      * \brief Get the wheel names from a wheel param

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -153,6 +153,11 @@ namespace diff_drive_controller
      */
     void setVelocityRollingWindowSize(size_t velocity_rolling_window_size);
 
+    /**
+     * \brief Reset Odometry internal state
+     */
+    void resetInternalState();
+
   private:
 
     /// Rolling mean accumulator and window:
@@ -198,6 +203,8 @@ namespace diff_drive_controller
     /// Previou wheel position/state [rad]:
     double left_wheel_old_pos_;
     double right_wheel_old_pos_;
+
+    bool first_data_;
 
     /// Rolling mean accumulators for the linar and angular velocities:
     size_t velocity_rolling_window_size_;

--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -155,8 +155,11 @@ namespace diff_drive_controller
 
     /**
      * \brief Reset Odometry internal state
+    * \param left_pos  Left  wheel position [rad] in which the system will be reset to
+     * \param right_pos Right wheel position [rad] in which the system will be reset to
+     * \param time      Current time in which the system will be reset to
      */
-    void resetInternalState();
+    void resetInternalState(double left_pos, double right_pos, const ros::Time &time);
 
   private:
 
@@ -204,7 +207,7 @@ namespace diff_drive_controller
     double left_wheel_old_pos_;
     double right_wheel_old_pos_;
 
-    bool first_data_;
+    bool reset_odometry_;
 
     /// Rolling mean accumulators for the linar and angular velocities:
     size_t velocity_rolling_window_size_;

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -353,6 +353,7 @@ namespace diff_drive_controller{
     }
 
     sub_command_ = controller_nh.subscribe("cmd_vel", 1, &DiffDriveController::cmdVelCallback, this);
+    reset_odometry_srv_ = controller_nh.advertiseService("/reset_odometry", &DiffDriveController::resetOdometryCallback, this);
 
     // Initialize dynamic parameters
     DynamicParams dynamic_params;
@@ -829,6 +830,14 @@ namespace diff_drive_controller{
 
       controller_state_pub_->unlockAndPublish();
     }
+  }
+
+  bool DiffDriveController::resetOdometryCallback(std_srvs::TriggerRequest &req, std_srvs::TriggerResponse &res)
+  {
+    brake();
+    odometry_.resetInternalState();
+    res.success = true;
+    return true;
   }
 
 } // namespace diff_drive_controller

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -159,6 +159,7 @@ namespace diff_drive_controller{
     , wheel_joints_size_(0)
     , publish_cmd_(false)
     , publish_wheel_joint_controller_state_(false)
+    , reset_odometry_(false)
   {
   }
 
@@ -353,7 +354,7 @@ namespace diff_drive_controller{
     }
 
     sub_command_ = controller_nh.subscribe("cmd_vel", 1, &DiffDriveController::cmdVelCallback, this);
-    reset_odometry_srv_ = controller_nh.advertiseService("/reset_odometry", &DiffDriveController::resetOdometryCallback, this);
+    sub_reset_odometry_ = controller_nh.subscribe("reset_odometry", 1, &DiffDriveController::resetOdometryCallback, this);
 
     // Initialize dynamic parameters
     DynamicParams dynamic_params;
@@ -422,6 +423,13 @@ namespace diff_drive_controller{
       right_pos /= wheel_joints_size_;
 
       // Estimate linear and angular velocity using joint information
+      if(reset_odometry_)
+      {
+        brake();
+        odometry_.resetInternalState(left_pos, right_pos, time);
+        reset_odometry_ = false;
+      }
+
       odometry_.update(left_pos, right_pos, time);
     }
 
@@ -832,12 +840,9 @@ namespace diff_drive_controller{
     }
   }
 
-  bool DiffDriveController::resetOdometryCallback(std_srvs::TriggerRequest &req, std_srvs::TriggerResponse &res)
+  void DiffDriveController::resetOdometryCallback(const std_msgs::Bool::ConstPtr& msg)
   {
-    brake();
-    odometry_.resetInternalState();
-    res.success = true;
-    return true;
+    reset_odometry_ = msg->data;
   }
 
 } // namespace diff_drive_controller

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -59,6 +59,7 @@ namespace diff_drive_controller
   , right_wheel_radius_(0.0)
   , left_wheel_old_pos_(0.0)
   , right_wheel_old_pos_(0.0)
+  , first_data_(true)
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
@@ -75,6 +76,15 @@ namespace diff_drive_controller
 
   bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)
   {
+    if(first_data_)
+    {
+      left_wheel_old_pos_  = left_pos  * left_wheel_radius_;
+      right_wheel_old_pos_ = right_pos * right_wheel_radius_;
+      timestamp_ = time;
+      first_data_ = false;
+      return true;
+    }
+
     /// Get current wheel joint positions:
     const double left_wheel_cur_pos  = left_pos  * left_wheel_radius_;
     const double right_wheel_cur_pos = right_pos * right_wheel_radius_;
@@ -171,6 +181,15 @@ namespace diff_drive_controller
   {
     linear_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
     angular_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+  }
+
+  void Odometry::resetInternalState()
+  {
+    resetAccumulators();
+    x_ = 0.0;
+    y_ = 0.0;
+    heading_ = 0.0;
+    first_data_ = true;
   }
 
 } // namespace diff_drive_controller

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -59,7 +59,6 @@ namespace diff_drive_controller
   , right_wheel_radius_(0.0)
   , left_wheel_old_pos_(0.0)
   , right_wheel_old_pos_(0.0)
-  , first_data_(true)
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
@@ -76,15 +75,6 @@ namespace diff_drive_controller
 
   bool Odometry::update(double left_pos, double right_pos, const ros::Time &time)
   {
-    if(first_data_)
-    {
-      left_wheel_old_pos_  = left_pos  * left_wheel_radius_;
-      right_wheel_old_pos_ = right_pos * right_wheel_radius_;
-      timestamp_ = time;
-      first_data_ = false;
-      return true;
-    }
-
     /// Get current wheel joint positions:
     const double left_wheel_cur_pos  = left_pos  * left_wheel_radius_;
     const double right_wheel_cur_pos = right_pos * right_wheel_radius_;
@@ -183,13 +173,15 @@ namespace diff_drive_controller
     angular_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
   }
 
-  void Odometry::resetInternalState()
+  void Odometry::resetInternalState(double left_pos, double right_pos, const ros::Time &time)
   {
     resetAccumulators();
     x_ = 0.0;
     y_ = 0.0;
     heading_ = 0.0;
-    first_data_ = true;
+    left_wheel_old_pos_  = left_pos  * left_wheel_radius_;
+    right_wheel_old_pos_ = right_pos * right_wheel_radius_;
+    timestamp_ = time;
   }
 
 } // namespace diff_drive_controller


### PR DESCRIPTION
**Why:**
The odometry state relies on the assumption that the node that implements the controller_manager interface has the same life cycle as it. In other words is assumes that the internal state is zero and any incoming messages are due robot movement. However this is not true when restarting the nodes but not the actual physical system. In this case the first reading of encoder position will be the current encoder position of the controller, what will be interpreted as being a valid input and will generate a spike in velocity, moving the internal state to a position far way from the origin. 

**How:**
This PR exposes a service to reset the odometry state of the diff_drive_controller. This allow us to reset the odometry in cases when you have to restart your system, but the actual controller is not resetted.
To overcome the initialization issue, the first reading of the controller will also be considered as an offset. This also ensures that no jump will occur when resetting the odometry state. 