### PR TITLE
Install headers of ackermann_steering_controller

### DIFF
--- a/ackermann_steering_controller/CMakeLists.txt
+++ b/ackermann_steering_controller/CMakeLists.txt
@@ -126,6 +126,11 @@ endif()
 ## Install ##
 #############
 
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
 # Install targets
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION
diff_drive_controller does it, so there's no reason for ackermann to not do it. I use the headers in a library that would like to utilize the odometry classes defined by these controllers.