### PR TITLE
changes for modern system environment (Ubuntu 22.04+)

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(ackermann_steering_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   controller_interface

--- a/diff_drive_controller/CMakeLists.txt
+++ b/diff_drive_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(diff_drive_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
     controller_interface

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -382,7 +382,8 @@ namespace diff_drive_controller{
     dyn_reconf_server_->updateConfig(config);
     dyn_reconf_server_mutex_.unlock();
 
-    dyn_reconf_server_->setCallback(boost::bind(&DiffDriveController::reconfCallback, this, _1, _2));
+    dyn_reconf_server_->setCallback(
+        boost::bind(&DiffDriveController::reconfCallback, this, boost::placeholders::_1, boost::placeholders::_2));
 
     return true;
   }

--- a/effort_controllers/CMakeLists.txt
+++ b/effort_controllers/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(effort_controllers)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   angles

--- a/force_torque_sensor_controller/CMakeLists.txt
+++ b/force_torque_sensor_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(force_torque_sensor_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   controller_interface

--- a/forward_command_controller/CMakeLists.txt
+++ b/forward_command_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(forward_command_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   controller_interface

--- a/four_wheel_steering_controller/CMakeLists.txt
+++ b/four_wheel_steering_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(four_wheel_steering_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS 
   controller_interface

--- a/gripper_action_controller/CMakeLists.txt
+++ b/gripper_action_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(gripper_action_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 find_package(catkin
   REQUIRED COMPONENTS
       actionlib

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
@@ -213,10 +213,9 @@ bool GripperActionController<HardwareInterface>::init(HardwareInterface* hw,
   pre_alloc_result_->stalled = false;
 
   // ROS API: Action interface
-  action_server_.reset(new ActionServer(controller_nh_, "gripper_cmd",
-					boost::bind(&GripperActionController::goalCB,   this, _1),
-					boost::bind(&GripperActionController::cancelCB, this, _1),
-					false));
+  action_server_.reset(new ActionServer(
+      controller_nh_, "gripper_cmd", boost::bind(&GripperActionController::goalCB, this, boost::placeholders::_1),
+      boost::bind(&GripperActionController::cancelCB, this, boost::placeholders::_1), false));
   action_server_->start();
   return true;
 }

--- a/imu_sensor_controller/CMakeLists.txt
+++ b/imu_sensor_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(imu_sensor_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   controller_interface

--- a/joint_state_controller/CMakeLists.txt
+++ b/joint_state_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(joint_state_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   controller_interface

--- a/joint_trajectory_controller/CMakeLists.txt
+++ b/joint_trajectory_controller/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(joint_trajectory_controller)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin
   REQUIRED COMPONENTS

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -293,10 +293,10 @@ bool JointTrajectoryController<SegmentImpl, HardwareInterface>::init(HardwareInt
   state_publisher_.reset(new StatePublisher(controller_nh_, "state", 1));
 
   // ROS API: Action interface
-  action_server_.reset(new ActionServer(controller_nh_, "follow_joint_trajectory",
-                                        boost::bind(&JointTrajectoryController::goalCB,   this, _1),
-                                        boost::bind(&JointTrajectoryController::cancelCB, this, _1),
-                                        false));
+  action_server_.reset(
+      new ActionServer(controller_nh_, "follow_joint_trajectory",
+                       boost::bind(&JointTrajectoryController::goalCB, this, boost::placeholders::_1),
+                       boost::bind(&JointTrajectoryController::cancelCB, this, boost::placeholders::_1), false));
   action_server_->start();
 
   // ROS API: Provided services

--- a/position_controllers/CMakeLists.txt
+++ b/position_controllers/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(position_controllers)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   forward_command_controller

--- a/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/joint_trajectory_controller.py
+++ b/rqt_joint_trajectory_controller/src/rqt_joint_trajectory_controller/joint_trajectory_controller.py
@@ -155,27 +155,27 @@ class JointTrajectoryController(Plugin):
 
         # Timer for sending commands to active controller
         self._update_cmd_timer = QTimer(self)
-        self._update_cmd_timer.setInterval(1000.0 / self._cmd_pub_freq)
+        self._update_cmd_timer.setInterval(int(1000.0 / self._cmd_pub_freq))
         self._update_cmd_timer.timeout.connect(self._update_cmd_cb)
 
         # Timer for updating the joint widgets from the controller state
         self._update_act_pos_timer = QTimer(self)
-        self._update_act_pos_timer.setInterval(1000.0 /
-                                               self._widget_update_freq)
+        self._update_act_pos_timer.setInterval(int(1000.0 /
+                                               self._widget_update_freq))
         self._update_act_pos_timer.timeout.connect(self._update_joint_widgets)
 
         # Timer for controller manager updates
         self._list_cm = ControllerManagerLister()
         self._update_cm_list_timer = QTimer(self)
-        self._update_cm_list_timer.setInterval(1000.0 /
-                                               self._ctrlrs_update_freq)
+        self._update_cm_list_timer.setInterval(int(1000.0 /
+                                               self._ctrlrs_update_freq))
         self._update_cm_list_timer.timeout.connect(self._update_cm_list)
         self._update_cm_list_timer.start()
 
         # Timer for running controller updates
         self._update_jtc_list_timer = QTimer(self)
-        self._update_jtc_list_timer.setInterval(1000.0 /
-                                                self._ctrlrs_update_freq)
+        self._update_jtc_list_timer.setInterval(int(1000.0 /
+                                                self._ctrlrs_update_freq))
         self._update_jtc_list_timer.timeout.connect(self._update_jtc_list)
         self._update_jtc_list_timer.start()
 

--- a/velocity_controllers/CMakeLists.txt
+++ b/velocity_controllers/CMakeLists.txt
@@ -1,11 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(velocity_controllers)
 
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Load catkin and all dependencies required for this package
 find_package(catkin REQUIRED COMPONENTS
   angles


### PR DESCRIPTION
These changes are needed to compile&use the packages sucessfully for [ros-o](https://github.com/ros-o) on Ubuntu 22.04 and upwards.

This PR subsumes #587 .