### PR TITLE
Don't "angle-wrap" non-continuous and prismatic joints

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h
@@ -779,7 +779,11 @@ updateStates(const ros::Time& sample_time, const Trajectory* const traj)
     desired_state_.velocity[joint_index] = desired_joint_state_.velocity[0];
     desired_state_.acceleration[joint_index] = desired_joint_state_.acceleration[0];
 
-    state_error_.position[joint_index] = angles::shortest_angular_distance(current_state_.position[joint_index],desired_joint_state_.position[0]);
+    if(angle_wraparound_[joint_index])
+      state_error_.position[joint_index] = angles::shortest_angular_distance(current_state_.position[joint_index], desired_joint_state_.position[0]);
+    else
+      state_error_.position[joint_index] = desired_joint_state_.position[0] - current_state_.position[joint_index];
+    
     state_error_.velocity[joint_index] = desired_joint_state_.velocity[0] - current_state_.velocity[joint_index];
     state_error_.acceleration[joint_index] = 0.0;
 


### PR DESCRIPTION
Some of the controllers try to incorrectly "angle-wrap" non-continuous joints.

- The problem is most obvious with prismatic joints. Linear positions should not be "wrapped around" like angles. 
- The issue can also affect revolute joints with joint limits. If the goal position is less than 180° across the joint limit, the robot moves into the joint limit. 
- When a robot is driven back under soft compliant control, the issue can cause the robot to suddenly hit out into the opposite direction.

The proposed code change seems to fix the issue for our use cases. 