### PR TITLE
Fix uncaught exception in joint_state_controller

### DIFF
--- a/joint_state_controller/src/joint_state_controller.cpp
+++ b/joint_state_controller/src/joint_state_controller.cpp
@@ -90,7 +90,11 @@ namespace joint_state_controller
     // initialize time exactly once, to maintain publish rate through controller resets
     if (!pub_time_initialized_)
     {
-      last_publish_time_ = time - ros::Duration(1.001/publish_rate_); //ensure publish on first cycle
+      try {
+        last_publish_time_ = time - ros::Duration(1.001/publish_rate_); //ensure publish on first cycle
+      } catch(std::runtime_error& ex) { // negative ros::Time is not allowed
+        last_publish_time_ = ros::Time::MIN;
+      }
       pub_time_initialized_ = true;
     }
   }


### PR DESCRIPTION
Using sim time in Gazebo, the starting time is close to zero, such that `time - ros::Duration(1/publish_rate_)` becomes negative. This causes an exception to be thrown: "Time is out of dual 32-bit range".