### PR TITLE
add flag controlling init of last_publish_time_

### DIFF
--- a/joint_state_controller/include/joint_state_controller/joint_state_controller.h
+++ b/joint_state_controller/include/joint_state_controller/joint_state_controller.h
@@ -93,6 +93,7 @@ private:
   ros::Time last_publish_time_;
   double publish_rate_;
   unsigned int num_hw_joints_; ///< Number of joints present in the JointStateInterface, excluding extra joints
+  bool pub_time_initialized_;
 
   void addExtraJoints(const ros::NodeHandle& nh, sensor_msgs::JointState& msg);
 };

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -90,6 +90,7 @@ namespace joint_state_controller
     if (!pub_time_initialized_)
     {
       last_publish_time_ = time - ros::Duration(1.001/publish_rate_); //ensure publish on first cycle
+      pub_time_initialized_ = true;
     }
   }
 

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -136,7 +136,6 @@ namespace joint_state_controller
       ROS_ERROR("Extra joints specification is not an array. Ignoring.");
       return;
     }
- 
     for(std::size_t i = 0; i < list.size(); ++i)
     {
       XmlRpc::XmlRpcValue& elem = list[i];

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -79,13 +79,18 @@ namespace joint_state_controller
     }
     addExtraJoints(controller_nh, realtime_pub_->msg_);
 
+    pub_time_initialized_=false;
+
     return true;
   }
 
   void JointStateController::starting(const ros::Time& time)
   {
-    // initialize time
-    last_publish_time_ = time;
+    // initialize time exactly once, to maintain publish rate through controller resets
+    if (!pub_time_initialized_)
+    {
+      last_publish_time_ = time - ros::Duration(1.001/publish_rate_); //ensure publish on first cycle
+    }
   }
 
   void JointStateController::update(const ros::Time& time, const ros::Duration& /*period*/)
@@ -131,7 +136,7 @@ namespace joint_state_controller
       ROS_ERROR("Extra joints specification is not an array. Ignoring.");
       return;
     }
-
+ 
     for(std::size_t i = 0; i < list.size(); ++i)
     {
       XmlRpc::XmlRpcValue& elem = list[i];

--- a/joint_state_controller/test/joint_state_controller_test.cpp
+++ b/joint_state_controller/test/joint_state_controller_test.cpp
@@ -133,6 +133,7 @@ TEST_F(JointStateControllerTest, publishOk)
   // NOTE: Below we subtract the loop rate because the the published message gets picked up in the
   // next iteration's spinOnce()
   const ros::Duration real_test_duration = ros::Time::now() - start_time - loop_rate.expectedCycleTime();
+  rec_msgs_-=1; //joint_state_controller now publishes on first update(), leading to an extra message (ie. 11 message for 10 intervals)
   const double real_pub_rate = static_cast<double>(rec_msgs_) / real_test_duration.toSec();
 
   // The publish rate should be close to the nominal value


### PR DESCRIPTION
This PR fixes the no publish during reset bug identified in issue 616 (https://github.com/ros-controls/ros_controllers/issues/616)