### PR TITLE
JointGroupVelocityController: stop motion if no commands received

### DIFF
--- a/velocity_controllers/include/velocity_controllers/joint_group_velocity_controller.h
+++ b/velocity_controllers/include/velocity_controllers/joint_group_velocity_controller.h
@@ -57,7 +57,17 @@ namespace velocity_controllers
  * Subscribes to:
  * - \b command (std_msgs::Float64MultiArray) : The joint velocities to apply
  */
-typedef forward_command_controller::ForwardJointGroupCommandController<hardware_interface::VelocityJointInterface>
-        JointGroupVelocityController;
+class JointGroupVelocityController : public forward_command_controller::ForwardJointGroupCommandController<hardware_interface::VelocityJointInterface>
+{
+  using BaseClass = forward_command_controller::ForwardJointGroupCommandController<hardware_interface::VelocityJointInterface>;
+  bool received_;
+  ros::WallTimer watchdog_;
+  ros::Subscriber sub_command_;
+  void commandCB(const std_msgs::Float64MultiArrayConstPtr&);
+  void watchDogCB(const ros::WallTimerEvent& event);
+
+public:
+  bool init(hardware_interface::VelocityJointInterface* hw, ros::NodeHandle &nh) override;
+};
 
 }


### PR DESCRIPTION
As a safety measure, this PR adapts the `JointGroupVelocityController` to reset control velocities to zero if no new command was received within a configurable interval (`watchdog_timeout`). If the steering process crashes or just finishes without resetting the velocity itself, the robot would otherwise just continue moving with the last speed commanded (and crash into something probably).
I have chosen a rather large default timeout (1s) to limit interferences with existing code.