### PR TITLE
Store trajectory segment being executed and store in feedback message

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.h
@@ -223,6 +223,11 @@ protected:
   ActionServerPtr    action_server_;
   ros::ServiceServer query_state_service_;
   StatePublisherPtr  state_publisher_;
+  /**
+   *  @brief Indices of trajectory that is currently being executed
+   *  @details These should usually (always?) be all the same
+   */
+  std::vector<Scalar> trajectory_indices_;
 
   ros::Timer         goal_handle_timer_;
   ros::Time          last_state_publish_time_;


### PR DESCRIPTION
This is to open up discussions related to this [PR](https://github.com/ros-controls/control_msgs/pull/67). Is there any possibility to get this into the ROS1 version