### PR TITLE
Ensure zero initialization of PosVelAccState::time_from_start

### DIFF
--- a/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
+++ b/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h
@@ -63,14 +63,13 @@ struct PosVelAccState
   PosVelAccState(const typename std::vector<Scalar>::size_type size)
     : position(    std::vector<Scalar>(size, static_cast<Scalar>(0))),
       velocity(    std::vector<Scalar>(size, static_cast<Scalar>(0))),
-      acceleration(std::vector<Scalar>(size, static_cast<Scalar>(0))),
-      time_from_start(static_cast<Scalar>(0))
+      acceleration(std::vector<Scalar>(size, static_cast<Scalar>(0)))
   {}
 
   std::vector<Scalar> position;
   std::vector<Scalar> velocity;
   std::vector<Scalar> acceleration;
-  Scalar time_from_start;
+  Scalar time_from_start{ static_cast<Scalar>(0) };
 };
 
 } // namespace


### PR DESCRIPTION
On a very specific setup using joint_trajectory_controller, I started to get strange random crashes with:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Duration is out of dual 32-bit range
```

Digging a bit, it seems that the program terminates [here](https://github.com/ros-controls/ros_controllers/blob/aa9c32b8ea8f83cb578cde82619f78e720fef89c/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L719) because of an uninitialized `PosVelAccState::time_from_start`.

Further digging showed that the problematic _state_ had been default constructed [here](https://github.com/ros-controls/ros_controllers/blob/aa9c32b8ea8f83cb578cde82619f78e720fef89c/joint_trajectory_controller/include/joint_trajectory_controller/init_joint_trajectory.h#L418), and checking the default constructor I can see that `time_from_start` [is never initialized](https://github.com/ros-controls/ros_controllers/blob/aa9c32b8ea8f83cb578cde82619f78e720fef89c/joint_trajectory_controller/include/trajectory_interface/pos_vel_acc_state.h#L47).

This seems to fix the problem for me, although it's difficult to confirm because the error is hard to reproduce reliably.