### PR TITLE
Increase spin box to six decimals

### DIFF
--- a/rqt_joint_trajectory_controller/resource/double_editor.ui
+++ b/rqt_joint_trajectory_controller/resource/double_editor.ui
@@ -83,6 +83,9 @@
      <property name="keyboardTracking">
       <bool>false</bool>
      </property>
+     <property name="decimals">
+      <number>6</number>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
Currently the spin box only provides 2 decimals which does not seem to be enough especially if you are dealing with linear axes(1 cm resolution).