### PR TITLE
update old pos before publishing odom

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/odometry.h
+++ b/diff_drive_controller/include/diff_drive_controller/odometry.h
@@ -198,6 +198,7 @@ namespace diff_drive_controller
     /// Previou wheel position/state [rad]:
     double left_wheel_old_pos_;
     double right_wheel_old_pos_;
+    bool old_pos_valid_;
 
     /// Rolling mean accumulators for the linar and angular velocities:
     size_t velocity_rolling_window_size_;

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -59,6 +59,7 @@ namespace diff_drive_controller
   , right_wheel_radius_(0.0)
   , left_wheel_old_pos_(0.0)
   , right_wheel_old_pos_(0.0)
+  , old_pos_valid_(false)
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
@@ -78,6 +79,15 @@ namespace diff_drive_controller
     /// Get current wheel joint positions:
     const double left_wheel_cur_pos  = left_pos  * left_wheel_radius_;
     const double right_wheel_cur_pos = right_pos * right_wheel_radius_;
+
+    if (!old_pos_valid_)
+    {
+      /// Update old position with current:
+      left_wheel_old_pos_ = left_wheel_cur_pos;
+      right_wheel_old_pos_ = right_wheel_cur_pos;
+      old_pos_valid_ = true;
+      return false;
+    }
 
     /// Estimate velocity of wheels using old and current position:
     const double left_wheel_est_vel  = left_wheel_cur_pos  - left_wheel_old_pos_;
@@ -171,6 +181,7 @@ namespace diff_drive_controller
   {
     linear_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
     angular_acc_ = RollingMeanAcc(RollingWindow::window_size = velocity_rolling_window_size_);
+    old_pos_valid_ = false;
   }
 
 } // namespace diff_drive_controller

--- a/diff_drive_controller/src/odometry.cpp
+++ b/diff_drive_controller/src/odometry.cpp
@@ -82,7 +82,7 @@ namespace diff_drive_controller
 
     if (!old_pos_valid_)
     {
-      /// Update old position with current:
+      /// Set old position with current to retain true velocities when initial wheel position is non-zero:
       left_wheel_old_pos_ = left_wheel_cur_pos;
       right_wheel_old_pos_ = right_wheel_cur_pos;
       old_pos_valid_ = true;


### PR DESCRIPTION
The PR solves a bug where the joint state positions used by odometry are non-zero by the time a controller starts.

We have found that as our hardware interface begins, and the peripheral devices initialize, the first joint states read by the controller are nonzero.

Fixing the bug from within the odometry class is more robust than implementing a position offset in the hardware interface. The reason it’s more robust is because :
* it allows the odometry’s velocity-accumulator to more quickly converge towards a more accurate velocity than if an erroneous value from a non zero previous joint state should have been used. 

> example :
> * robot initialization
> * controller stops
>       it solves an edge case where the controller and it’s odometry instance are destroyed, the destruction results in a similar scenario as the robot initialization where a non-zero old position is essential to maintaining reasonable velocity values / converging to the more accurate velocity values faster.

The PR maintains undefined behavior if the hardware interface shuts down and thus creates a large change in odometry based on a hardware failure, such a case would have still existed with out the fix.