### PR TITLE
Fix one joint trajectory controller case of std::runtime_error Duration is out of dual 32-bit range

### DIFF
--- a/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
+++ b/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
@@ -70,7 +70,7 @@ struct PosVelAccState
   std::vector<Scalar> position;
   std::vector<Scalar> velocity;
   std::vector<Scalar> acceleration;
-  Scalar time_from_start;
+  Scalar time_from_start = Scalar(0);
 };
 
 } // namespace


### PR DESCRIPTION
I was able to pin down the exception to a ros::Duration with an uninitialized double- possibly random bits will sometimes produce a usable value, but on my system the exception was very frequent.

Probably this has been lurking here since `time_from_start` was introduced 7fac696617a05eca4fa9a7fec401c17202664788

There are some issues and answers posts with the same exception that probably are a similar cause (in one there's an uninitialized `Rate` object which it sounded like the user corrected in their own code, but really Rate should always initialize to 0), but predate this particular one.