### PR TITLE
use boost::placeholders::_1/_2 in remaining instances

### DIFF
--- a/ackermann_steering_controller/src/odometry.cpp
+++ b/ackermann_steering_controller/src/odometry.cpp
@@ -42,8 +42,6 @@
 
 #include <ackermann_steering_controller/odometry.h>
 
-#include <boost/bind/bind.hpp>
-
 namespace ackermann_steering_controller
 {
   namespace bacc = boost::accumulators;
@@ -61,7 +59,7 @@ namespace ackermann_steering_controller
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
-  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, boost::placeholders::_1, boost::placeholders::_2))
+  , integrate_fun_(std::bind(&Odometry::integrateExact, this, std::placeholders::_1, std::placeholders::_2))
   {
   }
 

--- a/ackermann_steering_controller/src/odometry.cpp
+++ b/ackermann_steering_controller/src/odometry.cpp
@@ -42,7 +42,7 @@
 
 #include <ackermann_steering_controller/odometry.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ackermann_steering_controller
 {
@@ -61,7 +61,7 @@ namespace ackermann_steering_controller
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
-  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
+  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, boost::placeholders::_1, boost::placeholders::_2))
   {
   }
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -383,7 +383,7 @@ namespace diff_drive_controller{
     dyn_reconf_server_mutex_.unlock();
 
     dyn_reconf_server_->setCallback(
-        boost::bind(&DiffDriveController::reconfCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+        std::bind(&DiffDriveController::reconfCallback, this, std::placeholders::_1, std::placeholders::_2));
 
     return true;
   }

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -41,7 +41,7 @@
 
 #include <diff_drive_controller/odometry.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace diff_drive_controller
 {
@@ -62,7 +62,7 @@ namespace diff_drive_controller
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
-  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, _1, _2))
+  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, boost::placeholders::_1, boost::placeholders::_2))
   {
   }
 

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -41,8 +41,6 @@
 
 #include <diff_drive_controller/odometry.h>
 
-#include <boost/bind/bind.hpp>
-
 namespace diff_drive_controller
 {
   namespace bacc = boost::accumulators;
@@ -62,7 +60,7 @@ namespace diff_drive_controller
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
-  , integrate_fun_(boost::bind(&Odometry::integrateExact, this, boost::placeholders::_1, boost::placeholders::_2))
+  , integrate_fun_(std::bind(&Odometry::integrateExact, this, std::placeholders::_1, std::placeholders::_2))
   {
   }
 

--- a/four_wheel_steering_controller/src/odometry.cpp
+++ b/four_wheel_steering_controller/src/odometry.cpp
@@ -34,8 +34,6 @@
 
 #include <four_wheel_steering_controller/odometry.h>
 
-#include <boost/bind.hpp>
-
 namespace four_wheel_steering_controller
 {
   namespace bacc = boost::accumulators;

--- a/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
+++ b/gripper_action_controller/include/gripper_action_controller/gripper_action_controller_impl.h
@@ -214,8 +214,8 @@ bool GripperActionController<HardwareInterface>::init(HardwareInterface* hw,
 
   // ROS API: Action interface
   action_server_.reset(new ActionServer(
-      controller_nh_, "gripper_cmd", boost::bind(&GripperActionController::goalCB, this, boost::placeholders::_1),
-      boost::bind(&GripperActionController::cancelCB, this, boost::placeholders::_1), false));
+      controller_nh_, "gripper_cmd", std::bind(&GripperActionController::goalCB, this, std::placeholders::_1),
+      std::bind(&GripperActionController::cancelCB, this, std::placeholders::_1), false));
   action_server_->start();
   return true;
 }

--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -295,8 +295,8 @@ bool JointTrajectoryController<SegmentImpl, HardwareInterface>::init(HardwareInt
   // ROS API: Action interface
   action_server_.reset(
       new ActionServer(controller_nh_, "follow_joint_trajectory",
-                       boost::bind(&JointTrajectoryController::goalCB, this, boost::placeholders::_1),
-                       boost::bind(&JointTrajectoryController::cancelCB, this, boost::placeholders::_1), false));
+                       std::bind(&JointTrajectoryController::goalCB, this, std::placeholders::_1),
+                       std::bind(&JointTrajectoryController::cancelCB, this, std::placeholders::_1), false));
   action_server_->start();
 
   // ROS API: Provided services


### PR DESCRIPTION
Also include boost/bind/bind.hpp instead of boost/bind.hpp, eliminated unnecessary bind.hpp include.  Follows #588