### PR TITLE
Fix joint state controller exception starting with 0 time

### DIFF
--- a/joint_state_controller/include/joint_state_controller/joint_state_controller.h
+++ b/joint_state_controller/include/joint_state_controller/joint_state_controller.h
@@ -93,7 +93,6 @@ private:
   ros::Time last_publish_time_;
   double publish_rate_;
   unsigned int num_hw_joints_; ///< Number of joints present in the JointStateInterface, excluding extra joints
-  bool pub_time_initialized_;
 
   void addExtraJoints(const ros::NodeHandle& nh, sensor_msgs::JointState& msg);
 };

--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -80,26 +80,17 @@ namespace joint_state_controller
     }
     addExtraJoints(controller_nh, realtime_pub_->msg_);
 
-    pub_time_initialized_=false;
-
     return true;
   }
 
   void JointStateController::starting(const ros::Time& time)
   {
-    // initialize time exactly once, to maintain publish rate through controller resets
-    if (!pub_time_initialized_)
-    {
-      last_publish_time_ = time - ros::Duration(1.001/publish_rate_); //ensure publish on first cycle
-      pub_time_initialized_ = true;
-    }
   }
 
   void JointStateController::update(const ros::Time& time, const ros::Duration& /*period*/)
   {
     // limit rate of publishing
-    if (publish_rate_ > 0.0 && last_publish_time_ + ros::Duration(1.0/publish_rate_) < time){
-
+    if (publish_rate_ > 0.0 && (last_publish_time_.isZero() || last_publish_time_ + ros::Duration(1.0/publish_rate_) < time)){
       // try to publish
       if (realtime_pub_->trylock()){
         // we're actually publishing, so increment time


### PR DESCRIPTION
Fixes #628, crash in joint state controller when given start time less than the publish interval.

## Reproduction steps:

- Build joint state controller from source (the published package does not have the bug yet)
- Set publish rate less than 100 Hz (i.e. 50 Hz should give you 0.02 seconds publish interval)
- Start the joint state controller (arbitrary start time will be around 0.01 seconds)
- Note that if you set the publish rate to 100Hz that would give you 0.01 seconds publish interval, which is not less than start time, so the bug would not be exposed.

## Testing

I haven't updated unit tests for joint state controller yet, but the functionality was tested and appears to work:

- The issue was fixed
- The problem the bug was trying to solve remains fixed: joint state controller will update immediately on the first update as the author apparently desired, and then wait the publish interval on subsequent updates