### PR TITLE
Fix joint trajectory controller so results message is returned on tolerance failures

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -406,6 +406,8 @@ update(const ros::Time& time, const ros::Duration& period)
           rt_segment_goal->preallocated_result_->error_code =
           control_msgs::FollowJointTrajectoryResult::PATH_TOLERANCE_VIOLATED;
           rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
+          // Force this to run before destroying rt_active_goal_ so results message is returned
+          rt_active_goal_->runNonRealtime(ros::TimerEvent());
           rt_active_goal_.reset();
           successful_joint_traj_.reset();
         }
@@ -441,6 +443,8 @@ update(const ros::Time& time, const ros::Duration& period)
 
           rt_segment_goal->preallocated_result_->error_code = control_msgs::FollowJointTrajectoryResult::GOAL_TOLERANCE_VIOLATED;
           rt_segment_goal->setAborted(rt_segment_goal->preallocated_result_);
+          // Force this to run before destroying rt_active_goal_ so results message is returned
+          rt_active_goal_->runNonRealtime(ros::TimerEvent());
           rt_active_goal_.reset();
           successful_joint_traj_.reset();
         }


### PR DESCRIPTION
Ran into an issue where results message was not being returned in the event of a tolerance failure. The following changes solved the issue so it is always returned.

Related [issue](https://github.com/ros-controls/ros_controllers/issues/487)