### PR TITLE
Updated to use nodehandle in urdf parsing, which allows to use namespace for robot_description.

### DIFF
--- a/effort_controllers/src/joint_group_position_controller.cpp
+++ b/effort_controllers/src/joint_group_position_controller.cpp
@@ -76,7 +76,7 @@ namespace effort_controllers
 
     // Get URDF
     urdf::Model urdf;
-    if (!urdf.initParam("robot_description"))
+    if (!urdf.initParamWithNodeHandle("robot_description", n))
     {
       ROS_ERROR("Failed to parse urdf file");
       return false;


### PR DESCRIPTION
Refer the ROS question where I was facing an error with the namespaces while working with the group position controller.
https://answers.ros.org/question/397126/robot_description-not-found-on-parameter-server-while-launching-the-controller/