### PR TITLE
Updated ackermann_steering_controller tests launch file to use robot_…

### DIFF
--- a/ackermann_steering_controller/test/common/launch/view_ackermann_steering_bot.launch
+++ b/ackermann_steering_controller/test/common/launch/view_ackermann_steering_bot.launch
@@ -28,6 +28,6 @@
 	args="-urdf -model ackermann_steering_bot -param robot_description -z 0.5"/>
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" required="true" args="-d $(find ackermann_steering_controller)/test/common/rviz/display.rviz"/>
 </launch>


### PR DESCRIPTION
…her rather than state_publisher which is no longer available in Noetic.

I was getting the following error trying to launch `view_ackermann_steering_bot.launch`:
```
ERROR: cannot launch node of type [robot_state_publisher/state_publisher]: Cannot locate node of 
type [state_publisher] in package [robot_state_publisher]. Make sure file exists in package path 
and permission is set to executable (chmod +x)
```
